### PR TITLE
Add setting SPN in CredSspClient and some KdcProxy code fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = "1.0"
 serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
-reqwest = { version = "0.11", features = ["blocking"], optional = true, default-features = false }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], optional = true, default-features = false }
 picky-krb = "0.1.0"
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -171,6 +171,7 @@ pub struct CredSspClient {
     credentials_handle: Option<AuthIdentityBuffers>,
     ts_request_version: u32,
     client_mode: ClientMode,
+    service_principal_name: String,
 }
 
 impl CredSspClient {
@@ -179,6 +180,7 @@ impl CredSspClient {
         credentials: AuthIdentity,
         cred_ssp_mode: CredSspMode,
         client_mode: ClientMode,
+        service_principal_name: String,
     ) -> sspi::Result<Self> {
         Ok(Self {
             state: CredSspState::NegoToken,
@@ -190,6 +192,7 @@ impl CredSspClient {
             credentials_handle: None,
             ts_request_version: TS_REQUEST_VERSION,
             client_mode,
+            service_principal_name,
         })
     }
 
@@ -199,6 +202,7 @@ impl CredSspClient {
         cred_ssp_mode: CredSspMode,
         ts_request_version: u32,
         client_mode: ClientMode,
+        service_principal_name: String,
     ) -> sspi::Result<Self> {
         Ok(Self {
             state: CredSspState::NegoToken,
@@ -210,6 +214,7 @@ impl CredSspClient {
             credentials_handle: None,
             ts_request_version,
             client_mode,
+            service_principal_name,
         })
     }
 
@@ -256,6 +261,7 @@ impl CredSspClient {
                     .with_credentials_handle(&mut credentials_handle)
                     .with_context_requirements(ClientRequestFlags::empty())
                     .with_target_data_representation(DataRepresentation::Native)
+                    .with_target_name(&self.service_principal_name)
                     .with_input(&mut [input_token])
                     .with_output(&mut output_token)
                     .execute()?;

--- a/src/sspi/kerberos/client/generators.rs
+++ b/src/sspi/kerberos/client/generators.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 use chrono::{Duration, Utc};
 use kerberos_constants::key_usages::{KEY_USAGE_AP_REQ_AUTHEN, KEY_USAGE_TGS_REQ_AUTHEN};
@@ -36,9 +37,9 @@ use rand::rngs::OsRng;
 use rand::Rng;
 
 use super::{AES128_CTS_HMAC_SHA1_96, AES256_CTS_HMAC_SHA1_96};
-use crate::{ErrorKind, Error};
 use crate::sspi::kerberos::{EncryptionParams, KERBEROS_VERSION, SERVICE_NAME, TGT_SERVICE_NAME};
 use crate::sspi::Result;
+use crate::{Error, ErrorKind};
 
 const TGT_TICKET_LIFETIME_DAYS: i64 = 3;
 const NONCE_LEN: usize = 4;
@@ -245,7 +246,7 @@ pub fn generate_tgs_req(
             DEFAULT_TGS_REQ_OPTIONS.to_vec(),
         ))),
         cname: Optional::from(None),
-        realm: ExplicitContextTag2::from(Realm::from(IA5String::from_string(realm.into())?)),
+        realm: ExplicitContextTag2::from(Realm::from(IA5String::from_str(realm)?)),
         sname: Optional::from(Some(ExplicitContextTag3::from(PrincipalName {
             name_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NT_SRV_INST])),
             name_string: ExplicitContextTag1::from(Asn1SequenceOf::from(vec![

--- a/src/sspi/kerberos/network_client.rs
+++ b/src/sspi/kerberos/network_client.rs
@@ -6,7 +6,7 @@ use crate::sspi::Result;
 
 pub trait NetworkClient: Debug {
     fn send(&self, url: &Url, data: &[u8]) -> Result<Vec<u8>>;
-    fn send_http(&self, url: &Url, data: &[u8]) -> Result<Vec<u8>>;
+    fn send_http(&self, url: &Url, data: &[u8], domain: Option<String>) -> Result<Vec<u8>>;
     fn clone(&self) -> Box<dyn NetworkClient>;
 }
 
@@ -16,6 +16,10 @@ pub mod reqwest_network_client {
     use std::net::TcpStream;
 
     use byteorder::{BigEndian, ReadBytesExt};
+    use picky_asn1::restricted_string::IA5String;
+    use picky_asn1::wrapper::{ExplicitContextTag0, ExplicitContextTag1, OctetStringAsn1, Optional};
+    use picky_krb::data_types::KerberosStringAsn1;
+    use picky_krb::messages::KdcProxyMessage;
     use reqwest::blocking::Client;
     use url::Url;
 
@@ -68,12 +72,26 @@ pub mod reqwest_network_client {
             }
         }
 
-        fn send_http(&self, url: &Url, data: &[u8]) -> Result<Vec<u8>> {
+        fn send_http(&self, url: &Url, data: &[u8], domain: Option<String>) -> Result<Vec<u8>> {
             let client = Client::new();
 
-            Ok(client
+            let domain = if let Some(domain) = domain {
+                Some(ExplicitContextTag1::from(KerberosStringAsn1::from(
+                    IA5String::from_string(domain)?,
+                )))
+            } else {
+                None
+            };
+
+            let kdc_proxy_message = KdcProxyMessage {
+                kerb_message: ExplicitContextTag0::from(OctetStringAsn1::from(data.to_vec())),
+                target_domain: Optional::from(domain),
+                dclocator_hint: Optional::from(None),
+            };
+
+            let result_bytes = client
                 .post(url.clone())
-                .body(data.to_vec())
+                .body(picky_asn1_der::to_vec(&kdc_proxy_message)?)
                 .send()
                 .map_err(|err| Error {
                     error_type: ErrorKind::InternalError,
@@ -84,7 +102,11 @@ pub mod reqwest_network_client {
                     error_type: ErrorKind::InternalError,
                     description: format!("Unable to read the response data from the KDC Proxy: {:?}", err),
                 })?
-                .to_vec())
+                .to_vec();
+
+            let kdc_proxy_message: KdcProxyMessage = picky_asn1_der::from_bytes(&result_bytes)?;
+
+            Ok(kdc_proxy_message.kerb_message.0 .0)
         }
 
         fn clone(&self) -> Box<dyn NetworkClient> {


### PR DESCRIPTION
I'm working on integrating the latest changes of sspi-rs in IronRDP. It turned out that some things were missing in sspi-rs to make it works, so this PR fixes it. 
 
I added the `setting` service principal name in `CredSspClient`.
Also, I made some KdcProxy related code fixes:

-  Add missing reqwest `rustls` feature for TLS establishing.
- Add missing `KdbProxyMessage` generation in `ReqwestNetworkClient::send_http`.