### PR TITLE
use /FORCE:MULTIPLE to workaround symbol conflict on Windows

### DIFF
--- a/c-api/build.rs
+++ b/c-api/build.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target_os == "windows" {
+        println!("cargo:rustc-link-arg=/FORCE:MULTIPLE");
+    }
+}


### PR DESCRIPTION
Compilation fix for https://github.com/Devolutions/sspi-rs/pull/21 on Windows