### PR TITLE
Negotiate module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ kerberos_crypto = "0.3.6"
 kerberos_constants = "0.0.9"
 oid = "0.2.1"
 sys-info = "0.9"
+trust-dns-resolver = "0.21.2"
 
 [dev-dependencies]
 whoami = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [features]
-network_client = ["reqwest"]
+network_client = ["reqwest", "trust-dns-resolver", "portpicker"]
 
 [dependencies]
 byteorder = "1.2.7"
@@ -44,7 +44,8 @@ kerberos_crypto = "0.3.6"
 kerberos_constants = "0.0.9"
 oid = "0.2.1"
 sys-info = "0.9"
-trust-dns-resolver = "0.21.2"
+trust-dns-resolver = { version = "0.21.2", optional = true }
+portpicker = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 whoami = "0.5"

--- a/c-api/src/common.rs
+++ b/c-api/src/common.rs
@@ -45,7 +45,7 @@ pub unsafe extern "system" fn AcceptSecurityContext(
         Some(auth_data.as_mut().unwrap().clone())
     };
 
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let raw_buffers = from_raw_parts((*p_input).p_buffers, (*p_input).c_buffers as usize);
     let mut input_tokens = p_sec_buffers_to_security_buffers(raw_buffers);
@@ -85,7 +85,7 @@ pub type AcceptSecurityContextFn = unsafe extern "system" fn(
 
 #[no_mangle]
 pub unsafe extern "system" fn CompleteAuthToken(ph_context: PCtxtHandle, p_token: PSecBufferDesc) -> SecurityStatus {
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let raw_buffers = from_raw_parts((*p_token).p_buffers, (*p_token).c_buffers as usize);
     let mut buffers = p_sec_buffers_to_security_buffers(raw_buffers);
@@ -183,7 +183,7 @@ pub unsafe extern "system" fn EncryptMessage(
     p_message: PSecBufferDesc,
     message_seq_no: c_ulong,
 ) -> SecurityStatus {
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let len = (*p_message).c_buffers as usize;
     let raw_buffers = from_raw_parts((*p_message).p_buffers, len);
@@ -214,7 +214,7 @@ pub unsafe extern "system" fn DecryptMessage(
     message_seq_no: c_ulong,
     pf_qop: *mut c_ulong,
 ) -> SecurityStatus {
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let len = (*p_message).c_buffers as usize;
     let raw_buffers = from_raw_parts((*p_message).p_buffers, len);

--- a/c-api/src/sec_handle.rs
+++ b/c-api/src/sec_handle.rs
@@ -189,8 +189,7 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         Some(auth_data.as_mut().unwrap().clone())
     };
 
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
-    // let kerberos = kerberos_ptr.as_mut().unwrap();
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let mut input_tokens = if p_input == null::<SecBufferDesc>() as *mut _ {
         Vec::new()
@@ -263,7 +262,7 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         Some(auth_data.as_mut().unwrap().clone())
     };
 
-    let kerberos = p_ctxt_handle_to_security_package(ph_context);
+    let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
 
     let mut input_tokens = if p_input == null::<SecBufferDesc>() as *mut _ {
         Vec::new()
@@ -317,7 +316,7 @@ pub unsafe extern "system" fn QueryContextAttributesA(
 ) -> SecurityStatus {
     match ul_attribute {
         0 => {
-            let kerberos = p_ctxt_handle_to_security_package(ph_context);
+            let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
             let sizes = p_buffer as *mut SecPkgContextSizes;
 
             let pkg_sizes = kerberos.query_context_sizes().unwrap();
@@ -344,7 +343,7 @@ pub unsafe extern "system" fn QueryContextAttributesW(
 ) -> SecurityStatus {
     match ul_attribute {
         0 => {
-            let kerberos = p_ctxt_handle_to_security_package(ph_context);
+            let mut kerberos = p_ctxt_handle_to_security_package(ph_context);
             let sizes = p_buffer as *mut SecPkgContextSizes;
 
             let pkg_sizes = kerberos.query_context_sizes().unwrap();

--- a/c-api/src/utils.rs
+++ b/c-api/src/utils.rs
@@ -58,3 +58,16 @@ pub unsafe fn transform_credentials_handle<'a>(
         )
     }
 }
+
+#[macro_export]
+macro_rules! try_execute {
+    ($x:expr) => {{
+        match $x {
+            Ok(value) => value,
+            Err(err) => {
+                return err.error_type.to_u32().unwrap();
+            }
+        }
+    }};
+}
+

--- a/c-api/src/utils.rs
+++ b/c-api/src/utils.rs
@@ -1,7 +1,9 @@
 use std::slice::from_raw_parts;
 
 use libc::{c_char, c_ushort};
+use sspi::AuthIdentityBuffers;
 
+use crate::sec_handle::CredentialsHandle;
 use crate::sspi_data_types::{SecChar, SecWChar};
 
 pub fn into_raw_ptr<T>(value: T) -> *mut T {
@@ -41,4 +43,18 @@ pub unsafe fn c_str_into_string(s: *const SecChar) -> String {
     }
 
     String::from_utf8(from_raw_parts(s as *const u8, len).to_vec()).unwrap()
+}
+
+pub unsafe fn transform_credentials_handle<'a>(
+    credentials_handle: *mut CredentialsHandle,
+) -> (Option<AuthIdentityBuffers>, Option<&'a str>) {
+    if credentials_handle.is_null() {
+        (None, None)
+    } else {
+        let cred_handle = credentials_handle.as_mut().unwrap();
+        (
+            Some(cred_handle.credentials.clone()),
+            Some(cred_handle.security_package_name.as_str()),
+        )
+    }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -8,13 +8,15 @@ use std::io;
 use std::net::TcpStream;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use sspi::builders::EmptyInitializeSecurityContext;
+use sspi::internal::SspiImpl;
 #[cfg(windows)]
 use sspi::winapi::Ntlm;
 #[cfg(not(windows))]
 use sspi::Ntlm;
 use sspi::{
     AuthIdentity, ClientRequestFlags, CredentialUse, DataRepresentation, SecurityBuffer, SecurityBufferType,
-    SecurityStatus, Sspi, internal::SspiImpl, builders::EmptyInitializeSecurityContext,
+    SecurityStatus, Sspi,
 };
 
 const IP: &str = "127.0.0.1:8080";
@@ -87,7 +89,7 @@ fn do_authentication(ntlm: &mut Ntlm, identity: &AuthIdentity, mut stream: &mut 
         .with_target_data_representation(DataRepresentation::Native)
         .with_target_name(username.as_str())
         .with_output(&mut output_buffer);
-    
+
     let _result = ntlm.initialize_security_context_impl(&mut builder)?;
 
     write_message(&mut stream, &output_buffer[0].buffer)?;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -14,7 +14,7 @@ use sspi::winapi::Ntlm;
 use sspi::Ntlm;
 use sspi::{
     AuthIdentity, ClientRequestFlags, CredentialUse, DataRepresentation, SecurityBuffer, SecurityBufferType,
-    SecurityStatus, Sspi,
+    SecurityStatus, Sspi, internal::SspiImpl, builders::EmptyInitializeSecurityContext,
 };
 
 const IP: &str = "127.0.0.1:8080";
@@ -79,15 +79,16 @@ fn do_authentication(ntlm: &mut Ntlm, identity: &AuthIdentity, mut stream: &mut 
         .execute()?;
 
     let mut output_buffer = vec![SecurityBuffer::new(Vec::new(), SecurityBufferType::Token)];
+    let username = whoami::username();
 
-    let _result = ntlm
-        .initialize_security_context()
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
         .with_credentials_handle(&mut acq_cred_result.credentials_handle)
         .with_context_requirements(ClientRequestFlags::CONFIDENTIALITY | ClientRequestFlags::ALLOCATE_MEMORY)
         .with_target_data_representation(DataRepresentation::Native)
-        .with_target_name(whoami::username().as_str())
-        .with_output(&mut output_buffer)
-        .execute()?;
+        .with_target_name(username.as_str())
+        .with_output(&mut output_buffer);
+    
+    let _result = ntlm.initialize_security_context_impl(&mut builder)?;
 
     write_message(&mut stream, &output_buffer[0].buffer)?;
 
@@ -98,15 +99,15 @@ fn do_authentication(ntlm: &mut Ntlm, identity: &AuthIdentity, mut stream: &mut 
 
         read_message(&mut stream, &mut input_buffer[0].buffer)?;
 
-        let result = ntlm
-            .initialize_security_context()
+        let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
             .with_credentials_handle(&mut acq_cred_result.credentials_handle)
             .with_context_requirements(ClientRequestFlags::CONFIDENTIALITY | ClientRequestFlags::ALLOCATE_MEMORY)
             .with_target_data_representation(DataRepresentation::Native)
-            .with_target_name(whoami::username().as_str())
+            .with_target_name(username.as_str())
             .with_input(&mut input_buffer)
-            .with_output(&mut output_buffer)
-            .execute()?;
+            .with_output(&mut output_buffer);
+
+        let result = ntlm.initialize_security_context_impl(&mut builder)?;
 
         if [SecurityStatus::CompleteAndContinue, SecurityStatus::CompleteNeeded].contains(&result.status) {
             println!("Completing the token...");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! use sspi::winapi::Ntlm;
 //! #[cfg(not(windows))]
 //! use sspi::Ntlm;
+//! use sspi::builders::EmptyInitializeSecurityContext;
+//! use crate::sspi::internal::SspiImpl;
 //!
 //! let mut ntlm = Ntlm::new();
 //!
@@ -38,15 +40,15 @@
 //!     sspi::SecurityBufferType::Token,
 //! )];
 //!
-//! let result = ntlm
-//!     .initialize_security_context()
+//! let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
 //!     .with_credentials_handle(&mut acq_creds_handle_result.credentials_handle)
 //!     .with_context_requirements(
 //!         sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY
 //!     )
 //!     .with_target_data_representation(sspi::DataRepresentation::Native)
-//!     .with_output(&mut output)
-//!     .execute()
+//!     .with_output(&mut output);
+//! 
+//! let result = ntlm.initialize_security_context_impl(&mut builder)
 //!     .expect("InitializeSecurityContext resulted in error");
 //!
 //! println!("Initialized security context with result status: {:?}", result.status);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,9 @@ cfg_if::cfg_if! {
     }
 }
 
-pub use crate::sspi::negotiate::*;
-
 pub use crate::sspi::kerberos::config::KerberosConfig;
 pub use crate::sspi::kerberos::{Kerberos, KERBEROS_VERSION, PACKAGE_INFO as KERBEROS_PACKAGE_INFO};
+pub use crate::sspi::negotiate::*;
 #[cfg(windows)]
 pub use crate::sspi::winapi;
 pub use crate::sspi::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ cfg_if::cfg_if! {
     }
 }
 
+pub use crate::sspi::negotiate::*;
+
 pub use crate::sspi::kerberos::config::KerberosConfig;
 pub use crate::sspi::kerberos::{Kerberos, KERBEROS_VERSION, PACKAGE_INFO as KERBEROS_PACKAGE_INFO};
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!     )
 //!     .with_target_data_representation(sspi::DataRepresentation::Native)
 //!     .with_output(&mut output);
-//! 
+//!
 //! let result = ntlm.initialize_security_context_impl(&mut builder)
 //!     .expect("InitializeSecurityContext resulted in error");
 //!
@@ -84,11 +84,11 @@ cfg_if::cfg_if! {
 
 pub use crate::sspi::kerberos::config::KerberosConfig;
 pub use crate::sspi::kerberos::{Kerberos, KERBEROS_VERSION, PACKAGE_INFO as KERBEROS_PACKAGE_INFO};
-pub use crate::sspi::negotiate::*;
+pub use crate::sspi::negotiate::{Negotiate, NegotiateConfig};
 #[cfg(windows)]
 pub use crate::sspi::winapi;
 pub use crate::sspi::{
-    builders, enumerate_security_packages, internal, kerberos, query_security_package_info,
+    builders, enumerate_security_packages, internal, kerberos, negotiate, ntlm, query_security_package_info,
     AcceptSecurityContextResult, AcquireCredentialsHandleResult, AuthIdentity, AuthIdentityBuffers,
     CertTrustErrorStatus, CertTrustInfoStatus, CertTrustStatus, ClientRequestFlags, ClientResponseFlags, ContextNames,
     ContextSizes, CredentialUse, DataRepresentation, DecryptionFlags, EncryptionFlags, Error, ErrorKind,

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -6,7 +6,7 @@ pub mod negotiate;
 #[cfg(windows)]
 pub mod winapi;
 
-mod ntlm;
+pub mod ntlm;
 
 use std::{error, fmt, io, result, str, string};
 
@@ -203,7 +203,7 @@ where
     ///     )
     ///     .with_target_data_representation(sspi::DataRepresentation::Native)
     ///     .with_output(&mut output_buffer);
-    /// 
+    ///
     /// let result = ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// ```
     ///

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -6,6 +6,8 @@ pub mod negotiate;
 #[cfg(windows)]
 pub mod winapi;
 
+use std::fmt::Debug;
+
 mod ntlm;
 
 use std::{error, fmt, io, result, str, string};
@@ -103,7 +105,9 @@ pub fn enumerate_security_packages() -> Result<Vec<PackageInfo>> {
 /// * [SSPI.h](https://docs.microsoft.com/en-us/windows/win32/api/sspi/)
 pub trait Sspi
 where
-    Self: Sized + SspiImpl,
+    Self:
+    //   Sized +
+      SspiImpl,
 {
     /// Acquires a handle to preexisting credentials of a security principal. The preexisting credentials are
     /// available only for `sspi::winapi` module. This handle is required by the `initialize_security_context`
@@ -147,8 +151,8 @@ where
     /// * [AcquireCredentialshandleW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-acquirecredentialshandlew)
     fn acquire_credentials_handle(
         &mut self,
-    ) -> EmptyAcquireCredentialsHandle<'_, Self, Self::CredentialsHandle, Self::AuthenticationData> {
-        AcquireCredentialsHandle::new(self)
+    ) -> EmptyAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData> where Self: Sized {
+        AcquireCredentialsHandle::new(Box::new(self))
     }
 
     /// Initiates the client side, outbound security context from a credential handle.
@@ -208,8 +212,8 @@ where
     /// # MSDN
     ///
     /// * [InitializeSecurityContextW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-initializesecuritycontextw)
-    fn initialize_security_context(&mut self) -> EmptyInitializeSecurityContext<'_, Self, Self::CredentialsHandle> {
-        InitializeSecurityContext::new(self)
+    fn initialize_security_context(&mut self) -> EmptyInitializeSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle> where Self: Sized {
+        InitializeSecurityContext::new(Box::new(self))
     }
 
     /// Lets the server component of a transport application establish a security context between the server and a remote client.
@@ -289,8 +293,8 @@ where
     /// # MSDN
     ///
     /// * [AcceptSecurityContext function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-acceptsecuritycontext)
-    fn accept_security_context(&mut self) -> EmptyAcceptSecurityContext<'_, Self, Self::CredentialsHandle> {
-        AcceptSecurityContext::new(self)
+    fn accept_security_context(&mut self) -> EmptyAcceptSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle> where Self: Sized {
+        AcceptSecurityContext::new(Box::new(self))
     }
 
     /// Completes an authentication token. This function is used by protocols, such as DCE,
@@ -690,7 +694,9 @@ where
 
 pub trait SspiEx
 where
-    Self: Sized + SspiImpl,
+    Self:
+    // Sized +
+    SspiImpl,
 {
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData);
 }

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -216,11 +216,11 @@ where
     /// * [InitializeSecurityContextW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-initializesecuritycontextw)
     fn initialize_security_context(
         &mut self,
-    ) -> EmptyInitializeSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle>
+    ) -> EmptyInitializeSecurityContext<'_, Self::CredentialsHandle>
     where
         Self: Sized,
     {
-        InitializeSecurityContext::new(Box::new(self))
+        InitializeSecurityContext::new()
     }
 
     /// Lets the server component of a transport application establish a security context between the server and a remote client.

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -91,8 +91,9 @@ pub fn query_security_package_info(package_type: SecurityPackageType) -> Result<
 /// * [EnumerateSecurityPackagesW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesw)
 pub fn enumerate_security_packages() -> Result<Vec<PackageInfo>> {
     Ok(vec![
+        negotiate::PACKAGE_INFO.clone(),
         kerberos::PACKAGE_INFO.clone(),
-        kerberos::NEGO_PACKAGE_INFO.clone(),
+        ntlm::PACKAGE_INFO.clone(),
     ])
 }
 

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -2,6 +2,7 @@
 pub mod builders;
 pub mod internal;
 pub mod kerberos;
+pub mod negotiate;
 #[cfg(windows)]
 pub mod winapi;
 
@@ -57,6 +58,7 @@ pub fn query_security_package_info(package_type: SecurityPackageType) -> Result<
     match package_type {
         SecurityPackageType::Ntlm => Ok(ntlm::PACKAGE_INFO.clone()),
         SecurityPackageType::Kerberos => Ok(kerberos::PACKAGE_INFO.clone()),
+        SecurityPackageType::Negotiate => Ok(negotiate::PACKAGE_INFO.clone()),
         SecurityPackageType::Other(s) => Err(Error::new(
             ErrorKind::Unknown,
             format!("Queried info about unknown package: {:?}", s),
@@ -1025,14 +1027,16 @@ pub enum CredentialUse {
 pub enum SecurityPackageType {
     Ntlm,
     Kerberos,
+    Negotiate,
     Other(String),
 }
 
 impl string::ToString for SecurityPackageType {
     fn to_string(&self) -> String {
         match self {
-            SecurityPackageType::Ntlm => ntlm::PKG_NAME.to_string(),
-            SecurityPackageType::Kerberos => kerberos::PKG_NAME.to_string(),
+            SecurityPackageType::Ntlm => ntlm::PKG_NAME.into(),
+            SecurityPackageType::Kerberos => kerberos::PKG_NAME.into(),
+            SecurityPackageType::Negotiate => negotiate::PKG_NAME.into(),
             SecurityPackageType::Other(name) => name.clone(),
         }
     }
@@ -1045,6 +1049,7 @@ impl str::FromStr for SecurityPackageType {
         match s {
             ntlm::PKG_NAME => Ok(SecurityPackageType::Ntlm),
             kerberos::PKG_NAME => Ok(SecurityPackageType::Kerberos),
+            negotiate::PKG_NAME => Ok(SecurityPackageType::Negotiate),
             s => Ok(SecurityPackageType::Other(s.to_string())),
         }
     }

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -173,6 +173,8 @@ where
     ///
     /// ```
     /// # use sspi::Sspi;
+    /// # use sspi::builders::EmptyInitializeSecurityContext;
+    /// # use crate::sspi::internal::SspiImpl;
     /// #
     /// # let mut ntlm = sspi::Ntlm::new();
     /// #
@@ -194,16 +196,15 @@ where
     /// let mut output_buffer = vec![sspi::SecurityBuffer::new(Vec::new(), sspi::SecurityBufferType::Token)];
     ///
     /// # #[allow(unused_variables)]
-    /// let result = ntlm
-    ///     .initialize_security_context()
+    /// let mut builder = EmptyInitializeSecurityContext::<<sspi::Ntlm as SspiImpl>::CredentialsHandle>::new()
     ///     .with_credentials_handle(&mut credentials_handle)
     ///     .with_context_requirements(
     ///         sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY,
     ///     )
     ///     .with_target_data_representation(sspi::DataRepresentation::Native)
-    ///     .with_output(&mut output_buffer)
-    ///     .execute()
-    ///     .unwrap();
+    ///     .with_output(&mut output_buffer);
+    /// 
+    /// let result = ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// ```
     ///
     /// # MSDN
@@ -232,7 +233,9 @@ where
     /// # Example
     ///
     /// ```
-    /// #  use sspi::Sspi;
+    /// # use sspi::Sspi;
+    /// # use sspi::builders::EmptyInitializeSecurityContext;
+    /// # use crate::sspi::internal::SspiImpl;
     /// #
     /// # let mut client_ntlm = sspi::Ntlm::new();
     /// #
@@ -251,17 +254,16 @@ where
     /// #
     /// # let mut client_output_buffer = vec![sspi::SecurityBuffer::new(Vec::new(), sspi::SecurityBufferType::Token)];
     /// #
-    /// # let _result = client_ntlm
-    /// #     .initialize_security_context()
+    /// # let mut builder = EmptyInitializeSecurityContext::<<sspi::Ntlm as SspiImpl>::CredentialsHandle>::new()
     /// #     .with_credentials_handle(&mut client_acq_cred_result.credentials_handle)
     /// #     .with_context_requirements(
     /// #         sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY,
     /// #     )
     /// #     .with_target_data_representation(sspi::DataRepresentation::Native)
     /// #     .with_target_name("user")
-    /// #     .with_output(&mut client_output_buffer)
-    /// #     .execute()
-    /// #     .unwrap();
+    /// #     .with_output(&mut client_output_buffer);
+    /// #
+    /// # let _result = client_ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// #
     /// let mut ntlm = sspi::Ntlm::new();
     /// let mut output_buffer = vec![sspi::SecurityBuffer::new(Vec::new(), sspi::SecurityBufferType::Token)];
@@ -312,6 +314,8 @@ where
     ///
     /// ```
     /// # use sspi::Sspi;
+    /// # use sspi::builders::EmptyInitializeSecurityContext;
+    /// # use crate::sspi::internal::SspiImpl;
     /// #
     /// # let mut client_ntlm = sspi::Ntlm::new();
     /// # let mut ntlm = sspi::Ntlm::new();
@@ -342,8 +346,7 @@ where
     /// # loop {
     /// #     client_output_buffer[0].buffer.clear();
     /// #
-    /// #     let _client_result = client_ntlm
-    /// #         .initialize_security_context()
+    /// #     let mut builder = EmptyInitializeSecurityContext::<<sspi::Ntlm as SspiImpl>::CredentialsHandle>::new()
     /// #         .with_credentials_handle(&mut client_acq_cred_result.credentials_handle)
     /// #         .with_context_requirements(
     /// #             sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY,
@@ -351,9 +354,9 @@ where
     /// #         .with_target_data_representation(sspi::DataRepresentation::Native)
     /// #         .with_target_name("user")
     /// #         .with_input(&mut output_buffer)
-    /// #         .with_output(&mut client_output_buffer)
-    /// #         .execute()
-    /// #         .unwrap();
+    /// #         .with_output(&mut client_output_buffer);
+    /// #
+    /// #     let _client_result = client_ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// #
     /// #     let server_result = ntlm
     /// #         .accept_security_context()
@@ -397,6 +400,9 @@ where
     ///
     /// ```
     /// # use sspi::Sspi;
+    /// # use sspi::builders::EmptyInitializeSecurityContext;
+    /// # use crate::sspi::internal::SspiImpl;
+    /// #
     /// # let mut client_ntlm = sspi::Ntlm::new();
     /// # let mut ntlm = sspi::Ntlm::new();
     /// #
@@ -426,8 +432,7 @@ where
     /// # loop {
     /// #     client_output_buffer[0].buffer.clear();
     /// #
-    /// #     let _client_result = client_ntlm
-    /// #         .initialize_security_context()
+    /// #     let mut builder = EmptyInitializeSecurityContext::<<sspi::Ntlm as SspiImpl>::CredentialsHandle>::new()
     /// #         .with_credentials_handle(&mut client_acq_cred_result.credentials_handle)
     /// #         .with_context_requirements(
     /// #             sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY,
@@ -435,9 +440,9 @@ where
     /// #         .with_target_data_representation(sspi::DataRepresentation::Native)
     /// #         .with_target_name("user")
     /// #         .with_input(&mut server_output_buffer)
-    /// #         .with_output(&mut client_output_buffer)
-    /// #         .execute()
-    /// #         .unwrap();
+    /// #         .with_output(&mut client_output_buffer);
+    /// #
+    /// #     let _client_result = client_ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// #
     /// #     let server_result = ntlm
     /// #         .accept_security_context()
@@ -505,6 +510,9 @@ where
     ///
     /// ```
     /// # use sspi::Sspi;
+    /// # use sspi::builders::EmptyInitializeSecurityContext;
+    /// # use crate::sspi::internal::SspiImpl;
+    /// #
     /// # let mut ntlm = sspi::Ntlm::new();
     /// # let mut server_ntlm = sspi::Ntlm::new();
     /// #
@@ -534,8 +542,7 @@ where
     /// # loop {
     /// #     client_output_buffer[0].buffer.clear();
     /// #
-    /// #     let _client_result = ntlm
-    /// #         .initialize_security_context()
+    /// #     let mut builder = EmptyInitializeSecurityContext::<<sspi::Ntlm as SspiImpl>::CredentialsHandle>::new()
     /// #         .with_credentials_handle(&mut client_acq_cred_result.credentials_handle)
     /// #         .with_context_requirements(
     /// #             sspi::ClientRequestFlags::CONFIDENTIALITY | sspi::ClientRequestFlags::ALLOCATE_MEMORY,
@@ -543,9 +550,9 @@ where
     /// #         .with_target_data_representation(sspi::DataRepresentation::Native)
     /// #         .with_target_name("user")
     /// #         .with_input(&mut server_output_buffer)
-    /// #         .with_output(&mut client_output_buffer)
-    /// #         .execute()
-    /// #         .unwrap();
+    /// #         .with_output(&mut client_output_buffer);
+    /// #
+    /// #     let _client_result = ntlm.initialize_security_context_impl(&mut builder).unwrap();
     /// #
     /// #     let server_result = server_ntlm
     /// #         .accept_security_context()

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -105,9 +105,7 @@ pub fn enumerate_security_packages() -> Result<Vec<PackageInfo>> {
 /// * [SSPI.h](https://docs.microsoft.com/en-us/windows/win32/api/sspi/)
 pub trait Sspi
 where
-    Self:
-    //   Sized +
-      SspiImpl,
+    Self: SspiImpl,
 {
     /// Acquires a handle to preexisting credentials of a security principal. The preexisting credentials are
     /// available only for `sspi::winapi` module. This handle is required by the `initialize_security_context`
@@ -151,7 +149,10 @@ where
     /// * [AcquireCredentialshandleW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-acquirecredentialshandlew)
     fn acquire_credentials_handle(
         &mut self,
-    ) -> EmptyAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData> where Self: Sized {
+    ) -> EmptyAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData>
+    where
+        Self: Sized,
+    {
         AcquireCredentialsHandle::new(Box::new(self))
     }
 
@@ -212,7 +213,12 @@ where
     /// # MSDN
     ///
     /// * [InitializeSecurityContextW function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-initializesecuritycontextw)
-    fn initialize_security_context(&mut self) -> EmptyInitializeSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle> where Self: Sized {
+    fn initialize_security_context(
+        &mut self,
+    ) -> EmptyInitializeSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle>
+    where
+        Self: Sized,
+    {
         InitializeSecurityContext::new(Box::new(self))
     }
 
@@ -293,7 +299,12 @@ where
     /// # MSDN
     ///
     /// * [AcceptSecurityContext function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-acceptsecuritycontext)
-    fn accept_security_context(&mut self) -> EmptyAcceptSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle> where Self: Sized {
+    fn accept_security_context(
+        &mut self,
+    ) -> EmptyAcceptSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle>
+    where
+        Self: Sized,
+    {
         AcceptSecurityContext::new(Box::new(self))
     }
 
@@ -694,9 +705,7 @@ where
 
 pub trait SspiEx
 where
-    Self:
-    // Sized +
-    SspiImpl,
+    Self: SspiImpl,
 {
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData);
 }

--- a/src/sspi/builders/accept_sec_context.rs
+++ b/src/sspi/builders/accept_sec_context.rs
@@ -96,7 +96,9 @@ impl<
         OutputSet,
     >
 {
-    pub(crate) fn new(inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) -> Self {
+    pub(crate) fn new(
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
+    ) -> Self {
         Self {
             inner: Some(inner),
             phantom_creds_use_set: PhantomData,
@@ -243,17 +245,17 @@ impl<
     }
 }
 
-impl<'a, AuthData, CredsHandle>
-    FilledAcceptSecurityContext<'a, AuthData, CredsHandle>
-{
+impl<'a, AuthData, CredsHandle> FilledAcceptSecurityContext<'a, AuthData, CredsHandle> {
     /// Executes the SSPI function that the builder represents.
     pub fn execute(mut self) -> sspi::Result<AcceptSecurityContextResult> {
         let inner = self.inner.take().unwrap();
         inner.accept_security_context_impl(self)
     }
 
-    pub(crate) fn transform(self, inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) -> FilledAcceptSecurityContext<'a, AuthData, CredsHandle>
-    {
+    pub(crate) fn transform<AuthData2>(
+        self,
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData2>>,
+    ) -> FilledAcceptSecurityContext<'a, AuthData2, CredsHandle> {
         AcceptSecurityContext {
             inner: Some(inner),
             phantom_creds_use_set: PhantomData,

--- a/src/sspi/builders/acq_cred_handle.rs
+++ b/src/sspi/builders/acq_cred_handle.rs
@@ -6,8 +6,8 @@ use super::{Assigned, NotAssigned, ToAssign};
 use crate::sspi::internal::SspiImpl;
 use crate::sspi::{self, CredentialUse, Luid};
 
-pub type EmptyAcquireCredentialsHandle<'a, I, C, A> = AcquireCredentialsHandle<'a, I, C, A, WithoutCredentialUse>;
-pub type FilledAcquireCredentialsHandle<'a, I, C, A> = AcquireCredentialsHandle<'a, I, C, A, WithCredentialUse>;
+pub type EmptyAcquireCredentialsHandle<'a, C, A> = AcquireCredentialsHandle<'a, C, A, WithoutCredentialUse>;
+pub type FilledAcquireCredentialsHandle<'a, C, A> = AcquireCredentialsHandle<'a, C, A, WithCredentialUse>;
 
 /// Contains data returned by calling the `execute` method of
 /// the `AcquireCredentialsHandleBuilder` structure. The builder is returned by calling
@@ -24,13 +24,12 @@ pub struct AcquireCredentialsHandleResult<C> {
 ///
 /// These methods are required to be called before calling the `execute` method
 /// * [`with_credential_use`](struct.AcquireCredentialsHandle.html#method.with_credential_use)
-#[derive(Debug)]
-pub struct AcquireCredentialsHandle<'a, Inner, CredsHandle, AuthData, CredentialUseSet>
+// #[derive(Debug)]
+pub struct AcquireCredentialsHandle<'a, CredsHandle, AuthData, CredentialUseSet>
 where
-    Inner: SspiImpl,
     CredentialUseSet: ToAssign,
 {
-    pub(crate) inner: Option<&'a mut Inner>,
+    pub(crate) inner: Option<Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>>,
     pub(crate) phantom_cred_handle: PhantomData<CredsHandle>,
     pub(crate) phantom_cred_use_set: PhantomData<CredentialUseSet>,
 
@@ -41,13 +40,12 @@ where
     pub auth_data: Option<&'a AuthData>,
 }
 
-impl<'a, Inner, CredsHandle, AuthData, CredentialUseSet>
-    AcquireCredentialsHandle<'a, Inner, CredsHandle, AuthData, CredentialUseSet>
+impl<'a, CredsHandle, AuthData, CredentialUseSet>
+    AcquireCredentialsHandle<'a, CredsHandle, AuthData, CredentialUseSet>
 where
-    Inner: SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>,
     CredentialUseSet: ToAssign,
 {
-    pub(crate) fn new(inner: &'a mut Inner) -> Self {
+    pub(crate) fn new(inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) -> Self {
         Self {
             inner: Some(inner),
             phantom_cred_handle: PhantomData,
@@ -64,7 +62,7 @@ where
     pub fn with_credential_use(
         self,
         credential_use: CredentialUse,
-    ) -> AcquireCredentialsHandle<'a, Inner, CredsHandle, AuthData, WithCredentialUse> {
+    ) -> AcquireCredentialsHandle<'a, CredsHandle, AuthData, WithCredentialUse> {
         AcquireCredentialsHandle {
             inner: self.inner,
             phantom_cred_handle: PhantomData,
@@ -103,9 +101,7 @@ where
     }
 }
 
-impl<'a, Inner, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, Inner, CredsHandle, AuthData>
-where
-    Inner: SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>,
+impl<'a, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData>
 {
     /// Executes the SSPI function that the builder represents.
     pub fn execute(mut self) -> sspi::Result<AcquireCredentialsHandleResult<CredsHandle>> {
@@ -113,12 +109,10 @@ where
         inner.acquire_credentials_handle_impl(self)
     }
 
-    pub(crate) fn transform<Inner2>(
+    pub(crate) fn transform(
         self,
-        inner: &'a mut Inner2,
-    ) -> FilledAcquireCredentialsHandle<'a, Inner2, CredsHandle, AuthData>
-    where
-        Inner2: SspiImpl,
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
+    ) -> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData>
     {
         AcquireCredentialsHandle {
             inner: Some(inner),

--- a/src/sspi/builders/acq_cred_handle.rs
+++ b/src/sspi/builders/acq_cred_handle.rs
@@ -40,12 +40,13 @@ where
     pub auth_data: Option<&'a AuthData>,
 }
 
-impl<'a, CredsHandle, AuthData, CredentialUseSet>
-    AcquireCredentialsHandle<'a, CredsHandle, AuthData, CredentialUseSet>
+impl<'a, CredsHandle, AuthData, CredentialUseSet> AcquireCredentialsHandle<'a, CredsHandle, AuthData, CredentialUseSet>
 where
     CredentialUseSet: ToAssign,
 {
-    pub(crate) fn new(inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) -> Self {
+    pub(crate) fn new(
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
+    ) -> Self {
         Self {
             inner: Some(inner),
             phantom_cred_handle: PhantomData,
@@ -101,8 +102,7 @@ where
     }
 }
 
-impl<'a, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData>
-{
+impl<'a, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData> {
     /// Executes the SSPI function that the builder represents.
     pub fn execute(mut self) -> sspi::Result<AcquireCredentialsHandleResult<CredsHandle>> {
         let inner = self.inner.take().unwrap();
@@ -112,8 +112,7 @@ impl<'a, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, 
     pub(crate) fn transform(
         self,
         inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
-    ) -> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData>
-    {
+    ) -> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData> {
         AcquireCredentialsHandle {
             inner: Some(inner),
             phantom_cred_handle: PhantomData,

--- a/src/sspi/builders/init_sec_context.rs
+++ b/src/sspi/builders/init_sec_context.rs
@@ -16,10 +16,7 @@ pub type EmptyInitializeSecurityContext<'a, C> = InitializeSecurityContext<
     WithoutTargetDataRepresentation,
     WithoutOutput,
 >;
-pub type FilledInitializeSecurityContext<
-    'a,
-    C,
-> = InitializeSecurityContext<
+pub type FilledInitializeSecurityContext<'a, C> = InitializeSecurityContext<
     'a,
     C,
     WithCredentialsHandle,
@@ -238,4 +235,3 @@ impl<
         }
     }
 }
-

--- a/src/sspi/builders/init_sec_context.rs
+++ b/src/sspi/builders/init_sec_context.rs
@@ -19,10 +19,12 @@ pub type EmptyInitializeSecurityContext<'a, AuthData, C> = InitializeSecurityCon
     WithoutTargetDataRepresentation,
     WithoutOutput,
 >;
-pub type FilledInitializeSecurityContext<'a,
-AuthData,
-// I,
-C> = InitializeSecurityContext<
+pub type FilledInitializeSecurityContext<
+    'a,
+    AuthData,
+    // I,
+    C,
+> = InitializeSecurityContext<
     'a,
     // I,
     AuthData,
@@ -105,7 +107,9 @@ impl<
         OutputSet,
     >
 {
-    pub(crate) fn new(inner:Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) -> Self {
+    pub(crate) fn new(
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
+    ) -> Self {
         Self {
             inner: Some(inner),
             phantom_creds_use_set: PhantomData,
@@ -266,9 +270,7 @@ impl<
     }
 }
 
-impl<'a, AuthData, CredsHandle>
-    FilledInitializeSecurityContext<'a, AuthData, CredsHandle>
-{
+impl<'a, AuthData, CredsHandle> FilledInitializeSecurityContext<'a, AuthData, CredsHandle> {
     /// Executes the SSPI function that the builder represents.
     pub fn execute(mut self) -> sspi::Result<InitializeSecurityContextResult> {
         let inner = self.inner.take().unwrap();
@@ -282,15 +284,17 @@ impl<'a, AuthData, CredsHandle>
         inner.initialize_security_context_impl(self)
     }
 
-    pub(crate) fn inner(&mut self, inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>) {
+    pub(crate) fn inner(
+        &mut self,
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
+    ) {
         self.inner = Some(inner);
     }
 
-    pub(crate) fn transform(
+    pub(crate) fn transform<AuthData2>(
         self,
-        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData>>,
-    ) -> FilledInitializeSecurityContext<'a, AuthData, CredsHandle>
-    {
+        inner: Box<&'a mut dyn SspiImpl<CredentialsHandle = CredsHandle, AuthenticationData = AuthData2>>,
+    ) -> FilledInitializeSecurityContext<'a, AuthData2, CredsHandle> {
         InitializeSecurityContext {
             inner: Some(inner),
             phantom_creds_use_set: PhantomData,

--- a/src/sspi/internal.rs
+++ b/src/sspi/internal.rs
@@ -5,8 +5,7 @@ use crate::sspi::builders::{
 };
 use crate::sspi::{self, FilledAcceptSecurityContext, FilledAcquireCredentialsHandle, FilledInitializeSecurityContext};
 
-pub trait SspiImpl
-{
+pub trait SspiImpl {
     type CredentialsHandle;
     type AuthenticationData;
 

--- a/src/sspi/internal.rs
+++ b/src/sspi/internal.rs
@@ -6,24 +6,22 @@ use crate::sspi::builders::{
 use crate::sspi::{self, FilledAcceptSecurityContext, FilledAcquireCredentialsHandle, FilledInitializeSecurityContext};
 
 pub trait SspiImpl
-where
-    Self: Sized,
 {
     type CredentialsHandle;
     type AuthenticationData;
 
-    fn acquire_credentials_handle_impl(
-        &mut self,
-        builder: FilledAcquireCredentialsHandle<'_, Self, Self::CredentialsHandle, Self::AuthenticationData>,
+    fn acquire_credentials_handle_impl<'a>(
+        &'a mut self,
+        builder: FilledAcquireCredentialsHandle<'a, Self::CredentialsHandle, Self::AuthenticationData>,
     ) -> sspi::Result<AcquireCredentialsHandleResult<Self::CredentialsHandle>>;
 
-    fn initialize_security_context_impl(
+    fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: FilledInitializeSecurityContext<'_, Self, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult>;
 
-    fn accept_security_context_impl(
-        &mut self,
-        builder: FilledAcceptSecurityContext<'_, Self, Self::CredentialsHandle>,
+    fn accept_security_context_impl<'a>(
+        &'a mut self,
+        builder: FilledAcceptSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<AcceptSecurityContextResult>;
 }

--- a/src/sspi/internal.rs
+++ b/src/sspi/internal.rs
@@ -16,7 +16,7 @@ pub trait SspiImpl {
 
     fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult>;
 
     fn accept_security_context_impl<'a>(

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -268,7 +268,9 @@ impl CredSspClient {
                     .with_target_name(&self.service_principal_name)
                     .with_input(&mut input_token)
                     .with_output(&mut output_token);
-                let result = cred_ssp_context.sspi_context.initialize_security_context_impl(&mut builder)?;
+                let result = cred_ssp_context
+                    .sspi_context
+                    .initialize_security_context_impl(&mut builder)?;
                 self.credentials_handle = credentials_handle;
                 ts_request.nego_tokens = Some(output_token.remove(0).buffer);
 
@@ -552,9 +554,9 @@ impl SspiImpl for SspiContext {
         builder: FilledAcquireCredentialsHandle<'a, Self::CredentialsHandle, Self::AuthenticationData>,
     ) -> sspi::Result<AcquireCredentialsHandleResult<Self::CredentialsHandle>> {
         match self {
-            SspiContext::Ntlm(ntlm) => builder.transform(Box::new(ntlm)).execute(),
-            SspiContext::Kerberos(kerberos) => builder.transform(Box::new(kerberos)).execute(),
-            SspiContext::Negotiate(negotiate) => builder.transform(Box::new(negotiate)).execute(),
+            SspiContext::Ntlm(ntlm) => builder.transform(ntlm).execute(),
+            SspiContext::Kerberos(kerberos) => builder.transform(kerberos).execute(),
+            SspiContext::Negotiate(negotiate) => builder.transform(negotiate).execute(),
         }
     }
 
@@ -574,9 +576,9 @@ impl SspiImpl for SspiContext {
         builder: FilledAcceptSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<AcceptSecurityContextResult> {
         match self {
-            SspiContext::Ntlm(ntlm) => builder.transform(Box::new(ntlm)).execute(),
-            SspiContext::Kerberos(kerberos) => builder.transform(Box::new(kerberos)).execute(),
-            SspiContext::Negotiate(negotiate) => builder.transform(Box::new(negotiate)).execute(),
+            SspiContext::Ntlm(ntlm) => builder.transform(ntlm).execute(),
+            SspiContext::Kerberos(kerberos) => builder.transform(kerberos).execute(),
+            SspiContext::Negotiate(negotiate) => builder.transform(negotiate).execute(),
         }
     }
 }

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -540,7 +540,7 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity>> CredSspServer<C> {
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-enum SspiContext {
+pub enum SspiContext {
     Ntlm(Ntlm),
     Kerberos(Kerberos),
     Negotiate(Negotiate),

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -551,11 +551,11 @@ impl SspiImpl for SspiContext {
             SspiContext::Ntlm(ntlm) => {
                 // builder.inner(Box::new(ntlm));
                 ntlm.initialize_security_context_impl(builder)
-            },
+            }
             SspiContext::Kerberos(kerberos) => {
                 // builder.inner(Box::new(kerberos));
                 kerberos.initialize_security_context_impl(builder)
-            },
+            }
         }
         // builder.simple_execute()
     }

--- a/src/sspi/kerberos.rs
+++ b/src/sspi/kerberos.rs
@@ -328,7 +328,7 @@ impl SspiImpl for Kerberos {
         &mut self,
         builder: &mut crate::builders::FilledInitializeSecurityContext<
             '_,
-            Self::AuthenticationData,
+            // Self::AuthenticationData,
             Self::CredentialsHandle,
         >,
     ) -> Result<crate::InitializeSecurityContextResult> {

--- a/src/sspi/kerberos.rs
+++ b/src/sspi/kerberos.rs
@@ -70,14 +70,6 @@ lazy_static! {
         name: SecurityPackageType::Kerberos,
         comment: String::from("Kerberos Security Package"),
     };
-
-    pub static ref NEGO_PACKAGE_INFO: PackageInfo = PackageInfo {
-        capabilities: PackageCapabilities::empty(),
-        rpc_id: PACKAGE_ID_NONE,
-        max_token_len: 0xbb80, // 48 000 bytes: default maximum token len in Windows
-        name: SecurityPackageType::Other("Negotiate".into()),
-        comment: String::from("Negotiate Security Package"),
-    };
 }
 
 #[derive(Debug, Clone)]
@@ -326,11 +318,7 @@ impl SspiImpl for Kerberos {
 
     fn initialize_security_context_impl(
         &mut self,
-        builder: &mut crate::builders::FilledInitializeSecurityContext<
-            '_,
-            // Self::AuthenticationData,
-            Self::CredentialsHandle,
-        >,
+        builder: &mut crate::builders::FilledInitializeSecurityContext<'_, Self::CredentialsHandle>,
     ) -> Result<crate::InitializeSecurityContextResult> {
         let status = match self.state {
             KerberosState::Negotiate => {

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -188,6 +188,19 @@ impl SspiImpl for Negotiate {
         &mut self,
         builder: &mut builders::FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> Result<InitializeSecurityContextResult> {
+        #[cfg(feature = "network_client")]
+        if let NegotiatedProtocol::Ntlm(_) = self.protocol {
+            if let Some(Some(auth_data)) = builder.credentials_handle.as_ref() {
+                if let Some(domain) = get_domain_from_fqdm(&auth_data.user) {
+                    self.protocol = NegotiatedProtocol::Kerberos(Kerberos::new_client_from_config(KerberosConfig {
+                        url: Url::from_str(format!("tcp://{}:88", domain).as_str()).unwrap(),
+                        kdc_type: KdcType::Kdc,
+                        network_client: Box::new(ReqwestNetworkClient::new()),
+                    })?)
+                }
+            }
+        }
+
         match &mut self.protocol {
             NegotiatedProtocol::Kerberos(kerberos) => {
                 let result = kerberos.initialize_security_context_impl(builder);

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -5,9 +5,9 @@ use lazy_static::lazy_static;
 use url::Url;
 
 use crate::internal::SspiImpl;
-use crate::kerberos::SSPI_KDC_URL_ENV;
 use crate::kerberos::config::KdcType;
 use crate::kerberos::network_client::reqwest_network_client::ReqwestNetworkClient;
+use crate::kerberos::SSPI_KDC_URL_ENV;
 use crate::sspi::{Result, PACKAGE_ID_NONE};
 use crate::utils::get_domain_from_fqdm;
 use crate::{
@@ -29,8 +29,15 @@ lazy_static! {
     };
 }
 
+#[derive(Debug, Clone)]
 pub struct NegotiateConfig {
     pub krb_config: Option<KerberosConfig>,
+}
+
+impl NegotiateConfig {
+    pub fn new(krb_config: Option<KerberosConfig>) -> Self {
+        Self { krb_config }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -6,6 +6,7 @@ use url::Url;
 
 use crate::internal::SspiImpl;
 use crate::kerberos::config::KdcType;
+#[cfg(feature = "network_client")]
 use crate::kerberos::network_client::reqwest_network_client::ReqwestNetworkClient;
 use crate::kerberos::SSPI_KDC_URL_ENV;
 use crate::sspi::{Result, PACKAGE_ID_NONE};
@@ -186,7 +187,7 @@ impl SspiImpl for Negotiate {
 
     fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: &mut builders::FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
+        builder: &mut builders::FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
     ) -> Result<InitializeSecurityContextResult> {
         #[cfg(feature = "network_client")]
         if let NegotiatedProtocol::Ntlm(_) = self.protocol {

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -1,0 +1,148 @@
+
+use lazy_static::lazy_static;
+
+use crate::{PackageInfo, PackageCapabilities, sspi::{PACKAGE_ID_NONE, Result}, SecurityPackageType, KerberosConfig, Sspi, internal::SspiImpl, AuthIdentityBuffers, AuthIdentity, SecurityBuffer, SecurityStatus, ContextSizes, ContextNames, DecryptionFlags, CertTrustStatus, AcquireCredentialsHandleResult, builders, InitializeSecurityContextResult, AcceptSecurityContextResult, Kerberos, Ntlm, Error, ErrorKind};
+
+pub const PKG_NAME: &str = "Negotiate";
+
+lazy_static! {
+    pub static ref PACKAGE_INFO: PackageInfo = PackageInfo {
+        capabilities: PackageCapabilities::empty(),
+        rpc_id: PACKAGE_ID_NONE,
+        max_token_len: 0xbb80, // 48 000 bytes: default maximum token len in Windows
+        name: SecurityPackageType::Negotiate,
+        comment: String::from("Microsoft Package Negotiator"),
+    };
+}
+
+pub struct NegotiateConfig {
+    pub krb_config: Option<KerberosConfig>,
+}
+
+pub enum NegotiatedProtocol {
+    Kerberos(Kerberos),
+    Ntlm(Ntlm),
+}
+
+pub struct Negotiate {
+    config: NegotiateConfig,
+    protocol: NegotiatedProtocol,
+}
+
+impl Negotiate {
+    pub fn new(config: NegotiateConfig) -> Self {
+        Negotiate {
+            config,
+            protocol: NegotiatedProtocol::Ntlm(Ntlm::new()),
+        }
+    }
+}
+
+impl Sspi for Negotiate {
+    fn complete_auth_token(&mut self, token: &mut [SecurityBuffer]) -> Result<SecurityStatus> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.complete_auth_token(token),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.complete_auth_token(token),
+        }
+    }
+
+    fn encrypt_message(
+        &mut self,
+        flags: crate::EncryptionFlags,
+        message: &mut [SecurityBuffer],
+        sequence_number: u32,
+    ) -> Result<SecurityStatus> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.encrypt_message(flags, message, sequence_number),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.encrypt_message(flags, message, sequence_number),
+        }
+    }
+
+    fn decrypt_message(&mut self, message: &mut [SecurityBuffer], sequence_number: u32) -> Result<DecryptionFlags> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.decrypt_message(message, sequence_number),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.decrypt_message(message, sequence_number),
+        }
+    }
+
+    fn query_context_sizes(&mut self) -> Result<ContextSizes> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_sizes(),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_sizes(),
+        }
+    }
+
+    fn query_context_names(&mut self) -> Result<ContextNames> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_names(),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_names(),
+        }
+    }
+
+    fn query_context_package_info(&mut self) -> Result<PackageInfo> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_package_info(),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_package_info(),
+        }
+    }
+
+    fn query_context_cert_trust_status(&mut self) -> Result<CertTrustStatus> {
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_cert_trust_status(),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_cert_trust_status(),
+        }
+    }
+}
+
+impl SspiImpl for Negotiate {
+    type CredentialsHandle = Option<AuthIdentityBuffers>;
+
+    type AuthenticationData = AuthIdentity;
+
+    fn acquire_credentials_handle_impl(
+        &mut self,
+        builder: builders::FilledAcquireCredentialsHandle<'_, Self, Self::CredentialsHandle, Self::AuthenticationData>,
+    ) -> Result<AcquireCredentialsHandleResult<Self::CredentialsHandle>> {
+        todo!()
+    }
+
+    fn initialize_security_context_impl(
+        &mut self,
+        builder: builders::FilledInitializeSecurityContext<'_, Self, Self::CredentialsHandle>,
+    ) -> Result<InitializeSecurityContextResult> {
+        // match &mut self.protocol {
+        //     NegotiatedProtocol::Kerberos(kerberos) => {
+        //         let result = kerberos.initialize_security_context_impl();
+        //         let builder = builder.transform(kerberos);
+        //         if result.is_err() {
+        //             match result.as_ref().unwrap_err().error_type {
+        //                 ErrorKind::NoCredentials => {
+        //                     let mut ntlm = Ntlm::new();
+        //                     // ?acquire_credentials_handle_impl? 
+        //                     self.protocol = NegotiatedProtocol::Ntlm(ntlm);
+        //                 },
+        //                 _ => return result,
+        //             }
+        //         } else {
+        //             return result
+        //         }
+        //     },
+        //     _ => {},
+        // }
+
+        match &mut self.protocol {
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.initialize_security_context_impl(builder.transform(kerberos)),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.initialize_security_context_impl(builder.transform(ntlm)),
+        }
+    }
+
+    fn accept_security_context_impl(
+        &mut self,
+        builder: builders::FilledAcceptSecurityContext<'_, Self, Self::CredentialsHandle>,
+    ) -> Result<AcceptSecurityContextResult> {
+        Err(Error {
+            error_type: ErrorKind::UnsupportedFunction,
+            description: "Negotiate module is not supported for server".into(),
+        })
+    }
+}

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -14,7 +14,7 @@ use crate::{
     builders, AcceptSecurityContextResult, AcquireCredentialsHandleResult, AuthIdentity, AuthIdentityBuffers,
     CertTrustStatus, ContextNames, ContextSizes, CredentialUse, DecryptionFlags, Error, ErrorKind,
     InitializeSecurityContextResult, Kerberos, KerberosConfig, Ntlm, PackageCapabilities, PackageInfo, SecurityBuffer,
-    SecurityPackageType, SecurityStatus, Sspi,
+    SecurityPackageType, SecurityStatus, Sspi, SspiEx,
 };
 
 pub const PKG_NAME: &str = "Negotiate";
@@ -33,11 +33,13 @@ pub struct NegotiateConfig {
     pub krb_config: Option<KerberosConfig>,
 }
 
+#[derive(Debug, Clone)]
 pub enum NegotiatedProtocol {
     Kerberos(Kerberos),
     Ntlm(Ntlm),
 }
 
+#[derive(Debug, Clone)]
 pub struct Negotiate {
     // config: NegotiateConfig,
     protocol: NegotiatedProtocol,
@@ -68,6 +70,12 @@ impl Negotiate {
             protocol,
             auth_identity: None,
         })
+    }
+}
+
+impl SspiEx for Negotiate {
+    fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) {
+        self.auth_identity = Some(identity.into());
     }
 }
 

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -130,6 +130,27 @@ impl Ntlm {
             recv_sealing_key: None,
         }
     }
+
+    pub fn with_auth_identity(identity: Option<AuthIdentityBuffers>) -> Self {
+        Self {
+            negotiate_message: None,
+            challenge_message: None,
+            authenticate_message: None,
+
+            state: NtlmState::Initial,
+            flags: NegotiateFlags::empty(),
+            identity,
+            version: DEFAULT_NTLM_VERSION,
+
+            send_single_host_data: false,
+
+            send_signing_key: [0x00; HASH_SIZE],
+            recv_signing_key: [0x00; HASH_SIZE],
+            send_sealing_key: None,
+            recv_sealing_key: None,
+        }
+    }
+
     pub fn set_version(&mut self, version: [u8; NTLM_VERSION_SIZE]) {
         self.version = version;
     }

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -187,7 +187,7 @@ impl SspiImpl for Ntlm {
 
     fn initialize_security_context_impl(
         &mut self,
-        builder: &mut FilledInitializeSecurityContext<'_, Self::AuthenticationData, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'_, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult> {
         let status = match self.state {
             NtlmState::Initial => {

--- a/src/sspi/ntlm/test.rs
+++ b/src/sspi/ntlm/test.rs
@@ -215,15 +215,15 @@ fn initialize_security_context_wrong_state_negotiate() {
     context.state = NtlmState::Negotiate;
 
     let mut output = vec![SecurityBuffer::new(Vec::new(), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    assert!(context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .is_err());
+        .with_output(&mut output);
+
+    assert!(context.initialize_security_context_impl(&mut builder).is_err());
     assert_eq!(context.state, NtlmState::Negotiate);
 }
 
@@ -233,15 +233,15 @@ fn initialize_security_context_wrong_state_authenticate() {
     context.state = NtlmState::Authenticate;
 
     let mut output = vec![SecurityBuffer::new(Vec::new(), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    assert!(context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .is_err());
+        .with_output(&mut output);
+
+    assert!(context.initialize_security_context_impl(&mut builder).is_err());
     assert_eq!(context.state, NtlmState::Authenticate);
 }
 
@@ -251,15 +251,15 @@ fn initialize_security_context_wrong_state_completion() {
     context.state = NtlmState::Completion;
 
     let mut output = vec![SecurityBuffer::new(Vec::new(), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    assert!(context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .is_err());
+        .with_output(&mut output);
+
+    assert!(context.initialize_security_context_impl(&mut builder).is_err());
     assert_eq!(context.state, NtlmState::Completion);
 }
 
@@ -269,15 +269,15 @@ fn initialize_security_context_wrong_state_final() {
     context.state = NtlmState::Final;
 
     let mut output = vec![SecurityBuffer::new(Vec::new(), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    assert!(context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .is_err());
+        .with_output(&mut output);
+
+    assert!(context.initialize_security_context_impl(&mut builder).is_err());
     assert_eq!(context.state, NtlmState::Final);
 }
 
@@ -288,15 +288,15 @@ fn initialize_security_context_writes_negotiate_message() {
     context.state = NtlmState::Initial;
 
     let mut output = vec![SecurityBuffer::new(Vec::with_capacity(1024), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    let result = context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .unwrap();
+        .with_output(&mut output);
+
+    let result = context.initialize_security_context_impl(&mut builder).unwrap();
 
     assert_eq!(result.status, SecurityStatus::ContinueNeeded);
     let output = SecurityBuffer::find_buffer(&output, SecurityBufferType::Token).unwrap();
@@ -311,7 +311,7 @@ fn initialize_security_context_reads_challenge_message() {
     context.state = NtlmState::Challenge;
     context.negotiate_message = Some(NegotiateMessage::new(Vec::new()));
 
-    let input = SecurityBuffer::new(
+    let mut input = [SecurityBuffer::new(
         vec![
             0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x30, 0x00,
             0x00, 0x00, 0x97, 0x82, 0x88, 0xe0, 0xfe, 0x14, 0x51, 0x74, 0x06, 0x57, 0x92, 0x8a, 0x00, 0x00, 0x00, 0x00,
@@ -319,18 +319,18 @@ fn initialize_security_context_reads_challenge_message() {
             0x00, 0x00,
         ],
         SecurityBufferType::Token,
-    );
+    )];
     let mut output = vec![SecurityBuffer::new(Vec::with_capacity(1024), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    let result = context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
         .with_output(&mut output)
-        .with_input(&mut [input])
-        .execute()
-        .unwrap();
+        .with_input(&mut input);
+
+    let result = context.initialize_security_context_impl(&mut builder).unwrap();
     assert_eq!(result.status, SecurityStatus::Ok);
     assert_ne!(context.state, NtlmState::Challenge);
 }
@@ -341,7 +341,7 @@ fn initialize_security_context_writes_authenticate_message() {
     context.state = NtlmState::Challenge;
     context.negotiate_message = Some(NegotiateMessage::new(Vec::new()));
 
-    let input = SecurityBuffer::new(
+    let mut input = [SecurityBuffer::new(
         vec![
             0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x30, 0x00,
             0x00, 0x00, 0x97, 0x82, 0x88, 0xe0, 0xfe, 0x14, 0x51, 0x74, 0x06, 0x57, 0x92, 0x8a, 0x00, 0x00, 0x00, 0x00,
@@ -349,18 +349,18 @@ fn initialize_security_context_writes_authenticate_message() {
             0x00, 0x00,
         ],
         SecurityBufferType::Token,
-    );
+    )];
     let mut output = vec![SecurityBuffer::new(Vec::with_capacity(1024), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    let result = context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
         .with_output(&mut output)
-        .with_input(&mut [input])
-        .execute()
-        .unwrap();
+        .with_input(&mut input);
+
+    let result = context.initialize_security_context_impl(&mut builder).unwrap();
 
     assert_eq!(result.status, SecurityStatus::Ok);
     let output = SecurityBuffer::find_buffer(&output, SecurityBufferType::Token).unwrap();
@@ -374,15 +374,15 @@ fn initialize_security_context_fails_on_empty_output_on_challenge_state() {
     context.state = NtlmState::Challenge;
 
     let mut output = vec![SecurityBuffer::new(Vec::with_capacity(1024), SecurityBufferType::Token)];
+    let mut credentials = Some(TEST_CREDENTIALS.clone());
 
-    assert!(context
-        .initialize_security_context()
-        .with_credentials_handle(&mut Some(TEST_CREDENTIALS.clone()))
+    let mut builder = EmptyInitializeSecurityContext::<<Ntlm as SspiImpl>::CredentialsHandle>::new()
+        .with_credentials_handle(&mut credentials)
         .with_context_requirements(ClientRequestFlags::empty())
         .with_target_data_representation(DataRepresentation::Native)
-        .with_output(&mut output)
-        .execute()
-        .is_err());
+        .with_output(&mut output);
+
+    assert!(context.initialize_security_context_impl(&mut builder).is_err());
 }
 
 #[test]

--- a/src/sspi/winapi/ntlm.rs
+++ b/src/sspi/winapi/ntlm.rs
@@ -77,11 +77,9 @@ impl SspiImpl for Ntlm {
 
     fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult> {
-        todo!()
-        // builder.transform(Box::new(&mut self.0)).execute()
-        // self.0.initialize_security_context_impl(builder)
+        self.0.initialize_security_context_impl(builder)
     }
 
     fn accept_security_context_impl<'a>(

--- a/src/sspi/winapi/ntlm.rs
+++ b/src/sspi/winapi/ntlm.rs
@@ -61,7 +61,7 @@ impl SspiImpl for Ntlm {
         };
 
         let builder = AcquireCredentialsHandle {
-            inner: Some(Box::new(&mut self.0)),
+            inner: Some(&mut self.0),
             phantom_cred_handle: PhantomData,
             phantom_cred_use_set: PhantomData,
 
@@ -86,7 +86,7 @@ impl SspiImpl for Ntlm {
         &'a mut self,
         builder: FilledAcceptSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<AcceptSecurityContextResult> {
-        builder.transform(Box::new(&mut self.0)).execute()
+        builder.transform(&mut self.0).execute()
     }
 }
 

--- a/src/sspi/winapi/ntlm.rs
+++ b/src/sspi/winapi/ntlm.rs
@@ -37,7 +37,7 @@ impl SspiImpl for Ntlm {
 
     fn acquire_credentials_handle_impl(
         &mut self,
-        builder: FilledAcquireCredentialsHandle<'_, Self, Self::CredentialsHandle, Self::AuthenticationData>,
+        builder: FilledAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData>,
     ) -> sspi::Result<AcquireCredentialsHandleResult<Self::CredentialsHandle>> {
         let (identity, _auth_data) = if let Some(auth_data) = builder.auth_data {
             let domain_str = auth_data.domain.clone().unwrap_or_default();
@@ -61,7 +61,7 @@ impl SspiImpl for Ntlm {
         };
 
         let builder = AcquireCredentialsHandle {
-            inner: Some(&mut self.0),
+            inner: Some(Box::new(&mut self.0)),
             phantom_cred_handle: PhantomData,
             phantom_cred_use_set: PhantomData,
 
@@ -75,18 +75,20 @@ impl SspiImpl for Ntlm {
         builder.execute()
     }
 
-    fn initialize_security_context_impl(
+    fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: FilledInitializeSecurityContext<'_, Self, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult> {
-        builder.transform(&mut self.0).execute()
+        // builder.transform(Box::new(&mut self.0)).execute()
+        todo!()
     }
 
-    fn accept_security_context_impl(
-        &mut self,
-        builder: FilledAcceptSecurityContext<'_, Self, Self::CredentialsHandle>,
+    fn accept_security_context_impl<'a>(
+        &'a mut self,
+        builder: FilledAcceptSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<AcceptSecurityContextResult> {
-        builder.transform(&mut self.0).execute()
+        // builder.transform(Box::new(&mut self.0)).execute()
+        todo!()
     }
 }
 

--- a/src/sspi/winapi/ntlm.rs
+++ b/src/sspi/winapi/ntlm.rs
@@ -79,16 +79,16 @@ impl SspiImpl for Ntlm {
         &mut self,
         builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult> {
-        // builder.transform(Box::new(&mut self.0)).execute()
         todo!()
+        // builder.transform(Box::new(&mut self.0)).execute()
+        // self.0.initialize_security_context_impl(builder)
     }
 
     fn accept_security_context_impl<'a>(
         &'a mut self,
         builder: FilledAcceptSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
     ) -> sspi::Result<AcceptSecurityContextResult> {
-        // builder.transform(Box::new(&mut self.0)).execute()
-        todo!()
+        builder.transform(Box::new(&mut self.0)).execute()
     }
 }
 

--- a/src/sspi/winapi/security_package.rs
+++ b/src/sspi/winapi/security_package.rs
@@ -130,7 +130,7 @@ impl SspiImpl for SecurityPackage {
 
     fn initialize_security_context_impl<'a>(
         &mut self,
-        builder: &mut FilledInitializeSecurityContext<'a, Self::AuthenticationData, Self::CredentialsHandle>,
+        builder: &mut FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
     ) -> sspi::Result<InitializeSecurityContextResult> {
         let mut context_to_set = None;
         let (context, context_new) = if let Some(ref mut context) = self.context {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,15 +29,22 @@ pub fn get_domain_from_fqdn(fqdm: &[u8]) -> Option<String> {
 
 #[cfg(feature = "network_client")]
 pub fn resolve_kdc_host(domain: &str) -> Option<String> {
-    use trust_dns_resolver::{system_conf::read_system_conf, Resolver};
+    use trust_dns_resolver::system_conf::read_system_conf;
+    use trust_dns_resolver::Resolver;
 
     let (resolver_config, resolver_options) = read_system_conf().ok()?;
     let resolver = Resolver::new(resolver_config, resolver_options).ok()?;
 
     if let Some(records) = resolver.srv_lookup(&format!("_kerberos._tcp.{}", domain)).ok() {
-        records.into_iter().next().map(|record| format!("tcp://{}:88", record.target()))
+        records
+            .into_iter()
+            .next()
+            .map(|record| format!("tcp://{}:88", record.target()))
     } else if let Some(records) = resolver.srv_lookup(&format!("_kerberos._udp.{}", domain)).ok() {
-        records.into_iter().next().map(|record| format!("udp://{}:88", record.target()))
+        records
+            .into_iter()
+            .next()
+            .map(|record| format!("udp://{}:88", record.target()))
     } else {
         None
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,3 +15,31 @@ pub fn bytes_to_utf16_string(mut value: &[u8]) -> String {
 
     String::from_utf16_lossy(value_u16.as_ref())
 }
+
+pub fn get_domain_from_fqdm(fqdm: &[u8]) -> Option<String> {
+    let mut fqdm = bytes_to_utf16_string(fqdm);
+
+    if let Some(index) = fqdm.find('@') {
+        Some(fqdm.split_off(index + 1))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_domain_from_fqdm;
+
+    #[test]
+    fn test_get_domain_from_fqdm() {
+        // user1@example.com
+        let fqdm = [
+            117, 0, 115, 0, 101, 0, 114, 0, 49, 0, 64, 0, 101, 0, 120, 0, 97, 0, 109, 0, 112, 0, 108, 0, 101, 0, 46, 0,
+            99, 0, 111, 0, 109, 0,
+        ];
+
+        let domain = get_domain_from_fqdm(&fqdm).unwrap();
+
+        assert_eq!(&domain, "example.com");
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,8 @@ pub fn bytes_to_utf16_string(mut value: &[u8]) -> String {
     String::from_utf16_lossy(value_u16.as_ref())
 }
 
-pub fn get_domain_from_fqdm(fqdm: &[u8]) -> Option<String> {
+#[cfg(feature = "network_client")]
+pub fn get_domain_from_fqdn(fqdm: &[u8]) -> Option<String> {
     let mut fqdm = bytes_to_utf16_string(fqdm);
 
     if let Some(index) = fqdm.find('@') {
@@ -26,9 +27,10 @@ pub fn get_domain_from_fqdm(fqdm: &[u8]) -> Option<String> {
     }
 }
 
+#[cfg(feature = "network_client")]
 #[cfg(test)]
 mod tests {
-    use super::get_domain_from_fqdm;
+    use super::get_domain_from_fqdn;
 
     #[test]
     fn test_get_domain_from_fqdm() {
@@ -38,7 +40,7 @@ mod tests {
             99, 0, 111, 0, 109, 0,
         ];
 
-        let domain = get_domain_from_fqdm(&fqdm).unwrap();
+        let domain = get_domain_from_fqdn(&fqdm).unwrap();
 
         assert_eq!(&domain, "example.com");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,22 @@ pub fn get_domain_from_fqdn(fqdm: &[u8]) -> Option<String> {
 }
 
 #[cfg(feature = "network_client")]
+pub fn resolve_kdc_host(domain: &str) -> Option<String> {
+    use trust_dns_resolver::{system_conf::read_system_conf, Resolver};
+
+    let (resolver_config, resolver_options) = read_system_conf().ok()?;
+    let resolver = Resolver::new(resolver_config, resolver_options).ok()?;
+
+    if let Some(records) = resolver.srv_lookup(&format!("_kerberos._tcp.{}", domain)).ok() {
+        records.into_iter().next().map(|record| format!("tcp://{}:88", record.target()))
+    } else if let Some(records) = resolver.srv_lookup(&format!("_kerberos._udp.{}", domain)).ok() {
+        records.into_iter().next().map(|record| format!("udp://{}:88", record.target()))
+    } else {
+        None
+    }
+}
+
+#[cfg(feature = "network_client")]
 #[cfg(test)]
 mod tests {
     use super::get_domain_from_fqdn;


### PR DESCRIPTION
I've implemented the `Negotiate` module that will choose in the runtime (during authorization) what NLA protocol to use: Kerberos or NTLM.
Kerberos is preferred but not always possible. it falls back to the NTLM In two cases:
* When the user doesn't provide explicitly KDC URL and when we can not detect KDC using DNS
* When Kerberos returns the `SEC_E_NO_CREDENTIALS` error

It detects the KDC server host If the user tries to log in with FQDN then we'll cut the domain part from it and try to find `_kerberos._tcp.<domain>`/`_kerberos._udp.<domain>` DNS SRV records. If it is found, we'll take the target host from this record.

For example: if the user tries to log in with `user@example.com` then we'll cut `example.com` from it and try to find `_kerberos._tcp.example.com`/`_kerberos._udp.example.com` DNS SRV records.

Also, I've added support for different security packages in C-bindings (`sspi-c-api`).