### PR TITLE
Add SetCredentialsAttributesA/W

### DIFF
--- a/c-api/src/credentials_attributes.rs
+++ b/c-api/src/credentials_attributes.rs
@@ -1,0 +1,32 @@
+use libc::{c_uint, c_ulong, c_ushort};
+
+pub struct KdcProxySettings {
+    pub proxy_server: String,
+    #[allow(dead_code)]
+    pub client_tls_cred: Option<String>,
+}
+
+#[derive(Default)]
+pub struct CredentialsAttributes {
+    pub kdc_proxy_settings: Option<KdcProxySettings>,
+}
+
+#[repr(C)]
+pub struct SecPkgCredentialsKdcProxySettingsA {
+    pub version: c_uint,
+    pub flags: c_uint,
+    pub proxy_server_offset: c_ushort,
+    pub proxy_server_length: c_ushort,
+    pub client_tls_cred_offset: c_ushort,
+    pub client_tls_cred_length: c_ushort,
+}
+
+#[repr(C)]
+pub struct SecPkgCredentialsKdcProxySettingsW {
+    pub version: c_ulong,
+    pub flags: c_ulong,
+    pub proxy_server_offset: c_ushort,
+    pub proxy_server_length: c_ushort,
+    pub client_tls_cred_offset: c_ushort,
+    pub client_tls_cred_length: c_ushort,
+}

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::missing_safety_doc)]
 pub mod common;
+pub mod credentials_attributes;
 pub mod sec_buffer;
 #[allow(clippy::missing_safety_doc)]
 pub mod sec_handle;

--- a/c-api/src/utils.rs
+++ b/c-api/src/utils.rs
@@ -3,6 +3,7 @@ use std::slice::from_raw_parts;
 use libc::{c_char, c_ushort};
 use sspi::AuthIdentityBuffers;
 
+use crate::credentials_attributes::CredentialsAttributes;
 use crate::sec_handle::CredentialsHandle;
 use crate::sspi_data_types::{SecChar, SecWChar};
 
@@ -47,15 +48,16 @@ pub unsafe fn c_str_into_string(s: *const SecChar) -> String {
 
 pub unsafe fn transform_credentials_handle<'a>(
     credentials_handle: *mut CredentialsHandle,
-) -> (Option<AuthIdentityBuffers>, Option<&'a str>) {
+) -> Option<(AuthIdentityBuffers, &'a str, &'a CredentialsAttributes)> {
     if credentials_handle.is_null() {
-        (None, None)
+        None
     } else {
         let cred_handle = credentials_handle.as_mut().unwrap();
-        (
-            Some(cred_handle.credentials.clone()),
-            Some(cred_handle.security_package_name.as_str()),
-        )
+        Some((
+            cred_handle.credentials.clone(),
+            cred_handle.security_package_name.as_str(),
+            &cred_handle.attributes,
+        ))
     }
 }
 

--- a/src/sspi/kerberos/config.rs
+++ b/src/sspi/kerberos/config.rs
@@ -22,21 +22,26 @@ pub struct KerberosConfig {
     pub network_client: Box<dyn NetworkClient>,
 }
 
+pub fn parse_kdc_url(mut kdc: String) -> (Url, KdcType) {
+    if !kdc.contains("://") {
+        kdc = format!("tcp://{}", kdc);
+    }
+    let kdc_url = Url::from_str(&kdc).unwrap();
+    let kdc_type = match kdc_url.scheme() {
+        "tcp" => KdcType::Kdc,
+        "udp" => KdcType::Kdc,
+        "http" => KdcType::KdcProxy,
+        "https" => KdcType::KdcProxy,
+        _ => KdcType::Kdc,
+    };
+    (kdc_url, kdc_type)
+}
+
 impl KerberosConfig {
     pub fn get_kdc_env() -> Option<(Url, KdcType)> {
-        let mut kdc_url_env = env::var(SSPI_KDC_URL_ENV).expect("SSPI_KDC_URL environment variable must be set!");
-        if !kdc_url_env.contains("://") {
-            kdc_url_env = format!("tcp://{}", kdc_url_env);
-        }
-        let kdc_url = Url::from_str(&kdc_url_env).unwrap();
-        let kdc_type = match kdc_url.scheme() {
-            "tcp" => KdcType::Kdc,
-            "udp" => KdcType::Kdc,
-            "http" => KdcType::KdcProxy,
-            "https" => KdcType::KdcProxy,
-            _ => KdcType::Kdc,
-        };
-        Some((kdc_url, kdc_type))
+        Some(parse_kdc_url(
+            env::var(SSPI_KDC_URL_ENV).expect("SSPI_KDC_URL environment variable must be set!"),
+        ))
     }
 
     pub fn new_with_network_client(network_client: Box<dyn NetworkClient>) -> Self {
@@ -55,6 +60,16 @@ impl KerberosConfig {
     pub fn from_env() -> Self {
         let network_client = Box::new(ReqwestNetworkClient::new());
         Self::new_with_network_client(network_client)
+    }
+
+    pub fn from_kdc_url(url: &str, network_client: Box<dyn NetworkClient>) -> Self {
+        let (url, kdc_type) = parse_kdc_url(url.to_owned());
+
+        Self {
+            url,
+            kdc_type,
+            network_client,
+        }
     }
 
     #[cfg(not(feature = "network_client"))]


### PR DESCRIPTION
_SetCredentialsAttributesA/W_ allows setting _KDC_ /_KDC Proxy_  addresses without using the _SSPI_KDC_URL_ environment variable.

Useful links:
- https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-setcredentialsattributesa
- https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secpkgcredentials_kdcproxysettingsw
- https://github.com/Devolutions/MsRdpEx/blob/master/dll/Sspi.cpp#L251