### PR TITLE
C# NegotiateStream fixes

### DIFF
--- a/c-api/src/common.rs
+++ b/c-api/src/common.rs
@@ -10,8 +10,8 @@ use sspi::{
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 
-use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers, PSecBuffer, PSecBufferDesc};
 use crate::credentials_attributes::CredentialsAttributes;
+use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers, PSecBuffer, PSecBufferDesc};
 use crate::sec_handle::{p_ctxt_handle_to_sspi_context, CredentialsHandle, PCredHandle, PCtxtHandle};
 use crate::sspi_data_types::{PTimeStamp, SecurityStatus};
 use crate::utils::{into_raw_ptr, transform_credentials_handle};

--- a/c-api/src/common.rs
+++ b/c-api/src/common.rs
@@ -15,7 +15,6 @@ use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers,
 use crate::sec_handle::{p_ctxt_handle_to_sspi_context, CredentialsHandle, PCredHandle, PCtxtHandle};
 use crate::sspi_data_types::{PTimeStamp, SecurityStatus};
 use crate::utils::{into_raw_ptr, transform_credentials_handle};
-use crate::{check_null, try_execute};
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_FreeCredentialsHandle"))]
 #[no_mangle]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+mod macros;
 #[allow(clippy::missing_safety_doc)]
 pub mod common;
 pub mod credentials_attributes;

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,15 +1,14 @@
+#![allow(clippy::missing_safety_doc)]
+
 #[macro_use]
 mod macros;
-#[allow(clippy::missing_safety_doc)]
+
 pub mod common;
 pub mod credentials_attributes;
 pub mod sec_buffer;
-#[allow(clippy::missing_safety_doc)]
 pub mod sec_handle;
-#[allow(clippy::missing_safety_doc)]
 pub mod sec_pkg_info;
 pub mod sec_winnt_auth_identity;
 pub mod security_tables;
 pub mod sspi_data_types;
-#[allow(clippy::missing_safety_doc)]
 pub mod utils;

--- a/c-api/src/macros.rs
+++ b/c-api/src/macros.rs
@@ -1,0 +1,21 @@
+macro_rules! try_execute {
+    ($x:expr) => {{
+        match $x {
+            Ok(value) => value,
+            Err(err) => {
+                return err.error_type.to_u32().unwrap();
+            }
+        }
+    }};
+}
+
+macro_rules! check_null {
+    ($x:expr) => {{
+        use num_traits::ToPrimitive;
+        use sspi::ErrorKind;
+
+        if $x.is_null() {
+            return ErrorKind::InvalidParameter.to_u32().unwrap();
+        }
+    }};
+}

--- a/c-api/src/sec_handle.rs
+++ b/c-api/src/sec_handle.rs
@@ -16,11 +16,11 @@ use sspi::{
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 
-use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers, PSecBuffer, PSecBufferDesc};
-use crate::sec_pkg_info::{SecNegoInfoA, SecNegoInfoW, SecPkgInfoA, SecPkgInfoW};
 use crate::credentials_attributes::{
     CredentialsAttributes, KdcProxySettings, SecPkgCredentialsKdcProxySettingsA, SecPkgCredentialsKdcProxySettingsW,
 };
+use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers, PSecBuffer, PSecBufferDesc};
+use crate::sec_pkg_info::{SecNegoInfoA, SecNegoInfoW, SecPkgInfoA, SecPkgInfoW};
 use crate::sec_winnt_auth_identity::{SecWinntAuthIdentityA, SecWinntAuthIdentityW};
 use crate::sspi_data_types::{
     LpStr, LpcWStr, PSecurityString, PTimeStamp, SecChar, SecGetKeyFn, SecPkgContextSizes, SecWChar, SecurityStatus,
@@ -268,7 +268,9 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         Some(security_package_name),
         attributes
     ));
-    let sspi_context = sspi_context_ptr.as_mut().expect("security context pointer cannot be null");
+    let sspi_context = sspi_context_ptr
+        .as_mut()
+        .expect("security context pointer cannot be null");
 
     let mut input_tokens = if p_input.is_null() {
         Vec::new()
@@ -360,7 +362,9 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         Some(security_package_name),
         attributes,
     ));
-    let sspi_context = sspi_context_ptr.as_mut().expect("security context pointer cannot be null");
+    let sspi_context = sspi_context_ptr
+        .as_mut()
+        .expect("security context pointer cannot be null");
 
     let mut input_tokens = if p_input.is_null() {
         Vec::new()
@@ -417,9 +421,13 @@ pub unsafe extern "system" fn QueryContextAttributesA(
     ul_attribute: c_ulong,
     p_buffer: *mut c_void,
 ) -> SecurityStatus {
-    let sspi_context = try_execute!(p_ctxt_handle_to_sspi_context(&mut ph_context, None,  &CredentialsAttributes::default()))
-        .as_mut()
-        .expect("security context pointer cannot be null");
+    let sspi_context = try_execute!(p_ctxt_handle_to_sspi_context(
+        &mut ph_context,
+        None,
+        &CredentialsAttributes::default()
+    ))
+    .as_mut()
+    .expect("security context pointer cannot be null");
 
     check_null!(p_buffer);
 
@@ -459,9 +467,13 @@ pub unsafe extern "system" fn QueryContextAttributesW(
     ul_attribute: c_ulong,
     p_buffer: *mut c_void,
 ) -> SecurityStatus {
-    let sspi_context = try_execute!(p_ctxt_handle_to_sspi_context(&mut ph_context, None,  &CredentialsAttributes::default()))
-        .as_mut()
-        .expect("security context pointer cannot be null");
+    let sspi_context = try_execute!(p_ctxt_handle_to_sspi_context(
+        &mut ph_context,
+        None,
+        &CredentialsAttributes::default()
+    ))
+    .as_mut()
+    .expect("security context pointer cannot be null");
 
     check_null!(p_buffer);
 

--- a/c-api/src/sec_handle.rs
+++ b/c-api/src/sec_handle.rs
@@ -28,7 +28,6 @@ use crate::sspi_data_types::{
 use crate::utils::{
     c_w_str_to_string, into_raw_ptr, raw_str_into_bytes, raw_w_str_to_bytes, transform_credentials_handle,
 };
-use crate::{check_null, try_execute};
 
 pub const SECPKG_NEGOTIATION_COMPLETE: u32 = 0;
 pub const SECPKG_NEGOTIATION_OPTIMISTIC: u32 = 1;

--- a/c-api/src/sec_pkg_info.rs
+++ b/c-api/src/sec_pkg_info.rs
@@ -3,6 +3,7 @@ use sspi::{enumerate_security_packages, PackageInfo, KERBEROS_VERSION};
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 
+use crate::check_null;
 use crate::sspi_data_types::{SecChar, SecWChar, SecurityStatus};
 use crate::utils::{c_str_into_string, c_w_str_to_string, into_raw_ptr, vec_into_raw_ptr};
 
@@ -50,6 +51,20 @@ pub struct SecPkgInfoA {
 
 pub type PSecPkgInfoA = *mut SecPkgInfoA;
 
+#[derive(Debug)]
+#[repr(C)]
+pub struct SecNegoInfoW {
+    pub package_info: *mut SecPkgInfoW,
+    pub nego_state: c_ulong,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct SecNegoInfoA {
+    pub package_info: *mut SecPkgInfoA,
+    pub nego_state: c_uint,
+}
+
 impl From<PackageInfo> for SecPkgInfoA {
     fn from(data: PackageInfo) -> Self {
         let mut name = data.name.to_string().as_bytes().to_vec();
@@ -75,6 +90,9 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
     pc_packages: *mut c_ulong,
     pp_package_info: *mut PSecPkgInfoA,
 ) -> SecurityStatus {
+    check_null!(pc_packages);
+    check_null!(pp_package_info);
+
     let packages = enumerate_security_packages().unwrap();
 
     *pc_packages = packages.len() as c_ulong;
@@ -91,6 +109,9 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
     pc_packages: *mut c_ulong,
     pp_package_info: *mut *mut SecPkgInfoW,
 ) -> SecurityStatus {
+    check_null!(pc_packages);
+    check_null!(pp_package_info);
+
     let packages = enumerate_security_packages().unwrap();
 
     *pc_packages = packages.len() as c_ulong;
@@ -107,6 +128,9 @@ pub unsafe extern "system" fn QuerySecurityPackageInfoA(
     p_package_name: *const SecChar,
     pp_package_info: *mut PSecPkgInfoA,
 ) -> SecurityStatus {
+    check_null!(p_package_name);
+    check_null!(pp_package_info);
+
     let pkg_name = c_str_into_string(p_package_name);
 
     *pp_package_info = enumerate_security_packages()
@@ -126,6 +150,9 @@ pub unsafe extern "system" fn QuerySecurityPackageInfoW(
     p_package_name: *const SecWChar,
     pp_package_info: *mut PSecPkgInfoW,
 ) -> SecurityStatus {
+    check_null!(p_package_name);
+    check_null!(pp_package_info);
+
     let pkg_name = c_w_str_to_string(p_package_name);
 
     *pp_package_info = enumerate_security_packages()

--- a/c-api/src/sec_pkg_info.rs
+++ b/c-api/src/sec_pkg_info.rs
@@ -3,7 +3,6 @@ use sspi::{enumerate_security_packages, PackageInfo, KERBEROS_VERSION};
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 
-use crate::check_null;
 use crate::sspi_data_types::{SecChar, SecWChar, SecurityStatus};
 use crate::utils::{c_str_into_string, c_w_str_to_string, into_raw_ptr, vec_into_raw_ptr};
 

--- a/c-api/src/sec_winnt_auth_identity.rs
+++ b/c-api/src/sec_winnt_auth_identity.rs
@@ -1,4 +1,12 @@
-use libc::{c_char, c_uint, c_ulong, c_ushort};
+use std::ptr::drop_in_place;
+
+use libc::{c_char, c_uint, c_ulong, c_ushort, c_void};
+#[cfg(windows)]
+use symbol_rename_macro::rename_symbol;
+
+use crate::check_null;
+use crate::sspi_data_types::{SecWChar, SecurityStatus};
+use crate::utils::{c_w_str_to_string, into_raw_ptr};
 
 #[repr(C)]
 pub struct SecWinntAuthIdentityW {
@@ -20,4 +28,179 @@ pub struct SecWinntAuthIdentityA {
     pub password: *const c_char,
     pub password_length: c_uint,
     pub flags: c_uint,
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[cfg_attr(windows, rename_symbol(to = "Rust_SspiEncodeStringsAsAuthIdentity"))]
+#[no_mangle]
+pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
+    psz_user_name: *const SecWChar,
+    psz_domain_name: *const SecWChar,
+    psz_packed_credentials_string: *const SecWChar,
+    pp_auth_identity: *mut *mut c_void,
+) -> SecurityStatus {
+    check_null!(pp_auth_identity);
+    check_null!(psz_user_name);
+    check_null!(psz_domain_name);
+    check_null!(psz_packed_credentials_string);
+
+    let user = c_w_str_to_string(psz_user_name);
+    let domain = c_w_str_to_string(psz_domain_name);
+    let password = c_w_str_to_string(psz_packed_credentials_string);
+
+    let auth_identity = SecWinntAuthIdentityW {
+        user: psz_user_name,
+        user_length: user.len().try_into().unwrap(),
+        domain: psz_domain_name,
+        domain_length: domain.len().try_into().unwrap(),
+        password: psz_packed_credentials_string,
+        password_length: password.len().try_into().unwrap(),
+        flags: 0,
+    };
+
+    *pp_auth_identity = into_raw_ptr(auth_identity) as *mut c_void;
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[cfg_attr(windows, rename_symbol(to = "Rust_SspiFreeAuthIdentity"))]
+#[no_mangle]
+pub unsafe extern "system" fn SspiFreeAuthIdentity(auth_data: *mut c_void) -> SecurityStatus {
+    if auth_data.is_null() {
+        return 0;
+    }
+
+    let auth_data = auth_data.cast::<SecWinntAuthIdentityW>();
+
+    drop_in_place((*auth_data).user as *mut c_ushort);
+    drop_in_place((*auth_data).domain as *mut c_ushort);
+    drop_in_place((*auth_data).password as *mut c_ushort);
+
+    drop_in_place(auth_data);
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr::null;
+    use std::slice::from_raw_parts;
+
+    use libc::c_void;
+    use num_traits::ToPrimitive;
+    use sspi::ErrorKind;
+
+    use super::{SecWinntAuthIdentityW, SspiEncodeStringsAsAuthIdentity};
+    use crate::sec_winnt_auth_identity::SspiFreeAuthIdentity;
+
+    fn get_user_credentials() -> ([u16; 5], [u16; 5], [u16; 7]) {
+        // (user, pass, domain)
+        (
+            [0x75, 0x73, 0x65, 0x72, 0],
+            [0x70, 0x61, 0x73, 0x73, 0],
+            [0x64, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0],
+        )
+    }
+
+    #[test]
+    fn sspi_encode_strings_as_auth_identity() {
+        let (username, password, domain) = get_user_credentials();
+        let mut identity = null::<c_void>() as *mut c_void;
+
+        unsafe {
+            let status =
+                SspiEncodeStringsAsAuthIdentity(username.as_ptr(), domain.as_ptr(), password.as_ptr(), &mut identity);
+
+            assert_eq!(status, 0);
+            assert!(!identity.is_null());
+
+            let identity = identity.cast::<SecWinntAuthIdentityW>();
+
+            assert_eq!(
+                "user",
+                String::from_utf16_lossy(from_raw_parts((*identity).user, (*identity).user_length as usize))
+            );
+            assert_eq!(
+                "pass",
+                String::from_utf16_lossy(from_raw_parts(
+                    (*identity).password,
+                    (*identity).password_length as usize
+                ))
+            );
+            assert_eq!(
+                "domain",
+                String::from_utf16_lossy(from_raw_parts((*identity).domain, (*identity).domain_length as usize))
+            );
+        }
+    }
+
+    #[test]
+    fn sspi_encode_strings_as_auth_identity_on_null() {
+        let mut identity = null::<c_void>() as *mut c_void;
+
+        unsafe {
+            let status = SspiEncodeStringsAsAuthIdentity(null(), null(), null(), &mut identity);
+
+            assert_eq!(status, ErrorKind::InvalidParameter.to_u32().unwrap());
+            assert!(identity.is_null());
+        }
+    }
+
+    #[test]
+    fn sspi_encode_strings_as_auth_identity_on_empty_creds() {
+        let username = [0];
+        let password = [0];
+        let domain = [0];
+        let mut identity = null::<c_void>() as *mut c_void;
+
+        unsafe {
+            let status =
+                SspiEncodeStringsAsAuthIdentity(username.as_ptr(), domain.as_ptr(), password.as_ptr(), &mut identity);
+
+            assert_eq!(status, 0);
+            assert!(!identity.is_null());
+
+            let identity = identity.cast::<SecWinntAuthIdentityW>();
+
+            assert_eq!(
+                "",
+                String::from_utf16_lossy(from_raw_parts((*identity).user, (*identity).user_length as usize))
+            );
+            assert_eq!(
+                "",
+                String::from_utf16_lossy(from_raw_parts(
+                    (*identity).password,
+                    (*identity).password_length as usize
+                ))
+            );
+            assert_eq!(
+                "",
+                String::from_utf16_lossy(from_raw_parts((*identity).domain, (*identity).domain_length as usize))
+            );
+        }
+    }
+
+    #[test]
+    fn sspi_free_auth_identity() {
+        let (username, password, domain) = get_user_credentials();
+        let mut identity = null::<c_void>() as *mut c_void;
+
+        unsafe {
+            SspiEncodeStringsAsAuthIdentity(username.as_ptr(), domain.as_ptr(), password.as_ptr(), &mut identity);
+
+            let status = SspiFreeAuthIdentity(identity);
+
+            assert_eq!(status, 0);
+        }
+    }
+
+    #[test]
+    fn sspi_free_auth_identity_on_null() {
+        unsafe {
+            let status = SspiFreeAuthIdentity(null::<c_void>() as *mut _);
+
+            assert_eq!(status, 0);
+        }
+    }
 }

--- a/c-api/src/sec_winnt_auth_identity.rs
+++ b/c-api/src/sec_winnt_auth_identity.rs
@@ -4,7 +4,6 @@ use libc::{c_char, c_uint, c_ulong, c_ushort, c_void};
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 
-use crate::check_null;
 use crate::sspi_data_types::{SecWChar, SecurityStatus};
 use crate::utils::{c_w_str_to_string, into_raw_ptr};
 

--- a/c-api/src/utils.rs
+++ b/c-api/src/utils.rs
@@ -60,27 +60,3 @@ pub unsafe fn transform_credentials_handle<'a>(
         ))
     }
 }
-
-#[macro_export]
-macro_rules! try_execute {
-    ($x:expr) => {{
-        match $x {
-            Ok(value) => value,
-            Err(err) => {
-                return err.error_type.to_u32().unwrap();
-            }
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! check_null {
-    ($x:expr) => {{
-        use num_traits::ToPrimitive;
-        use sspi::ErrorKind;
-
-        if $x.is_null() {
-            return ErrorKind::InvalidParameter.to_u32().unwrap();
-        }
-    }};
-}

--- a/c-api/src/utils.rs
+++ b/c-api/src/utils.rs
@@ -72,3 +72,15 @@ macro_rules! try_execute {
         }
     }};
 }
+
+#[macro_export]
+macro_rules! check_null {
+    ($x:expr) => {{
+        use num_traits::ToPrimitive;
+        use sspi::ErrorKind;
+
+        if $x.is_null() {
+            return ErrorKind::InvalidParameter.to_u32().unwrap();
+        }
+    }};
+}

--- a/c-api/sspi.def
+++ b/c-api/sspi.def
@@ -42,3 +42,5 @@ EXPORTS
     QueryContextAttributesExW=Rust_QueryContextAttributesExW
     QueryCredentialsAttributesExA=Rust_QueryCredentialsAttributesExA
     QueryCredentialsAttributesExW=Rust_QueryCredentialsAttributesExW
+    SspiEncodeStringsAsAuthIdentity=Rust_SspiEncodeStringsAsAuthIdentity
+    SspiFreeAuthIdentity=Rust_SspiFreeAuthIdentity

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -257,9 +257,7 @@ impl SspiImpl for Ntlm {
             NtlmState::Authenticate => {
                 let input_token = SecurityBuffer::find_buffer(input, SecurityBufferType::Token)?;
 
-                if let Some(identity) = builder.credentials_handle {
-                    self.identity = identity.clone();
-                }
+                self.identity = builder.credentials_handle.and_then(|creds| creds.clone());
 
                 server::read_authenticate(self, input_token.buffer.as_slice())?
             }

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -257,7 +257,7 @@ impl SspiImpl for Ntlm {
             NtlmState::Authenticate => {
                 let input_token = SecurityBuffer::find_buffer(input, SecurityBufferType::Token)?;
 
-                self.identity = builder.credentials_handle.and_then(|creds| creds.clone());
+                self.identity = builder.credentials_handle.cloned().flatten();
 
                 server::read_authenticate(self, input_token.buffer.as_slice())?
             }

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -257,6 +257,10 @@ impl SspiImpl for Ntlm {
             NtlmState::Authenticate => {
                 let input_token = SecurityBuffer::find_buffer(input, SecurityBufferType::Token)?;
 
+                if let Some(identity) = builder.credentials_handle {
+                    self.identity = identity.clone();
+                }
+
                 server::read_authenticate(self, input_token.buffer.as_slice())?
             }
             _ => {
@@ -286,6 +290,10 @@ impl Sspi for Ntlm {
         message: &mut [SecurityBuffer],
         sequence_number: u32,
     ) -> sspi::Result<SecurityStatus> {
+        if self.send_sealing_key.is_none() || self.recv_sealing_key.is_none() {
+            self.complete_auth_token(&mut [])?;
+        }
+
         SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Token)?; // check if exists
         let data = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Data)?;
 
@@ -310,6 +318,10 @@ impl Sspi for Ntlm {
         message: &mut [SecurityBuffer],
         sequence_number: u32,
     ) -> sspi::Result<DecryptionFlags> {
+        if self.send_sealing_key.is_none() || self.recv_sealing_key.is_none() {
+            self.complete_auth_token(&mut [])?;
+        }
+
         SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Token)?; // check if exists
         let data = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Data)?;
 


### PR DESCRIPTION
C# _NegotiateStream_ calls _SSPI_ to make an authentication. If  _NegotiateStream_ uses sspi-rs as the _SSPI_ module, authentication will fail because of some issues and not implemented things in sspi-rs. This PR fixes it.

Improvements:
- Added an implementation of the _Negotiate_ structure for a server (`accept_security_context_impl` function).
- Added an explicit calling to the complete_auth_token if there wasn't one before.  To fully complete _NTLM_ authentication, the user needs to call the `complete_auth_token` function, but _NegotiateStream_ doesn't call it. 
- Added support for _SECPKG_ATTR_NEGOTIATION_INFO_ attribute in _QueryContextAttributesA/W_. _NegotiateStream_ needs it.
- Fixed context attributes. So far _NTLM_ and other implemented security packages didn't care about context attributes but _NegotiateStream_ does. I just make them in C-API as a user wants to: 
`*pf_context_attr = f_context_req;`