### PR TITLE
SECBUFFER_CHANNEL_BINDINGS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
-picky-krb = "0.3.0"
+picky-krb = { path = "../picky-rs/picky-krb" }
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
-picky-krb = { path = "../picky-rs/picky-krb" }
+picky-krb = { git = "https://github.com/Devolutions/picky-rs.git", rev = "8a05c988832722af2628d2270c46cb6b47c1c41d" }
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
-picky-krb = { git = "https://github.com/Devolutions/picky-rs.git", rev = "8a05c988832722af2628d2270c46cb6b47c1c41d" }
+picky-krb = "0.3.1"
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -8,6 +8,8 @@ use md5::Md5;
 pub use rc4::Rc4;
 use sha2::Sha256;
 
+use crate::sspi::ChannelBindings;
+
 pub const HASH_SIZE: usize = 16;
 
 const SHA256_SIZE: usize = 32;
@@ -25,6 +27,24 @@ pub fn compute_md5(data: &[u8]) -> [u8; HASH_SIZE] {
     let mut context = Md5::new();
     let mut result = [0x00; HASH_SIZE];
     context.update(data);
+    result.clone_from_slice(&context.finalize());
+
+    result
+}
+
+pub fn compute_md5_channel_bindings_hash(channel_bindings: &ChannelBindings) -> [u8; HASH_SIZE] {
+    let mut context = Md5::new();
+    let mut result = [0x00; HASH_SIZE];
+
+    context.update(&channel_bindings.initiator_addr_type.to_be_bytes());
+    context.update(&channel_bindings.initiator.len().to_be_bytes());
+
+    context.update(&channel_bindings.acceptor_addr_type.to_be_bytes());
+    context.update(&channel_bindings.acceptor.len().to_be_bytes());
+
+    context.update(&channel_bindings.application_data.len().to_be_bytes());
+    context.update(&channel_bindings.application_data);
+
     result.clone_from_slice(&context.finalize());
 
     result

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -8,7 +8,7 @@ use md5::Md5;
 pub use rc4::Rc4;
 use sha2::Sha256;
 
-use crate::sspi::ChannelBindings;
+use crate::sspi::channel_bindings::ChannelBindings;
 
 pub const HASH_SIZE: usize = 16;
 

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -1,5 +1,6 @@
 /// The builders are required to compose and execute some of the `Sspi` methods.
 pub mod builders;
+pub mod channel_bindings;
 pub mod internal;
 pub mod kerberos;
 pub mod negotiate;
@@ -8,10 +9,8 @@ pub mod winapi;
 
 pub mod ntlm;
 
-use std::mem::size_of;
 use std::{error, fmt, io, result, str, string};
 
-use ::winapi::shared::sspi::{PSEC_CHANNEL_BINDINGS, SEC_CHANNEL_BINDINGS};
 use bitflags::bitflags;
 use num_derive::{FromPrimitive, ToPrimitive};
 use picky_asn1::restricted_string::CharSetError;
@@ -1572,88 +1571,5 @@ impl From<Error> for io::Error {
             io::ErrorKind::Other,
             format!("{:?}: {}", err.error_type, err.description),
         )
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ChannelBindings {
-    pub initiator_addr_type: u32,
-    pub initiator: Vec<u8>,
-    pub acceptor_addr_type: u32,
-    pub acceptor: Vec<u8>,
-    pub application_data: Vec<u8>,
-}
-
-impl ChannelBindings {
-    pub fn from_bytes<T: AsRef<[u8]>>(data: T) -> Result<Self> {
-        let data = data.as_ref();
-
-        if data.len() < size_of::<SEC_CHANNEL_BINDINGS>() {
-            return Err(Error::new(
-                ErrorKind::InvalidParameter,
-                "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-            ));
-        }
-
-        unsafe {
-            let sec_channel_bindings: PSEC_CHANNEL_BINDINGS = data.as_ptr() as *mut _;
-
-            let initiator_addr_type = (*sec_channel_bindings).dwInitiatorAddrType;
-
-            let len = (*sec_channel_bindings).cbInitiatorLength as usize;
-            let offset = (*sec_channel_bindings).dwInitiatorOffset as usize;
-            if offset + len > data.len() {
-                return Err(Error::new(
-                    ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let initiator = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            let acceptor_addr_type = (*sec_channel_bindings).dwAcceptorAddrType;
-
-            let len = (*sec_channel_bindings).cbAcceptorLength as usize;
-            let offset = (*sec_channel_bindings).dwAcceptorOffset as usize;
-            if offset + len > data.len() {
-                return Err(Error::new(
-                    ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let acceptor = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            let len = (*sec_channel_bindings).cbApplicationDataLength as usize;
-            let offset = (*sec_channel_bindings).dwApplicationDataOffset as usize;
-            if offset + len > data.len() {
-                return Err(Error::new(
-                    ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let application_data = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            Ok(Self {
-                initiator_addr_type,
-                initiator,
-                acceptor_addr_type,
-                acceptor,
-                application_data,
-            })
-        }
     }
 }

--- a/src/sspi/channel_bindings.rs
+++ b/src/sspi/channel_bindings.rs
@@ -4,7 +4,7 @@ use crate::{Error, ErrorKind, Result};
 const SEC_CHANNEL_BINDINGS_SIZE: usize = 32;
 
 /// [SEC_CHANNEL_BINDINGS](https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_channel_bindings)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChannelBindings {
     pub initiator_addr_type: u32,
     pub initiator: Vec<u8>,

--- a/src/sspi/channel_bindings.rs
+++ b/src/sspi/channel_bindings.rs
@@ -1,0 +1,173 @@
+use crate::{Error, ErrorKind, Result};
+
+// size of SEC_CHANNEL_BINDINGS structure
+const SEC_CHANNEL_BINDINGS_SIZE: usize = 32;
+
+/// [SEC_CHANNEL_BINDINGS](https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_channel_bindings)
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelBindings {
+    pub initiator_addr_type: u32,
+    pub initiator: Vec<u8>,
+    pub acceptor_addr_type: u32,
+    pub acceptor: Vec<u8>,
+    pub application_data: Vec<u8>,
+}
+
+impl ChannelBindings {
+    pub fn from_bytes<T: AsRef<[u8]>>(data: T) -> Result<Self> {
+        let data = data.as_ref();
+
+        if data.len() < SEC_CHANNEL_BINDINGS_SIZE {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Invalid SEC_CHANNEL_BINDINGS buffer: buffer is too short: {}. Minimum len: {}",
+                    data.len(),
+                    SEC_CHANNEL_BINDINGS_SIZE,
+                ),
+            ));
+        }
+
+        let initiator_addr_type = u32::from_le_bytes(data[0..4].try_into().unwrap());
+
+        let initiator_len = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
+        let initiator_offset = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        if initiator_offset + initiator_len > data.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Invalid SEC_CHANNEL_BINDINGS buffer: initiator offset + len ({}) goes outside the buffer ({})",
+                    initiator_offset + initiator_len,
+                    data.len()
+                ),
+            ));
+        }
+
+        let initiator = if initiator_len > 0 {
+            data[initiator_offset..(initiator_offset + initiator_len)].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        let acceptor_addr_type = u32::from_le_bytes(data[12..16].try_into().unwrap());
+
+        let acceptor_len = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
+        let acceptor_offset = u32::from_le_bytes(data[20..24].try_into().unwrap()) as usize;
+        if acceptor_offset + acceptor_len > data.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Invalid SEC_CHANNEL_BINDINGS buffer: acceptor offset + len ({}) goes outside the buffer ({})",
+                    acceptor_offset + acceptor_len,
+                    data.len()
+                ),
+            ));
+        }
+
+        let acceptor = if acceptor_len > 0 {
+            data[acceptor_offset..(acceptor_offset + acceptor_len)].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        let application_len = u32::from_le_bytes(data[24..28].try_into().unwrap()) as usize;
+        let application_offset = u32::from_le_bytes(data[28..32].try_into().unwrap()) as usize;
+        if application_offset + application_len > data.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Invalid SEC_CHANNEL_BINDINGS buffer: application offset + len ({}) goes outside the buffer ({})",
+                    application_offset + application_len,
+                    data.len()
+                ),
+            ));
+        }
+
+        let application_data = if application_len > 0 {
+            data[application_offset..(application_offset + application_len)].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            initiator_addr_type,
+            initiator,
+            acceptor_addr_type,
+            acceptor,
+            application_data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChannelBindings;
+
+    #[test]
+    fn from_bytes() {
+        let expected = ChannelBindings {
+            initiator_addr_type: 0,
+            initiator: Vec::new(),
+            acceptor_addr_type: 0,
+            acceptor: Vec::new(),
+            application_data: vec![1, 2, 3, 4],
+        };
+
+        let channel_bindings_token = [1, 2, 3, 4];
+        let application_offset = 32_u32;
+        let application_len = channel_bindings_token.len();
+
+        let mut buffer = [0; 36];
+
+        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
+        buffer[32..].copy_from_slice(&channel_bindings_token);
+
+        let channel_bindings = ChannelBindings::from_bytes(&buffer).unwrap();
+
+        assert_eq!(channel_bindings, expected);
+    }
+
+    #[test]
+    fn too_small_buffer() {
+        assert!(ChannelBindings::from_bytes(&[1, 2, 3, 4, 5, 6, 7, 8]).is_err());
+
+        assert!(ChannelBindings::from_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn invalid_len() {
+        let channel_bindings_token = [1, 2, 3, 4];
+        let application_offset = 32_u32;
+        // invalid len
+        let application_len = channel_bindings_token.len() + 2;
+
+        let mut buffer = [0; 36];
+
+        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
+        buffer[32..].copy_from_slice(&channel_bindings_token);
+
+        let channel_bindings = ChannelBindings::from_bytes(&buffer);
+
+        assert!(channel_bindings.is_err());
+    }
+
+    #[test]
+    fn invalid_offset() {
+        let channel_bindings_token = [1, 2, 3, 4];
+        // invalid offset
+        let application_offset = 32_u32 + 3;
+        let application_len = channel_bindings_token.len();
+
+        let mut buffer = [0; 36];
+
+        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
+        buffer[32..].copy_from_slice(&channel_bindings_token);
+
+        let channel_bindings = ChannelBindings::from_bytes(&buffer);
+
+        assert!(channel_bindings.is_err());
+    }
+}

--- a/src/sspi/kerberos/client/extractors.rs
+++ b/src/sspi/kerberos/client/extractors.rs
@@ -88,15 +88,15 @@ pub fn extract_encryption_params_from_as_rep(as_rep: &AsRep) -> Result<(u8, Stri
         .unwrap_or_default()
     {
         Some(data) => {
-            let pa_etype_into2: EtypeInfo2 = picky_asn1_der::from_bytes(&data)?;
-            let pa_etype_into2 = pa_etype_into2.0.get(0).ok_or(Error {
+            let pa_etype_info2: EtypeInfo2 = picky_asn1_der::from_bytes(&data)?;
+            let pa_etype_info2 = pa_etype_info2.0.get(0).ok_or(Error {
                 error_type: ErrorKind::InternalError,
                 description: "Missing EtypeInto2Entry in EtypeInfo2".into(),
             })?;
 
             Ok((
-                pa_etype_into2.etype.0 .0.get(0).copied().unwrap(),
-                pa_etype_into2
+                pa_etype_info2.etype.0 .0.first().copied().unwrap(),
+                pa_etype_info2
                     .salt
                     .0
                     .as_ref()
@@ -127,7 +127,7 @@ pub fn extract_status_code_from_krb_priv_response(
             .etype
             .0
              .0
-            .get(0)
+            .first()
             .unwrap_or(&(DEFAULT_ENCRYPTION_TYPE as u8)) as i32,
     );
 

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -3,15 +3,14 @@ mod messages;
 mod test;
 
 use std::io;
-use std::mem::size_of;
 
 use bitflags::bitflags;
 use byteorder::{LittleEndian, WriteBytesExt};
 use lazy_static::lazy_static;
 use messages::{client, server};
 use serde_derive::{Deserialize, Serialize};
-use winapi::shared::sspi::{PSEC_CHANNEL_BINDINGS, SEC_CHANNEL_BINDINGS};
 
+use super::ChannelBindings;
 use crate::crypto::{compute_hmac_md5, Rc4, HASH_SIZE};
 use crate::sspi::internal::SspiImpl;
 use crate::sspi::{
@@ -57,89 +56,6 @@ enum NtlmState {
     Authenticate,
     Completion,
     Final,
-}
-
-#[derive(Debug, Clone)]
-pub struct ChannelBindings {
-    pub initiator_addr_type: u32,
-    pub initiator: Vec<u8>,
-    pub acceptor_addr_type: u32,
-    pub acceptor: Vec<u8>,
-    pub application_data: Vec<u8>,
-}
-
-impl ChannelBindings {
-    pub fn from_bytes<T: AsRef<[u8]>>(data: T) -> sspi::Result<Self> {
-        let data = data.as_ref();
-
-        if data.len() < size_of::<SEC_CHANNEL_BINDINGS>() {
-            return Err(sspi::Error::new(
-                sspi::ErrorKind::InvalidParameter,
-                "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-            ));
-        }
-
-        unsafe {
-            let sec_channel_bindings: PSEC_CHANNEL_BINDINGS = data.as_ptr() as *mut _;
-
-            let initiator_addr_type = (*sec_channel_bindings).dwInitiatorAddrType;
-
-            let len = (*sec_channel_bindings).cbInitiatorLength as usize;
-            let offset = (*sec_channel_bindings).dwInitiatorOffset as usize;
-            if offset + len > data.len() {
-                return Err(sspi::Error::new(
-                    sspi::ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let initiator = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            let acceptor_addr_type = (*sec_channel_bindings).dwAcceptorAddrType;
-
-            let len = (*sec_channel_bindings).cbAcceptorLength as usize;
-            let offset = (*sec_channel_bindings).dwAcceptorOffset as usize;
-            if offset + len > data.len() {
-                return Err(sspi::Error::new(
-                    sspi::ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let acceptor = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            let len = (*sec_channel_bindings).cbApplicationDataLength as usize;
-            let offset = (*sec_channel_bindings).dwApplicationDataOffset as usize;
-            if offset + len > data.len() {
-                return Err(sspi::Error::new(
-                    sspi::ErrorKind::InvalidParameter,
-                    "Invalid SEC_CHANNEL_BINDINGS buffer".into(),
-                ));
-            }
-
-            let application_data = if len > 0 {
-                data[offset..(offset + len)].to_vec()
-            } else {
-                Vec::new()
-            };
-
-            Ok(Self {
-                initiator_addr_type,
-                initiator,
-                acceptor_addr_type,
-                acceptor,
-                application_data,
-            })
-        }
-    }
 }
 
 /// Specifies the NT LAN Manager (NTLM) Authentication Protocol, used for authentication between clients and servers.

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use messages::{client, server};
 use serde_derive::{Deserialize, Serialize};
 
-use super::ChannelBindings;
+use super::channel_bindings::ChannelBindings;
 use crate::crypto::{compute_hmac_md5, Rc4, HASH_SIZE};
 use crate::sspi::internal::SspiImpl;
 use crate::sspi::{

--- a/src/sspi/ntlm/messages/client/authenticate.rs
+++ b/src/sspi/ntlm/messages/client/authenticate.rs
@@ -100,7 +100,7 @@ pub fn write_authenticate(
     // NTLMv2
     let target_info = get_authenticate_target_info(
         challenge_message.target_info.as_ref(),
-        &context.channel_bindings,
+        context.channel_bindings.as_ref(),
         context.send_single_host_data,
     )?;
 

--- a/src/sspi/ntlm/messages/client/authenticate.rs
+++ b/src/sspi/ntlm/messages/client/authenticate.rs
@@ -98,8 +98,11 @@ pub fn write_authenticate(
 
     // calculate needed fields
     // NTLMv2
-    let target_info =
-        get_authenticate_target_info(challenge_message.target_info.as_ref(), context.send_single_host_data)?;
+    let target_info = get_authenticate_target_info(
+        challenge_message.target_info.as_ref(),
+        &context.channel_bindings,
+        context.send_single_host_data,
+    )?;
 
     let client_challenge = generate_challenge()?;
     let ntlm_v2_hash = compute_ntlm_v2_hash(credentials)?;

--- a/src/sspi/ntlm/messages/computations.rs
+++ b/src/sspi/ntlm/messages/computations.rs
@@ -6,10 +6,12 @@ use std::io::{self, Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{DateTime, TimeZone, Utc};
 use lazy_static::lazy_static;
+use md5::{Digest, Md5};
 use rand::rngs::OsRng;
 use rand::Rng;
 
 use crate::crypto::{compute_hmac_md5, compute_md4, compute_md5, HASH_SIZE};
+use crate::ntlm::ChannelBindings;
 use crate::sspi::ntlm::messages::av_pair::*;
 use crate::sspi::ntlm::{
     AuthIdentityBuffers, CHALLENGE_SIZE, LM_CHALLENGE_RESPONSE_BUFFER_SIZE, MESSAGE_INTEGRITY_CHECK_SIZE,
@@ -78,7 +80,29 @@ pub fn get_challenge_target_info(timestamp: u64) -> sspi::Result<Vec<u8>> {
     Ok(AvPair::list_to_buffer(&av_pairs)?)
 }
 
-pub fn get_authenticate_target_info(target_info: &[u8], send_single_host_data: bool) -> sspi::Result<Vec<u8>> {
+pub fn calculate_channel_bindings_hash(channel_bindings: &ChannelBindings) -> [u8; HASH_SIZE] {
+    let mut context = Md5::new();
+    let mut result = [0x00; HASH_SIZE];
+
+    context.update(&channel_bindings.initiator_addr_type.to_be_bytes());
+    context.update(&channel_bindings.initiator.len().to_be_bytes());
+
+    context.update(&channel_bindings.acceptor_addr_type.to_be_bytes());
+    context.update(&channel_bindings.acceptor.len().to_be_bytes());
+
+    context.update(&channel_bindings.application_data.len().to_be_bytes());
+    context.update(&channel_bindings.application_data);
+
+    result.clone_from_slice(&context.finalize());
+
+    result
+}
+
+pub fn get_authenticate_target_info(
+    target_info: &[u8],
+    channel_bindings: &Option<ChannelBindings>,
+    send_single_host_data: bool,
+) -> sspi::Result<Vec<u8>> {
     let mut av_pairs = AvPair::buffer_to_av_pairs(target_info)?;
 
     av_pairs.retain(|av_pair| av_pair.as_u16() != AV_PAIR_EOL);
@@ -95,6 +119,12 @@ pub fn get_authenticate_target_info(target_info: &[u8], send_single_host_data: b
     // will not check suppress_extended_protection and
     // will not add channel bindings and service principal name
     // because it is not used anywhere
+
+    if let Some(channel_bindings) = channel_bindings {
+        av_pairs.push(AvPair::ChannelBindings(calculate_channel_bindings_hash(
+            channel_bindings,
+        )));
+    }
 
     let mut authenticate_target_info = AvPair::list_to_buffer(&av_pairs)?;
 
@@ -246,9 +276,7 @@ pub fn read_ntlm_v2_response(mut challenge_response: &[u8]) -> io::Result<(Vec<u
     Ok((av_pairs, client_challenge))
 }
 
-pub fn get_av_flags_from_response(target_info: &[u8]) -> io::Result<MsvAvFlags> {
-    let av_pairs = AvPair::buffer_to_av_pairs(target_info)?;
-
+pub fn get_av_flags_from_response(av_pairs: &[AvPair]) -> io::Result<MsvAvFlags> {
     if let Some(AvPair::Flags(value)) = av_pairs.iter().find(|&av_pair| av_pair.as_u16() == AV_PAIR_FLAGS) {
         Ok(MsvAvFlags::from_bits(*value).unwrap_or_else(MsvAvFlags::empty))
     } else {

--- a/src/sspi/ntlm/messages/computations.rs
+++ b/src/sspi/ntlm/messages/computations.rs
@@ -10,13 +10,12 @@ use rand::rngs::OsRng;
 use rand::Rng;
 
 use crate::crypto::{compute_hmac_md5, compute_md4, compute_md5, compute_md5_channel_bindings_hash, HASH_SIZE};
-use crate::ntlm::ChannelBindings;
+use crate::sspi::channel_bindings::ChannelBindings;
 use crate::sspi::ntlm::messages::av_pair::*;
 use crate::sspi::ntlm::{
     AuthIdentityBuffers, CHALLENGE_SIZE, LM_CHALLENGE_RESPONSE_BUFFER_SIZE, MESSAGE_INTEGRITY_CHECK_SIZE,
 };
-use crate::sspi::{self};
-use crate::utils;
+use crate::{sspi, utils};
 
 pub const SSPI_CREDENTIALS_HASH_LENGTH_OFFSET: usize = 512;
 pub const SINGLE_HOST_DATA_SIZE: usize = 48;
@@ -81,7 +80,7 @@ pub fn get_challenge_target_info(timestamp: u64) -> sspi::Result<Vec<u8>> {
 
 pub fn get_authenticate_target_info(
     target_info: &[u8],
-    channel_bindings: &Option<ChannelBindings>,
+    channel_bindings: Option<&ChannelBindings>,
     send_single_host_data: bool,
 ) -> sspi::Result<Vec<u8>> {
     let mut av_pairs = AvPair::buffer_to_av_pairs(target_info)?;

--- a/src/sspi/ntlm/messages/computations/test.rs
+++ b/src/sspi/ntlm/messages/computations/test.rs
@@ -102,7 +102,7 @@ fn get_authenticate_target_info_correct_returns_with_use_mic() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],
@@ -143,7 +143,7 @@ fn get_authenticate_target_info_correct_returns_with_send_single_host_data() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],
@@ -185,7 +185,7 @@ fn get_authenticate_target_info_returns_without_principal_name() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],
@@ -424,7 +424,10 @@ fn get_av_flags_from_response_returns_empty_flags_if_flags_are_absent() {
 
     let expected_flags = MsvAvFlags::empty();
 
-    let flags = get_av_flags_from_response(AvPair::list_to_buffer(input_flags.as_ref()).unwrap().as_ref()).unwrap();
+    let buffer = AvPair::list_to_buffer(input_flags.as_ref()).unwrap();
+    let av_pairs = AvPair::buffer_to_av_pairs(&buffer).unwrap();
+
+    let flags = get_av_flags_from_response(&av_pairs).unwrap();
 
     assert_eq!(expected_flags, flags);
 }

--- a/src/sspi/ntlm/messages/computations/test.rs
+++ b/src/sspi/ntlm/messages/computations/test.rs
@@ -102,7 +102,7 @@ fn get_authenticate_target_info_correct_returns_with_use_mic() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],
@@ -143,7 +143,7 @@ fn get_authenticate_target_info_correct_returns_with_send_single_host_data() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],
@@ -185,7 +185,7 @@ fn get_authenticate_target_info_returns_without_principal_name() {
     let target_info = get_challenge_target_info(TIMESTAMP).unwrap();
 
     let mut authenticate_target_info =
-        get_authenticate_target_info(target_info.as_ref(), &None, send_single_host_data).unwrap();
+        get_authenticate_target_info(target_info.as_ref(), None, send_single_host_data).unwrap();
 
     assert_eq!(
         authenticate_target_info[authenticate_target_info.len() - AUTHENTICATE_TARGET_INFO_PADDING_SIZE..],

--- a/src/sspi/ntlm/messages/server/authenticate.rs
+++ b/src/sspi/ntlm/messages/server/authenticate.rs
@@ -2,6 +2,8 @@ use std::io::{self, Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
+use crate::ntlm::messages::av_pair::{AvPair, AV_PAIR_CHANNEL_BINDINGS};
+use crate::ntlm::ChannelBindings;
 use crate::sspi::ntlm::messages::av_pair::MsvAvFlags;
 use crate::sspi::ntlm::messages::computations::*;
 use crate::sspi::ntlm::messages::{read_ntlm_header, try_read_version, MessageFields, MessageTypes};
@@ -36,8 +38,13 @@ pub fn read_authenticate(mut context: &mut Ntlm, mut stream: impl io::Read) -> s
     let mic = read_payload(flags, &mut message_fields, &mut buffer)?;
     let message = buffer.into_inner();
 
-    let (authenticate_message, updated_identity) =
-        process_message_fields(&context.identity, message_fields, mic, message)?;
+    let (authenticate_message, updated_identity) = process_message_fields(
+        &context.identity,
+        message_fields,
+        mic,
+        message,
+        &context.channel_bindings,
+    )?;
     context.identity = Some(updated_identity);
     context.authenticate_message = Some(authenticate_message);
 
@@ -140,6 +147,7 @@ fn process_message_fields(
     message_fields: AuthenticateMessageFields,
     mic: Option<Mic>,
     authenticate_message: Vec<u8>,
+    channel_bindings: &Option<ChannelBindings>,
 ) -> sspi::Result<(AuthenticateMessage, AuthIdentityBuffers)> {
     if message_fields.nt_challenge_response.buffer.is_empty() {
         return Err(sspi::Error::new(
@@ -147,9 +155,13 @@ fn process_message_fields(
             String::from("NtChallengeResponse cannot be empty"),
         ));
     }
+
     let (target_info, client_challenge) = read_ntlm_v2_response(message_fields.nt_challenge_response.buffer.as_ref())?;
+
+    let av_pairs = AvPair::buffer_to_av_pairs(target_info.as_ref())?;
+
     let mic = if mic.is_some() {
-        let challenge_response_av_flags = get_av_flags_from_response(target_info.as_ref())?;
+        let challenge_response_av_flags = get_av_flags_from_response(&av_pairs)?;
         if challenge_response_av_flags.contains(MsvAvFlags::MESSAGE_INTEGRITY_CHECK) {
             mic
         } else {
@@ -158,6 +170,20 @@ fn process_message_fields(
     } else {
         None
     };
+
+    if let Some(AvPair::ChannelBindings(hash)) = av_pairs
+        .iter()
+        .find(|av_pair| av_pair.as_u16() == AV_PAIR_CHANNEL_BINDINGS)
+    {
+        if let Some(channel_bindings) = channel_bindings.as_ref() {
+            if calculate_channel_bindings_hash(channel_bindings) != *hash {
+                return Err(sspi::Error::new(
+                    sspi::ErrorKind::BadBindings,
+                    "Channel bindings hash mismatch".into(),
+                ));
+            }
+        }
+    }
 
     // will not set workstation because it is not used anywhere
 

--- a/src/sspi/ntlm/messages/server/authenticate.rs
+++ b/src/sspi/ntlm/messages/server/authenticate.rs
@@ -2,6 +2,7 @@ use std::io::{self, Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
+use crate::crypto::compute_md5_channel_bindings_hash;
 use crate::ntlm::messages::av_pair::{AvPair, AV_PAIR_CHANNEL_BINDINGS};
 use crate::ntlm::ChannelBindings;
 use crate::sspi::ntlm::messages::av_pair::MsvAvFlags;
@@ -176,7 +177,7 @@ fn process_message_fields(
         .find(|av_pair| av_pair.as_u16() == AV_PAIR_CHANNEL_BINDINGS)
     {
         if let Some(channel_bindings) = channel_bindings.as_ref() {
-            if calculate_channel_bindings_hash(channel_bindings) != *hash {
+            if compute_md5_channel_bindings_hash(channel_bindings) != *hash {
                 return Err(sspi::Error::new(
                     sspi::ErrorKind::BadBindings,
                     "Channel bindings hash mismatch".into(),


### PR DESCRIPTION
I added support of the security channel bindings. Basically, the channel bindings are an md5 checksum of the token that is used to prevent MITM attacks.

1. In the case of the NTLM, this checksum is transferred as special AvPair (AvPair::ChannelBindings).
2. In the case of the Kerberos, it is transferred as a part of the checksum in the authenticator during the AP exchange. 

The token for md5 checksum calculation passed into our library as the SecurityBuffer with the type SECBUFFER_CHANNEL_BINDINGS.

References:

- https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/extended-protection-for-authentication-overview
- https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_channel_bindings
- https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-NLMP/%5bMS-NLMP%5d.pdf
- https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-KILE/[MS-KILE].pdf
- https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1