### PR TITLE
fix: structs not implementing Send trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sspi"
-version = "0.3.6"
+version = "0.4.0"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/devolutions/sspi-rs"
 repository = "https://github.com/devolutions/sspi-rs"

--- a/src/sspi/kerberos/config.rs
+++ b/src/sspi/kerberos/config.rs
@@ -15,11 +15,19 @@ pub enum KdcType {
     KdcProxy,
 }
 
-#[derive(Debug)]
 pub struct KerberosConfig {
     pub url: Url,
     pub kdc_type: KdcType,
     pub network_client: Box<dyn NetworkClient>,
+}
+
+impl Debug for KerberosConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KerberosConfig")
+            .field("url", &self.url)
+            .field("kdc_type", &self.kdc_type)
+            .finish_non_exhaustive()
+    }
 }
 
 pub fn parse_kdc_url(mut kdc: String) -> (Url, KdcType) {

--- a/src/sspi/kerberos/network_client.rs
+++ b/src/sspi/kerberos/network_client.rs
@@ -1,10 +1,8 @@
-use std::fmt::Debug;
-
 use url::Url;
 
 use crate::sspi::Result;
 
-pub trait NetworkClient: Debug {
+pub trait NetworkClient: Send {
     fn send(&self, url: &Url, data: &[u8]) -> Result<Vec<u8>>;
     fn send_http(&self, url: &Url, data: &[u8], domain: Option<String>) -> Result<Vec<u8>>;
     fn clone(&self) -> Box<dyn NetworkClient>;


### PR DESCRIPTION
cc @RRRadicalEdward 

Introduction of a field with the type `Box<dyn NetworkClient>` caused all wrapping structs to be non-`Send`ables. This is breaking and probably not desirable (this notably breaks Devolutions Gateway code).

Other breaking changes were introduced in version starting 0.3.3 and up to 0.3.6, the most obvious one being the `CredSspClient::new` function which now has 5 parameters instead of 3.

For this reason, I yanked all these versions and this PR bumps the version to 0.4.0.