### PR TITLE
Replace kerberos_crypto with picky-krb Kerberos crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,10 @@ serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
-picky-krb = "0.3.1"
+picky-krb = { git = "https://github.com/Devolutions/picky-rs.git", rev = "f7dc334" }
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"
-kerberos_crypto = "0.3.6"
-kerberos_constants = "0.0.9"
 oid = "0.2.1"
 sys-info = "0.9"
 trust-dns-resolver = { version = "0.21.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_derive = "1.0"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
-picky-krb = { git = "https://github.com/Devolutions/picky-rs.git", rev = "f7dc334" }
+picky-krb = "0.4.0"
 picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"

--- a/ffi/src/sec_pkg_info.rs
+++ b/ffi/src/sec_pkg_info.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use libc::{c_uint, c_ulong, c_ushort, c_char};
+use libc::{c_char, c_uint, c_ulong, c_ushort};
 use sspi::{enumerate_security_packages, PackageInfo, KERBEROS_VERSION};
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;

--- a/src/sspi/kerberos/client/mod.rs
+++ b/src/sspi/kerberos/client/mod.rs
@@ -1,6 +1,2 @@
 pub mod extractors;
 pub mod generators;
-
-// supported encryption types
-pub const AES128_CTS_HMAC_SHA1_96: i32 = kerberos_constants::etypes::AES128_CTS_HMAC_SHA1_96;
-pub const AES256_CTS_HMAC_SHA1_96: i32 = kerberos_constants::etypes::AES256_CTS_HMAC_SHA1_96;

--- a/src/sspi/kerberos/encryption_params.rs
+++ b/src/sspi/kerberos/encryption_params.rs
@@ -1,11 +1,10 @@
-use kerberos_crypto::AesSizes;
 use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
-
-use crate::sspi::kerberos::{AES128_CTS_HMAC_SHA1_96, AES256_CTS_HMAC_SHA1_96};
+use picky_krb::crypto::aes::AesSize;
+use picky_krb::crypto::CipherSuite;
 
 #[derive(Debug, Clone)]
 pub struct EncryptionParams {
-    pub encryption_type: Option<i32>,
+    pub encryption_type: Option<CipherSuite>,
     pub session_key: Option<Vec<u8>>,
     pub sub_session_key: Option<Vec<u8>>,
     pub sspi_encrypt_key_usage: i32,
@@ -33,11 +32,11 @@ impl EncryptionParams {
         }
     }
 
-    pub fn aes_sizes(&self) -> Option<AesSizes> {
-        self.encryption_type.map(|e_type| match e_type {
-            AES256_CTS_HMAC_SHA1_96 => AesSizes::Aes256,
-            AES128_CTS_HMAC_SHA1_96 => AesSizes::Aes128,
-            _ => AesSizes::Aes256,
+    pub fn aes_size(&self) -> Option<AesSize> {
+        self.encryption_type.as_ref().and_then(|e_type| match e_type {
+            CipherSuite::Aes256CtsHmacSha196 => Some(AesSize::Aes256),
+            CipherSuite::Aes128CtsHmacSha196 => Some(AesSize::Aes128),
+            CipherSuite::Des3CbcSha1Kd => None,
         })
     }
 }

--- a/src/sspi/kerberos/utils.rs
+++ b/src/sspi/kerberos/utils.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto;
 use std::io::Write;
 
-use kerberos_crypto::{checksum_sha_aes, AesSizes};
 use picky_krb::constants::key_usages::INITIATOR_SIGN;
+use picky_krb::crypto::aes::{checksum_sha_aes, AesSize};
 use picky_krb::gss_api::MicToken;
 use serde::Serialize;
 
@@ -51,12 +51,7 @@ pub fn validate_mic_token(raw_token: &[u8], key_usage: i32, params: &EncryptionP
         });
     };
 
-    let checksum = checksum_sha_aes(
-        key,
-        key_usage,
-        &payload,
-        &params.aes_sizes().unwrap_or(AesSizes::Aes256),
-    );
+    let checksum = checksum_sha_aes(key, key_usage, &payload, &params.aes_size().unwrap_or(AesSize::Aes256))?;
 
     if checksum != token.checksum {
         return Err(Error {
@@ -77,8 +72,8 @@ pub fn generate_initiator_raw(mut payload: Vec<u8>, seq_number: u64, session_key
         session_key,
         INITIATOR_SIGN,
         &payload,
-        &AesSizes::Aes256,
-    ));
+        &AesSize::Aes256,
+    )?);
 
     let mut mic_token_raw = Vec::new();
     mic_token.encode(&mut mic_token_raw)?;


### PR DESCRIPTION
Hi! This PR replaces the `kerberos-crypto` and `kerberos-constants` crates the `picky-krb` Kerberos crypto implementation.