### PR TITLE
Fix version number parsing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -164,7 +164,7 @@ jobs:
 
           $CsprojXml = [Xml] (Get-Content .\ffi\dotnet\Devolutions.Sspi\Devolutions.Sspi.csproj)
           $ProjectVersion = $CsprojXml.Project.PropertyGroup.Version | Select-Object -First 1
-          $PackageVersion = $ProjectVersion -Replace "^(\d+)\.(\d+)\.(\d+)(\.0)$", "`$1.`$2.`$3"
+          $PackageVersion = $ProjectVersion -Replace "^(\d+)\.(\d+)\.(\d+).(\d+)$", "`$1.`$2.`$3"
 
           $CargoToml = Get-Content .\ffi\Cargo.toml
           $CargoToml = $CargoToml | ForEach-Object {


### PR DESCRIPTION
I'd like to modify this to use the current date instead, but then I'm unsure how to deal with multiple releases per day.