### PR TITLE
replace sys_info::hostname by whoami::hostname

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,6 @@ picky-asn1 = { version = "0.5.0", features = ["chrono_conversion"] }
 picky-asn1-der = "0.3.1"
 picky-asn1-x509 = "0.7.0"
 oid = "0.2.1"
-sys-info = "0.9"
+whoami = "0.5"
 trust-dns-resolver = { version = "0.21.2", optional = true }
 portpicker = { version = "0.1.1", optional = true }
-
-[dev-dependencies]
-whoami = "0.5"

--- a/src/sspi/kerberos/client/generators.rs
+++ b/src/sspi/kerberos/client/generators.rs
@@ -155,12 +155,10 @@ pub fn generate_as_req(options: &GenerateAsReqOptions) -> Result<AsReq> {
         })?)),
     });
 
-    let address = sys_info::hostname().ok().map(|hostname| {
-        ExplicitContextTag9::from(Asn1SequenceOf::from(vec![HostAddress {
-            addr_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NET_BIOS_ADDR_TYPE])),
-            address: ExplicitContextTag1::from(OctetStringAsn1::from(hostname.as_bytes().to_vec())),
-        }]))
-    });
+    let address = Some(ExplicitContextTag9::from(Asn1SequenceOf::from(vec![HostAddress {
+        addr_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NET_BIOS_ADDR_TYPE])),
+        address: ExplicitContextTag1::from(OctetStringAsn1::from(whoami::hostname().as_bytes().to_vec())),
+    }])));
 
     let mut service_names = Vec::with_capacity(snames.len());
     for sname in *snames {
@@ -524,7 +522,7 @@ pub fn generate_krb_priv_request(
         s_address: ExplicitContextTag4::from(HostAddress {
             addr_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NET_BIOS_ADDR_TYPE])),
             address: ExplicitContextTag1::from(OctetStringAsn1::from(
-                sys_info::hostname().unwrap().as_bytes().to_vec(),
+                whoami::hostname().as_bytes().to_vec(),
             )),
         }),
         r_address: Optional::from(None),


### PR DESCRIPTION
sys_info::hostname() calls hostname.exe on Windows, while whoami::hostname() calls the Win32 APIs. We had some calls to whoami::hostname() in some places already, and sys_info::hostname() was the only reason to import the sys_info crate.