### PR TITLE
sspi-rs: update native library packaging in nuget

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -187,10 +187,45 @@ jobs:
           name: sspi-${{matrix.os}}-${{matrix.arch}}
           path: dependencies/runtimes/${{matrix.os}}-${{matrix.arch}}
 
+  build-universal:
+    name: Universal Build
+    runs-on: ubuntu-20.04
+    needs: build-native
+
+    steps:
+      - name: Configure runner
+        run: |
+          wget -q https://github.com/awakecoding/llvm-prebuilt/releases/download/v2021.2.4/cctools-x86_64-ubuntu-20.04.tar.xz
+          tar -xf cctools-x86_64-ubuntu-20.04.tar.xz -C /tmp
+          sudo mv /tmp/cctools-x86_64-ubuntu-20.04/bin/lipo /usr/local/bin
+
+      - name: Download native components
+        uses: actions/download-artifact@v3
+        with:
+          path: dependencies/runtimes
+
+      - name: Lipo
+        shell: pwsh
+        run: |
+          Set-Location "dependencies/runtimes"
+          # No RID for osx-universal, see: https://github.com/dotnet/runtime/issues/53156
+          $OutputPath = Join-Path "osx-universal" "native"
+          New-Item -ItemType Directory -Path $OutputPath | Out-Null
+          $Libraries = Get-ChildItem -Recurse -Path "sspi-osx-*" -Filter "*.dylib" | Foreach-Object { $_.FullName } | Select -Unique
+          $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "libDevolutionsSspi.dylib")) + $Libraries) -Join ' '
+          Write-Host $LipoCmd
+          Invoke-Expression $LipoCmd
+
+      - name: Upload native components
+        uses: actions/upload-artifact@v3
+        with:
+          name: sspi-osx-universal
+          path: dependencies/runtimes/osx-universal
+
   build-managed:
     name: Managed build
     runs-on: windows-2022
-    needs: build-native
+    needs: [build-native, build-universal]
 
     steps:
       - name: Check out ${{ github.repository }}
@@ -234,6 +269,7 @@ jobs:
     needs:
       - preflight
       - build-managed
+      - build-universal
 
     steps:
       - name: Download NuGet package artifact

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -19,6 +19,7 @@
     <NativeLibPath_win_arm64>$(RuntimesPath)/win-arm64/native/DevolutionsSspi.dll</NativeLibPath_win_arm64>
     <NativeLibPath_osx_x64>$(RuntimesPath)/osx-x64/native/libDevolutionsSspi.dylib</NativeLibPath_osx_x64>
     <NativeLibPath_osx_arm64>$(RuntimesPath)/osx-arm64/native/libDevolutionsSspi.dylib</NativeLibPath_osx_arm64>
+    <NativeLibPath_osx_universal>$(RuntimesPath)/osx-universal/native/libDevolutionsSspi.dylib</NativeLibPath_osx_universal>
     <NativeLibPath_linux_x64>$(RuntimesPath)/linux-x64/native/libDevolutionsSspi.so</NativeLibPath_linux_x64>
     <NativeLibPath_linux_arm64>$(RuntimesPath)/linux-arm64/native/libDevolutionsSspi.so</NativeLibPath_linux_arm64>
     <NativeLibPath_android_x86>$(RuntimesPath)/android-x86/native/libDevolutionsSspi.so</NativeLibPath_android_x86>
@@ -58,6 +59,15 @@
     <Content Include="$(NativeLibPath_osx_arm64)">
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/osx-arm64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(NativeLibPath_osx_universal)')">
+    <Content Include="$(NativeLibPath_osx_universal)">
+      <Link>%(Filename)%(Extension)</Link>
+      <PackagePath>runtimes/osx-universal/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
@@ -12,7 +12,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsSspi.dylib">
+    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-x64\native\libDevolutionsSspi.dylib">
       <Link>runtimes\osx-x64\native\libDevolutionsSspi.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -20,7 +20,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsSspi.dylib">
+    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-arm64\native\libDevolutionsSspi.dylib">
       <Link>runtimes\osx-arm64\native\libDevolutionsSspi.dylib</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -44,7 +44,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x86\native\libDevolutionsSspi.so">
+    <Content Condition="$(AndroidSupportedAbis.Contains('x86'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x86\native\libDevolutionsSspi.so">
       <Link>runtimes\android-x86\native\libDevolutionsSspi.so</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -52,7 +52,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x64\native\libDevolutionsSspi.so">
+    <Content Condition="$(AndroidSupportedAbis.Contains('x86_64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x64\native\libDevolutionsSspi.so">
       <Link>runtimes\android-x64\native\libDevolutionsSspi.so</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -60,7 +60,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsSspi.so">
+    <Content Condition="$(AndroidSupportedAbis.Contains('armeabi-v7a'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsSspi.so">
       <Link>runtimes\android-arm\native\libDevolutionsSspi.so</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -68,7 +68,7 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm64\native\libDevolutionsSspi.so">
+    <Content Condition="$(AndroidSupportedAbis.Contains('arm64-v8a'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm64\native\libDevolutionsSspi.so">
       <Link>runtimes\android-arm64\native\libDevolutionsSspi.so</Link>
       <PublishState>Included</PublishState>
       <Visible>False</Visible>
@@ -76,5 +76,11 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true'">
+    <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsSspi.dylib">
+      <Kind>Dynamic</Kind>
+      <SmartLink>False</SmartLink>
+    </NativeReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use `lipo` to create a universal binary for macOS. Using `osx-universal` as the RID but there doesn't seem to be an official "universal" RID currently
- The nuget packages references the native library on macOS using `NativeReference`; and only deploys the thin binaries for the PowerShell target
- Make a naive check for Android target in the .targets file to only deploy Android binaries on that platform