### PR TITLE
Android and iOS packaging

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -17,8 +17,13 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       dry-run: ${{ steps.get-dry-run.outputs.dry-run }}
+      project-version: ${{ steps.get-version.outputs.project-version }}
+      package-version: ${{ steps.get-version.outputs.package-version }}
 
     steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v3
+
       - name: Get dry run
         id: get-dry-run
         shell: pwsh
@@ -33,9 +38,20 @@ jobs:
             Write-Host '::set-output name=dry-run::false'
           }
 
+      - name: Get version
+        id: get-version
+        shell: pwsh
+        run: |
+          $CsprojXml = [Xml] (Get-Content .\ffi\dotnet\Devolutions.Sspi\Devolutions.Sspi.csproj)
+          $ProjectVersion = $CsprojXml.Project.PropertyGroup.Version | Select-Object -First 1
+          $PackageVersion = $ProjectVersion -Replace "^(\d+)\.(\d+)\.(\d+).(\d+)$", "`$1.`$2.`$3"
+          Write-Host "::set-output name=project-version::$ProjectVersion"
+          Write-Host "::set-output name=package-version::$PackageVersion"
+
   build-native:
     name: Native build
-    runs-on: ${{matrix.runner}}
+    runs-on: ${{ matrix.runner }}
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +91,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure Android NDK
-        if: runner.os == 'linux'
+        if: matrix.os == 'android'
         shell: pwsh
         run: |
           $CargoConfigFile = "~/.cargo/config"
@@ -207,9 +223,8 @@ jobs:
             $Env:RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
           }
 
-          $CsprojXml = [Xml] (Get-Content .\ffi\dotnet\Devolutions.Sspi\Devolutions.Sspi.csproj)
-          $ProjectVersion = $CsprojXml.Project.PropertyGroup.Version | Select-Object -First 1
-          $PackageVersion = $ProjectVersion -Replace "^(\d+)\.(\d+)\.(\d+).(\d+)$", "`$1.`$2.`$3"
+          $ProjectVersion = '${{ needs.preflight.outputs.project-version }}'
+          $PackageVersion = '${{ needs.preflight.outputs.package-version }}'
 
           $CargoToml = Get-Content .\ffi\Cargo.toml
           $CargoToml = $CargoToml | ForEach-Object {
@@ -235,14 +250,22 @@ jobs:
   build-universal:
     name: Universal Build
     runs-on: ubuntu-20.04
-    needs: build-native
+    needs: [preflight, build-native]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ osx, ios ]
 
     steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v3
+
       - name: Configure runner
         run: |
           wget -q https://github.com/awakecoding/llvm-prebuilt/releases/download/v2022.2.0/cctools-x86_64-ubuntu-20.04.tar.xz
           tar -xf cctools-x86_64-ubuntu-20.04.tar.xz -C /tmp
           sudo mv /tmp/cctools-x86_64-ubuntu-20.04/bin/lipo /usr/local/bin
+          sudo mv /tmp/cctools-x86_64-ubuntu-20.04/bin/install_name_tool /usr/local/bin
 
       - name: Download native components
         uses: actions/download-artifact@v3
@@ -253,19 +276,64 @@ jobs:
         shell: pwsh
         run: |
           Set-Location "dependencies/runtimes"
-          # No RID for osx-universal, see: https://github.com/dotnet/runtime/issues/53156
-          $OutputPath = Join-Path "osx-universal" "native"
+          # No RID for universal binaries, see: https://github.com/dotnet/runtime/issues/53156
+          $OutputPath = Join-Path "${{ matrix.os }}-universal" "native"
           New-Item -ItemType Directory -Path $OutputPath | Out-Null
-          $Libraries = Get-ChildItem -Recurse -Path "sspi-osx-*" -Filter "*.dylib" | Foreach-Object { $_.FullName } | Select -Unique
+          $Libraries = Get-ChildItem -Recurse -Path "sspi-${{ matrix.os }}-*" -Filter "*.dylib" | Foreach-Object { $_.FullName } | Select -Unique
           $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "libDevolutionsSspi.dylib")) + $Libraries) -Join ' '
           Write-Host $LipoCmd
           Invoke-Expression $LipoCmd
 
+      - name: Framework
+        shell: pwsh
+        if: ${{ matrix.os == 'ios' }}
+        run: |
+          $Version = '${{ needs.preflight.outputs.project-version }}'
+          $ShortVersion = '${{ needs.preflight.outputs.package-version }}'
+          $BundleName = "libDevolutionsSspi"
+          $RuntimesDir = Join-Path "dependencies" "runtimes" "ios-universal" "native"
+          $FrameworkDir = Join-Path "$RuntimesDir" "$BundleName.framework"
+          New-Item -Path $FrameworkDir -ItemType "directory" -Force
+          $FrameworkExecutable = Join-Path $FrameworkDir $BundleName
+          Copy-Item -Path (Join-Path "$RuntimesDir" "$BundleName.dylib") -Destination $FrameworkExecutable -Force
+
+          $RPathCmd = $(@('install_name_tool', '-id', "@rpath/$BundleName.framework/$BundleName", "$FrameworkExecutable")) -Join ' '
+          Write-Host $RPathCmd
+          Invoke-Expression $RPathCmd
+
+          [xml] $InfoPlistXml = Get-Content "Info.plist"
+          Select-Xml -xml $InfoPlistXml -XPath "/plist/dict/key[. = 'CFBundleIdentifier']/following-sibling::string[1]" |
+          %{ 	
+          $_.Node.InnerXml = "com.devolutions.sspi"
+          }
+          Select-Xml -xml $InfoPlistXml -XPath "/plist/dict/key[. = 'CFBundleExecutable']/following-sibling::string[1]" |
+          %{ 	
+          $_.Node.InnerXml = $BundleName
+          }
+          Select-Xml -xml $InfoPlistXml -XPath "/plist/dict/key[. = 'CFBundleVersion']/following-sibling::string[1]" |
+          %{ 	
+          $_.Node.InnerXml = $Version
+          }
+          Select-Xml -xml $InfoPlistXml -XPath "/plist/dict/key[. = 'CFBundleShortVersionString']/following-sibling::string[1]" |
+          %{ 	
+          $_.Node.InnerXml = $ShortVersion
+          }
+
+          # Write the plist *without* a BOM
+          $Encoding = New-Object System.Text.UTF8Encoding($false)
+          $Writer = New-Object System.IO.StreamWriter((Join-Path $FrameworkDir "Info.plist"), $false, $Encoding)
+          $InfoPlistXml.Save($Writer)
+          $Writer.Close()
+
+          # .NET XML document inserts two square brackets at the end of the DOCTYPE tag
+          # It's perfectly valid XML, but we're dealing with plists here and dyld will not be able to read the file
+          ((Get-Content -Path (Join-Path $FrameworkDir "Info.plist") -Raw) -Replace 'PropertyList-1.0.dtd"\[\]', 'PropertyList-1.0.dtd"') | Set-Content -Path (Join-Path $FrameworkDir "Info.plist")
+
       - name: Upload native components
         uses: actions/upload-artifact@v3
         with:
-          name: sspi-osx-universal
-          path: dependencies/runtimes/osx-universal
+          name: sspi-${{ matrix.os }}-universal
+          path: dependencies/runtimes/${{ matrix.os }}-universal
 
   build-managed:
     name: Managed build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 **/*.rs.bk
 Cargo.lock
 .idea/
+.DS_Store

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string></string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string></string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0.0</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>12.1</string>
+</dict>
+</plist>

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -28,6 +28,8 @@
     <NativeLibPath_android_arm64>$(RuntimesPath)/android-arm64/native/libDevolutionsSspi.so</NativeLibPath_android_arm64>
     <NativeLibPath_ios_x64>$(RuntimesPath)/ios-x64/native/libDevolutionsSspi.dylib</NativeLibPath_ios_x64>
     <NativeLibPath_ios_arm64>$(RuntimesPath)/ios-arm64/native/libDevolutionsSspi.dylib</NativeLibPath_ios_arm64>
+    <NativeLibPath_ios_universal>$(RuntimesPath)/ios-universal/native/libDevolutionsSspi.dylib</NativeLibPath_ios_universal>
+    <NativeLibPath_ios_framework>$(RuntimesPath)/ios-universal/native/libDevolutionsSspi.framework</NativeLibPath_ios_framework>
   </PropertyGroup>
 
   <ItemGroup Condition="Exists('$(NativeLibPath_win_x64)')">
@@ -35,7 +37,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/win-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -44,7 +46,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/win-arm64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -53,7 +55,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -62,7 +64,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/osx-arm64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -71,7 +73,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/osx-universal/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -80,7 +82,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/linux-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -89,7 +91,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/linux-arm64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -98,7 +100,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/android-x86/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -107,7 +109,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/android-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -116,7 +118,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/android-arm/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -125,7 +127,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/android-arm64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -134,7 +136,7 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/ios-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 
@@ -143,8 +145,25 @@
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/ios-arm64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(NativeLibPath_ios_universal)')">
+    <Content Include="$(NativeLibPath_ios_universal)">
+      <Link>%(Filename)%(Extension)</Link>
+      <PackagePath>runtimes/ios-universal/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(NativeLibPath_ios_framework)')">
+    <None Include="$(RuntimesPath)/ios-universal/native/*.framework/**">
+      <PackagePath>runtimes/ios-universal/native/</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
@@ -99,8 +99,8 @@
       <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
-  <ItemGroup Condition="(('$(Platform)' == 'iPhone'))">
-    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios-universal\native\libDevolutionsSspi.framework">
+  <ItemGroup Condition="(('$(Platform)' == 'iPhone')) or (('$(Platform)' == 'iPhoneSimulator'))">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\runtimes\ios-universal\native\libDevolutionsSspi.framework">
       <Kind>Framework</Kind>
     </NativeReference>
   </ItemGroup>

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
@@ -52,38 +52,6 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="$(AndroidSupportedAbis.Contains('x86'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x86\native\libDevolutionsSspi.so">
-      <Link>runtimes\android-x86\native\libDevolutionsSspi.so</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
-    <Content Condition="$(AndroidSupportedAbis.Contains('x86_64'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x64\native\libDevolutionsSspi.so">
-      <Link>runtimes\android-x64\native\libDevolutionsSspi.so</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
-    <Content Condition="$(AndroidSupportedAbis.Contains('armeabi-v7a'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsSspi.so">
-      <Link>runtimes\android-arm\native\libDevolutionsSspi.so</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
-    <Content Condition="$(AndroidSupportedAbis.Contains('arm64-v8a'))" Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm64\native\libDevolutionsSspi.so">
-      <Link>runtimes\android-arm64\native\libDevolutionsSspi.so</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
     <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\ios-x64\native\libDevolutionsSspi.dylib">
       <Link>runtimes\ios-x64\native\libDevolutionsSspi.dylib</Link>
       <PublishState>Included</PublishState>
@@ -101,10 +69,39 @@
       <Pack>false</Pack>
     </Content>
   </ItemGroup>
+  <ItemGroup Condition="$(AndroidSupportedAbis.Contains('armeabi-v7a')) or $(RuntimeIdentifiers.Contains('android-arm'))">
+      <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsSspi.so">
+          <Link>%(Filename)%(Extension)</Link>
+          <Abi>armeabi-v7a</Abi>
+      </AndroidNativeLibrary>
+  </ItemGroup>
+    <ItemGroup Condition="$(AndroidSupportedAbis.Contains('arm64-v8a')) or $(RuntimeIdentifiers.Contains('android-arm64'))">
+      <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm64\native\libDevolutionsSspi.so">
+          <Link>%(Filename)%(Extension)</Link>
+          <Abi>arm64-v8a</Abi>
+      </AndroidNativeLibrary>
+  </ItemGroup>
+  <ItemGroup Condition="$(AndroidSupportedAbis.Contains('x86')) or $(RuntimeIdentifiers.Contains('android-x86'))">
+      <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x86\native\libDevolutionsSspi.so">
+          <Link>%(Filename)%(Extension)</Link>
+          <Abi>x86</Abi>
+      </AndroidNativeLibrary>
+  </ItemGroup>
+  <ItemGroup Condition="$(AndroidSupportedAbis.Contains('x86_64')) or $(RuntimeIdentifiers.Contains('android-x64'))">
+      <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-x64\native\libDevolutionsSspi.so">
+          <Link>%(Filename)%(Extension)</Link>
+          <Abi>x86_64</Abi>
+      </AndroidNativeLibrary>
+  </ItemGroup> 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true'">
     <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsSspi.dylib">
       <Kind>Dynamic</Kind>
       <SmartLink>False</SmartLink>
+    </NativeReference>
+  </ItemGroup>
+  <ItemGroup Condition="(('$(Platform)' == 'iPhone'))">
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios-universal\native\libDevolutionsSspi.framework">
+      <Kind>Framework</Kind>
     </NativeReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix Android packaging to properly reference the native libraries in the final build

Add a universal build for iOS, and wrap the resulting .dylib in a framework bundle. Although universal builds are not needed for our case (RDM only supports arm64), it's simpler to just re-use the macOS step. There is no extra cost to this as the iOS application build strips unsupported ABIs from the final .app.

I'm unable to test the iOS changes as a VS issue is preventing me from installing local nuget packages; however the Android changes should be fine. If there is an issue with the iOS package I'll iterate further.