### PR TITLE
Use dns-sd on iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ winreg = "0.10"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 windows = { version = "0.39.0", features = [ "Win32_Foundation", "Win32_NetworkManagement_Dns"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-dnssd = "0.5.0"
 futures = "0.3.1"
 tokio = { version = "1.1", features = ["time", "rt"] }

--- a/ffi/src/credentials_attributes.rs
+++ b/ffi/src/credentials_attributes.rs
@@ -1,5 +1,5 @@
-use libc::{c_uint, c_ulong, c_ushort};
 use crate::sspi_data_types::{SecChar, SecWChar};
+use libc::{c_uint, c_ulong, c_ushort};
 
 pub struct KdcProxySettings {
     pub proxy_server: String,

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -18,12 +18,14 @@ use symbol_rename_macro::rename_symbol;
 
 use crate::credentials_attributes::{
     CredentialsAttributes, KdcProxySettings, SecPkgCredentialsKdcProxySettingsA, SecPkgCredentialsKdcProxySettingsW,
-    SecPkgCredentialsKdcUrlA, SecPkgCredentialsKdcUrlW
+    SecPkgCredentialsKdcUrlA, SecPkgCredentialsKdcUrlW,
 };
 use crate::sec_buffer::{copy_to_c_sec_buffer, p_sec_buffers_to_security_buffers, PSecBuffer, PSecBufferDesc};
 use crate::sec_pkg_info::{SecNegoInfoA, SecNegoInfoW, SecPkgInfoA, SecPkgInfoW};
-use crate::sec_winnt_auth_identity::{SecWinntAuthIdentityA, SecWinntAuthIdentityW,
-    SecWinntAuthIdentityExA, SecWinntAuthIdentityExW, SEC_WINNT_AUTH_IDENTITY_VERSION};
+use crate::sec_winnt_auth_identity::{
+    SecWinntAuthIdentityA, SecWinntAuthIdentityExA, SecWinntAuthIdentityExW, SecWinntAuthIdentityW,
+    SEC_WINNT_AUTH_IDENTITY_VERSION,
+};
 use crate::sspi_data_types::{
     LpStr, LpcWStr, PSecurityString, PTimeStamp, SecChar, SecGetKeyFn, SecPkgContextSizes, SecWChar, SecurityStatus,
 };
@@ -93,8 +95,9 @@ pub(crate) unsafe fn p_ctxt_handle_to_sspi_context(
             }
             kerberos::PKG_NAME => {
                 if let Some(kdc_url) = attributes.kdc_url() {
-                    SspiContext::Kerberos(Kerberos::new_client_from_config(
-                        KerberosConfig::from_kdc_url(&kdc_url, Box::new(ReqwestNetworkClient::new()),
+                    SspiContext::Kerberos(Kerberos::new_client_from_config(KerberosConfig::from_kdc_url(
+                        &kdc_url,
+                        Box::new(ReqwestNetworkClient::new()),
                     ))?)
                 } else {
                     SspiContext::Kerberos(Kerberos::new_client_from_config(KerberosConfig::from_env())?)

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -142,7 +142,7 @@ cfg_if::cfg_if! {
         }
 
         impl From<&QueryRecordResult> for DnsSrvRecord {
-            fn from(record: &QueryRecordResult) -> Self {    
+            fn from(record: &QueryRecordResult) -> Self {
                 let rdata = record.rdata.as_slice();
                 let priority = u16::from_be_bytes(rdata[0..2].try_into().unwrap());
                 let weight = u16::from_be_bytes(rdata[2..4].try_into().unwrap());
@@ -159,7 +159,7 @@ cfg_if::cfg_if! {
 
         pub fn dns_decode_target_data_to_string(v: &[u8]) -> String {
             let mut names = Vec::new();
-        
+
             let mut i = 0;
             while i < v.len() {
                 let size = v[i] as usize;
@@ -169,19 +169,19 @@ cfg_if::cfg_if! {
                 names.push(String::from_utf8_lossy(&v[i+1..i+1+size]));
                 i = i + 1 + size;
             }
-        
+
             names.join(".")
         }
 
         pub fn dns_query_srv_records(name: &str) -> Vec<DnsSrvRecord> {
             let query_timeout = 1000;
             let mut dns_records: Vec<DnsSrvRecord> = Vec::new();
-        
+
             let rt = runtime::Builder::new_current_thread().enable_all().build().unwrap();
-        
+
             rt.block_on(async {
                 let mut query = query_record(name, Type::SRV);
-        
+
                 loop {
                     match timeout(Duration::from_millis(query_timeout), query.next()).await {
                         Ok(Some(Ok(dns_record))) => {
@@ -197,7 +197,7 @@ cfg_if::cfg_if! {
                     }
                 }
             });
-        
+
             dns_records
         }
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -126,7 +126,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os="macos")] {
+    if #[cfg(any(target_os="macos", target_os="ios"))] {
         use std::time::Duration;
         use tokio::time::timeout;
         use tokio::runtime;
@@ -326,7 +326,7 @@ pub fn detect_kdc_hosts_from_dns(domain: &str) -> Vec<String> {
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
             detect_kdc_hosts_from_dns_windows(domain)
-        } else if #[cfg(target_os="macos")] {
+        } else if #[cfg(any(target_os="macos", target_os="ios"))] {
             detect_kdc_hosts_from_dns_apple(domain)
         } else if #[cfg(feature="network_client")] {
             detect_kdc_hosts_from_dns_trust(domain)

--- a/src/kdc.rs
+++ b/src/kdc.rs
@@ -36,7 +36,7 @@ pub fn detect_kdc_hosts_from_system(domain: &str) -> Vec<String> {
 
     for krb5_conf_path in krb5_conf_paths {
         if krb5_conf_path.exists() {
-            if let Some(krb5_conf)  = Krb5Conf::new_from_file(krb5_conf_path) {
+            if let Some(krb5_conf) = Krb5Conf::new_from_file(krb5_conf_path) {
                 if let Some(kdc) = krb5_conf.get_value(vec!["realms", domain, "kdc"]) {
                     let kdc_url = format!("tcp://{}", kdc.as_str());
                     return vec![kdc_url];

--- a/src/sspi/kerberos.rs
+++ b/src/sspi/kerberos.rs
@@ -34,7 +34,7 @@ use self::server::extractors::extract_tgt_ticket;
 use self::utils::{serialize_message, utf16_bytes_to_utf8_string};
 use super::channel_bindings::ChannelBindings;
 use crate::builders::ChangePassword;
-use crate::{detect_kdc_url};
+use crate::detect_kdc_url;
 use crate::kerberos::client::extractors::extract_status_code_from_krb_priv_response;
 use crate::sspi::kerberos::client::extractors::extract_salt_from_krb_error;
 use crate::sspi::kerberos::client::generators::{generate_final_neg_token_targ, get_mech_list};
@@ -150,11 +150,10 @@ impl Kerberos {
         if let Some((realm, kdc_url)) = self.get_kdc() {
             return match kdc_url.scheme() {
                 "udp" | "tcp" => self.config.network_client.send(&kdc_url, data),
-                "http" | "https" => {
-                    self.config
-                        .network_client
-                        .send_http(&kdc_url, data, Some(realm.to_string()))
-                }
+                "http" | "https" => self
+                    .config
+                    .network_client
+                    .send_http(&kdc_url, data, Some(realm.to_string())),
                 _ => Err(Error {
                     error_type: ErrorKind::InternalError,
                     description: "Invalid KDC server URL protocol scheme".to_owned(),

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -122,9 +122,15 @@ impl Negotiate {
                 };
 
                 match package_name.as_str() {
-                    "ntlm" => { ntlm_package = enabled; }
-                    "kerberos" => { kerberos_package = enabled; }
-                    _ => { eprintln!("unexpected package name: {}", &package_name); }
+                    "ntlm" => {
+                        ntlm_package = enabled;
+                    }
+                    "kerberos" => {
+                        kerberos_package = enabled;
+                    }
+                    _ => {
+                        eprintln!("unexpected package name: {}", &package_name);
+                    }
                 }
             }
         }
@@ -132,16 +138,19 @@ impl Negotiate {
         (ntlm_package, kerberos_package)
     }
 
-    fn filter_protocol(negotiated_protocol: &NegotiatedProtocol, package_list: &Option<String>) -> Option<NegotiatedProtocol> {
+    fn filter_protocol(
+        negotiated_protocol: &NegotiatedProtocol,
+        package_list: &Option<String>,
+    ) -> Option<NegotiatedProtocol> {
         let mut filtered_protocol = None;
         let (ntlm_package, kerberos_package) = Self::get_package_list_config(package_list);
-        
+
         match &negotiated_protocol {
             NegotiatedProtocol::Kerberos(_) => {
                 if !kerberos_package {
                     filtered_protocol = Some(NegotiatedProtocol::Ntlm(Ntlm::new()));
                 }
-            },
+            }
             NegotiatedProtocol::Ntlm(_) => {
                 if !ntlm_package {
                     let kerberos_client = Kerberos::new_client_from_config(KerberosConfig::from_env()).unwrap();


### PR DESCRIPTION
`trust-dns` resolver won't work on iOS; it tries to read configuration from `/etc/resolv.conf`. Even if iOS uses this path itself, it won't be readable by us as it's outside the application sandbox.

`dnssd` is available since iOS 10; so just switch to use the same code paths as macOS.

Check the individual commits as there was some churn from running `cargo fmt`.