### PR TITLE
PKU2U: RSA signature generation fix

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -36,13 +36,13 @@ pub fn compute_md5_channel_bindings_hash(channel_bindings: &ChannelBindings) -> 
     let mut context = Md5::new();
     let mut result = [0x00; HASH_SIZE];
 
-    context.update(&channel_bindings.initiator_addr_type.to_be_bytes());
-    context.update(&channel_bindings.initiator.len().to_be_bytes());
+    context.update(channel_bindings.initiator_addr_type.to_be_bytes());
+    context.update(channel_bindings.initiator.len().to_be_bytes());
 
-    context.update(&channel_bindings.acceptor_addr_type.to_be_bytes());
-    context.update(&channel_bindings.acceptor.len().to_be_bytes());
+    context.update(channel_bindings.acceptor_addr_type.to_be_bytes());
+    context.update(channel_bindings.acceptor.len().to_be_bytes());
 
-    context.update(&channel_bindings.application_data.len().to_be_bytes());
+    context.update(channel_bindings.application_data.len().to_be_bytes());
     context.update(&channel_bindings.application_data);
 
     result.clone_from_slice(&context.finalize());

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -392,6 +392,7 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity>> CredSspServer<C> {
         })
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn process(&mut self, mut ts_request: TsRequest) -> Result<ServerState, ServerError> {
         if self.context.is_none() {
             self.context = match &self.context_config {

--- a/src/sspi/pku2u/cert_utils/win_extraction.rs
+++ b/src/sspi/pku2u/cert_utils/win_extraction.rs
@@ -92,7 +92,7 @@ fn decode_private_key(mut buffer: impl Read) -> Result<PrivateKey> {
         &BigUint::from_bytes_be(&modulus),
         &BigUint::from_bytes_be(&public_exp),
         &BigUint::from_bytes_be(&private_exp),
-        &vec![BigUint::from_bytes_be(&prime1), BigUint::from_bytes_be(&prime2)],
+        &[BigUint::from_bytes_be(&prime1), BigUint::from_bytes_be(&prime2)],
     )
     .map_err(|err| {
         Error::new(

--- a/src/sspi/pku2u/generators.rs
+++ b/src/sspi/pku2u/generators.rs
@@ -149,13 +149,8 @@ pub fn generate_signer_info(p2p_cert: &Certificate, digest: Vec<u8>, private_key
 
     let encoded_signed_attributes = picky_asn1_der::to_vec(&signed_attributes)?;
 
-    let mut sha1 = Sha1::new();
-    sha1.update(&encoded_signed_attributes);
-
-    let hashed_signed_attributes = sha1.finalize().to_vec();
-
     let signature = SignatureAlgorithm::RsaPkcs1v15(HashAlgorithm::SHA1)
-        .sign(&hashed_signed_attributes, private_key)
+        .sign(&encoded_signed_attributes, private_key)
         .map_err(|err| {
             Error::new(
                 ErrorKind::InternalError,


### PR DESCRIPTION
In https://github.com/Devolutions/sspi-rs/pull/61, one of the comments was to use `picky-rs` instead of `rsa` directly for an RSA signature generation.  The changes have been made, but `picky-rs` generates hash itself and so we shouldn't generate it. Now, we generate a hash in `ssp-rs` before the sign, then, pass the generated hash to SignatureAlgorithm::RsaPkcs1v15::sign which performs hashing again. That is not correct. This PR fixes it.
Also, I fixed `clippy` warnings. 