### PR TITLE
Kerberos authentication fixes 

### DIFF
--- a/src/sspi/kerberos.rs
+++ b/src/sspi/kerberos.rs
@@ -193,7 +193,7 @@ impl Kerberos {
             pa_data_options.salt = correct_salt.as_bytes().to_vec()
         }
 
-        pa_data_options.with_pre_auth = false;
+        pa_data_options.with_pre_auth = true;
         let pa_datas = generate_pa_datas_for_as_req(&pa_data_options)?;
 
         let kdc_req_body = generate_as_req_kdc_body(&options)?;

--- a/src/sspi/kerberos/client/generators.rs
+++ b/src/sspi/kerberos/client/generators.rs
@@ -167,8 +167,7 @@ pub fn generate_as_req_kdc_body(options: &GenerateAsReqOptions) -> Result<KdcReq
 
     let address = Some(ExplicitContextTag9::from(Asn1SequenceOf::from(vec![HostAddress {
         addr_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NET_BIOS_ADDR_TYPE])),
-        // address: ExplicitContextTag1::from(OctetStringAsn1::from(whoami::hostname().as_bytes().to_vec())),
-        address: ExplicitContextTag1::from(OctetStringAsn1::from("DESKTOP-8F33RFH\x20".as_bytes().to_vec())),
+        address: ExplicitContextTag1::from(OctetStringAsn1::from(whoami::hostname().as_bytes().to_vec())),
     }])));
 
     let mut service_names = Vec::with_capacity(snames.len());


### PR DESCRIPTION
- Removed a hardcoded hostname
- Turn on preauthentication