### PR TITLE
fix(ffi): improve debugging infrastructure

### DIFF
--- a/ffi/src/debug.rs
+++ b/ffi/src/debug.rs
@@ -3,6 +3,7 @@ pub use self::implementation::*;
 #[cfg(feature = "debug_mode")]
 mod implementation {
     use std::fs::OpenOptions;
+    use std::path::PathBuf;
     use std::sync::Once;
 
     use tracing_subscriber::prelude::*;
@@ -10,11 +11,35 @@ mod implementation {
 
     static SETUP: Once = Once::new();
 
+    const SSPI_DBG_LOG_PATH_ENV: &str = "SSPI_DBG_LOG_PATH";
+
+    #[cfg(windows)]
+    const HOME_PATH_ENV: &str = "USERPROFILE";
+
+    #[cfg(not(windows))]
+    const HOME_PATH_ENV: &str = "HOME";
+
     pub fn setup_logger() {
         SETUP.call_once(|| {
-            let path = format!("{}/sspi-rs.log", std::env::var("HOMEPATH").unwrap());
+            let path = if let Ok(path) = std::env::var(SSPI_DBG_LOG_PATH_ENV) {
+                PathBuf::from(path)
+            } else if let Ok(path) = std::env::var(HOME_PATH_ENV) {
+                let mut path = PathBuf::from(path);
+                path.push("sspi-rs.log");
+                path
+            } else {
+                println!("[SSPI-DEBUG] Couldn’t find path for log file");
+                return;
+            };
 
-            let file = OpenOptions::new().read(true).append(true).open(path).unwrap();
+            let file = match OpenOptions::new().read(true).append(true).open(path) {
+                Ok(f) => f,
+                Err(e) => {
+                    println!("[SSPI-DEBUG] Couldn’t open log file: {e}");
+                    return;
+                }
+            };
+
             let fmt_layer = tracing_subscriber::fmt::layer()
                 .pretty()
                 .with_thread_names(true)
@@ -38,6 +63,19 @@ mod implementation {
                 }
             }));
         })
+    }
+
+    /// FFI function to call in order to manually setup the debug logger.
+    ///
+    /// Under normal circumstances, it is not required to call this function.
+    /// Indeed `InitSecurityInterface*` family functions will trigger the same
+    /// behavior. However, you can call this directly if you need to manually set up the logger
+    /// (maybe in order to debug `InitSecurityInterface*`).
+    ///
+    /// This function can be called multiple times safely.
+    #[no_mangle]
+    pub extern "system" fn RustSspiSetupLogger() {
+        setup_logger();
     }
 }
 

--- a/ffi/src/security_tables.rs
+++ b/ffi/src/security_tables.rs
@@ -113,6 +113,7 @@ pub struct SecurityFunctionTableW {
 
 pub type PSecurityFunctionTableW = *mut SecurityFunctionTableW;
 
+#[cfg_attr(feature = "debug_mode", instrument(skip_all))]
 #[cfg_attr(windows, rename_symbol(to = "Rust_InitSecurityInterfaceA"))]
 #[no_mangle]
 pub extern "system" fn InitSecurityInterfaceA() -> PSecurityFunctionTableA {
@@ -155,6 +156,7 @@ pub extern "system" fn InitSecurityInterfaceA() -> PSecurityFunctionTableA {
     })
 }
 
+#[cfg_attr(feature = "debug_mode", instrument(skip_all))]
 #[cfg_attr(windows, rename_symbol(to = "Rust_InitSecurityInterfaceW"))]
 #[no_mangle]
 pub extern "system" fn InitSecurityInterfaceW() -> PSecurityFunctionTableW {


### PR DESCRIPTION
The `SSPI_DBG_LOG_PATH` environment variable can be used to specify the log file.

An FFI function `RustSspiSetupLogger` is provided in order to manually setup the logger.