### PR TITLE
Fix Kerberos EncryptMessage

### DIFF
--- a/src/sspi/kerberos.rs
+++ b/src/sspi/kerberos.rs
@@ -261,7 +261,7 @@ impl Sspi for Kerberos {
         wrap_token.encode(&mut raw_wrap_token)?;
 
         match self.state {
-            KerberosState::PubKeyAuth | KerberosState::Credentials => {
+            KerberosState::PubKeyAuth | KerberosState::Credentials | KerberosState::Final => {
                 *data.buffer.as_mut() = raw_wrap_token[SECURITY_TRAILER..].to_vec();
                 let header = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Token)?;
                 *header.buffer.as_mut() = raw_wrap_token[0..SECURITY_TRAILER].to_vec();


### PR DESCRIPTION
WSMan/WinRM calls EncryptMessage/DecryptMessage more times than CredSSP does, so we've hit a condition where the internal Kerberos state was incorrectly rejecting the calls.