### PR TITLE
Fix regression in dns module

### DIFF
--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -5,7 +5,7 @@
     <Description>Portable Rust SSPI library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2022.11.7.0</Version>
+    <Version>2022.11.18.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -241,7 +241,7 @@ cfg_if::cfg_if! {
         use url::Url;
 
         fn get_trust_dns_name_server_from_url_str(url: &str) -> Option<NameServerConfig> {
-            let url = if !url.contains("://") && url.is_empty() {
+            let url = if !url.contains("://") && !url.is_empty() {
                 format!("udp://{}", url)
             } else {
                 url.to_string()
@@ -294,12 +294,12 @@ cfg_if::cfg_if! {
 
         #[cfg(not(target_os="windows"))]
         fn get_trust_dns_resolver(_domain: &str) -> Option<Resolver> {
-            if let Ok((resolver_config, resolver_options)) = read_system_conf() {
-                Resolver::new(resolver_config, resolver_options).ok()
-            } else if let Ok(name_server_list) = env::var("SSPI_DNS_URL") {
+            if let Ok(name_server_list) = env::var("SSPI_DNS_URL") {
                 let name_servers: Vec<String> = name_server_list
                     .split(',').map(|c|c.trim().to_string()).filter(|x: &String| !x.is_empty()).collect();
                 get_trust_dns_resolver_from_name_servers(name_servers)
+            } else if let Ok((resolver_config, resolver_options)) = read_system_conf() {
+                    Resolver::new(resolver_config, resolver_options).ok()
             } else {
                 None
             }

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -1482,10 +1482,7 @@ impl From<Asn1DerError> for Error {
 
 impl From<KrbError> for Error {
     fn from(err: KrbError) -> Self {
-        Self::new(
-            ErrorKind::InternalError,
-            format!("Got the krb error: {}", err.0.to_string()),
-        )
+        Self::new(ErrorKind::InternalError, format!("KRB error: {:?}", err.0.error_code))
     }
 }
 


### PR DESCRIPTION
I also inverted the order in `get_trust_dns_resolver`. The "SSPI_DNS_URL" variable is checked first - this lets us override the system_conf more easily for testing (on systems that support it).