### PR TITLE
fix(ci): run apt update in CI

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -173,6 +173,10 @@ jobs:
             echo "IPHONEOS_DEPLOYMENT_TARGET=12.1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           }
 
+      - name: Update runner
+        if: ${{ matrix.os == 'linux' }}
+        run: sudo apt update
+
       - name: Build sspi (${{matrix.os}}-${{matrix.arch}}) (${{matrix.build}})
         shell: pwsh
         run: |


### PR DESCRIPTION
The `rust-toolchain` installs prerequisites using `apt` on Linux. If a package is moved or replaced, this can fail.

We must call `apt update` before invoking `cargo`.