### PR TITLE
Allow hostname passing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ portpicker = { version = "0.1.1", optional = true }
 num-bigint-dig = "0.8.1"
 tracing = { version = "0.1.37" }
 
+[target.'cfg(not(target_arch = "wasm32-unknown-unknown"))'.dependencies]
+whoami = "0.5"
+
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10"
 winapi = { version = "0.3", features = ["sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -701,7 +701,7 @@ pub type SetContextAttributesFnA = extern "system" fn(PCtxtHandle, c_ulong, *mut
 #[cfg_attr(windows, rename_symbol(to = "Rust_SetContextAttributesW"))]
 #[no_mangle]
 pub extern "system" fn SetContextAttributesW(
-    _ph_credential: PCtxtHandle,
+    _ph_context: PCtxtHandle,
     _ul_attribute: c_ulong,
     _p_buffer: *mut c_void,
     _cb_buffer: c_ulong,

--- a/src/sspi.rs
+++ b/src/sspi.rs
@@ -736,6 +736,7 @@ where
     Self: Sized + SspiImpl,
 {
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData);
+    fn custom_set_hostname(&mut self, hostname: String);
 }
 
 pub type SspiPackage<'a, CredsHandle, AuthData> =

--- a/src/sspi/internal/credssp.rs
+++ b/src/sspi/internal/credssp.rs
@@ -687,6 +687,15 @@ impl SspiEx for SspiContext {
             SspiContext::Pku2u(pku2u) => pku2u.custom_set_auth_identity(identity),
         }
     }
+
+    fn custom_set_hostname(&mut self, hostname: String) {
+        match self {
+            SspiContext::Ntlm(ntlm) => ntlm.custom_set_hostname(hostname),
+            SspiContext::Kerberos(kerberos) => kerberos.custom_set_hostname(hostname),
+            SspiContext::Negotiate(negotiate) => negotiate.custom_set_hostname(hostname),
+            SspiContext::Pku2u(pku2u) => pku2u.custom_set_hostname(hostname),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/sspi/kerberos/client/generators.rs
+++ b/src/sspi/kerberos/client/generators.rs
@@ -150,6 +150,7 @@ pub struct GenerateAsReqOptions<'a> {
     pub cname_type: u8,
     pub snames: &'a [&'a str],
     pub nonce: &'a [u8],
+    pub hostname: &'a str,
 }
 
 pub fn generate_as_req_kdc_body(options: &GenerateAsReqOptions) -> Result<KdcReqBody> {
@@ -159,13 +160,12 @@ pub fn generate_as_req_kdc_body(options: &GenerateAsReqOptions) -> Result<KdcReq
         cname_type,
         snames,
         nonce,
+        hostname: address,
     } = options;
 
     let expiration_date = Utc::now()
         .checked_add_signed(Duration::days(TGT_TICKET_LIFETIME_DAYS))
         .unwrap();
-
-    let address = "INJECT HOSTNAME VIA ARGUMENTS"; // FIXME: previously whoami::hostname()
 
     let host_address = HostAddress {
         addr_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NET_BIOS_ADDR_TYPE])),
@@ -536,10 +536,9 @@ pub fn generate_krb_priv_request(
     authenticator: &Authenticator,
     enc_params: &EncryptionParams,
     seq_num: u32,
+    address: &str,
 ) -> Result<KrbPrivMessage> {
     let ap_req = generate_ap_req(ticket, session_key, authenticator, enc_params, &EMPTY_AP_REQ_OPTIONS)?;
-
-    let address = "INJECT HOSTNAME VIA ARGUMENTS"; // FIXME: previously whoami::hostname()
 
     let enc_part = EncKrbPrivPart::from(EncKrbPrivPartInner {
         user_data: ExplicitContextTag0::from(OctetStringAsn1::from(new_password.to_vec())),

--- a/src/sspi/negotiate.rs
+++ b/src/sspi/negotiate.rs
@@ -222,6 +222,14 @@ impl SspiEx for Negotiate {
             NegotiatedProtocol::Ntlm(ntlm) => ntlm.custom_set_auth_identity(identity),
         }
     }
+
+    fn custom_set_hostname(&mut self, hostname: String) {
+        match &mut self.protocol {
+            NegotiatedProtocol::Pku2u(pku2u) => pku2u.custom_set_hostname(hostname),
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.custom_set_hostname(hostname),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.custom_set_hostname(hostname),
+        }
+    }
 }
 
 impl Sspi for Negotiate {

--- a/src/sspi/ntlm.rs
+++ b/src/sspi/ntlm.rs
@@ -424,6 +424,8 @@ impl SspiEx for Ntlm {
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) {
         self.identity = Some(identity.into());
     }
+
+    fn custom_set_hostname(&mut self, _hostname: String) {}
 }
 
 impl NegotiateMessage {

--- a/src/sspi/pku2u.rs
+++ b/src/sspi/pku2u.rs
@@ -48,7 +48,7 @@ use crate::sspi::pku2u::extractors::{
 use crate::sspi::pku2u::generators::{generate_authenticator, generate_authenticator_extension};
 use crate::sspi::pku2u::validate::validate_signed_data;
 use crate::sspi::{self, PACKAGE_ID_NONE};
-use crate::utils::generate_random_symmetric_key;
+use crate::utils::{generate_random_symmetric_key, unwrap_hostname};
 use crate::{
     AcceptSecurityContextResult, AcquireCredentialsHandleResult, AuthIdentity, AuthIdentityBuffers, CertTrustStatus,
     ClientResponseFlags, ContextNames, ContextSizes, CredentialUse, DecryptionFlags, EncryptionFlags, Error, ErrorKind,
@@ -143,6 +143,7 @@ pub struct Pku2u {
     // The checksum is performed on all previous NEGOEX messages in the context negotiation.
     gss_api_messages: Vec<u8>,
     negoex_random: [u8; RANDOM_ARRAY_SIZE],
+    hostname: Option<String>,
 }
 
 impl Pku2u {
@@ -166,6 +167,7 @@ impl Pku2u {
             negoex_messages: Vec::new(),
             gss_api_messages: Vec::new(),
             negoex_random: rng.gen::<[u8; RANDOM_ARRAY_SIZE]>(),
+            hostname: None,
         })
     }
 
@@ -189,6 +191,7 @@ impl Pku2u {
             negoex_messages: Vec::new(),
             gss_api_messages: Vec::new(),
             negoex_random: rng.gen::<[u8; RANDOM_ARRAY_SIZE]>(),
+            hostname: None,
         })
     }
 
@@ -510,6 +513,7 @@ impl SspiImpl for Pku2u {
                     snames: &snames,
                     // we don't need the nonce in Pku2u
                     nonce: &[0],
+                    hostname: &unwrap_hostname(self.hostname.as_deref())?,
                 })?;
                 let pa_datas = generate_pa_datas_for_as_req(
                     &self.config.p2p_certificate,
@@ -793,5 +797,9 @@ impl SspiImpl for Pku2u {
 impl SspiEx for Pku2u {
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) {
         self.auth_identity = Some(identity.into());
+    }
+
+    fn custom_set_hostname(&mut self, hostname: String) {
+        self.hostname = Some(hostname);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 
 #[allow(unused)]
 use crate::sspi::pku2u::AZURE_AD_DOMAIN;
+use crate::{Error, ErrorKind, Result};
 
 pub fn string_to_utf16(value: &str) -> Vec<u8> {
     value
@@ -46,4 +47,19 @@ pub fn generate_random_symmetric_key(cipher: &CipherSuite, rnd: &mut OsRng) -> V
     }
 
     key
+}
+
+pub fn unwrap_hostname(hostname: Option<&str>) -> Result<String> {
+    if let Some(hostname) = hostname {
+        Ok(hostname.into())
+    } else {
+        if cfg!(not(target_arch = "wasm32")) {
+            Ok(whoami::hostname())
+        } else {
+            Err(Error::new(
+                ErrorKind::InvalidParameter,
+                "The hostname is not provided".into(),
+            ))
+        }
+    }
 }


### PR DESCRIPTION
I've improved `sspi-rs` API and now we can pass the hostname directly into the `SspiContext`.

I added a new trait method `SspiEx::custom_set_hostname` and implemented it for all the security packages. I decided to not change the main `Sspi` trait because the original `SSPI` doesn't have such a method. On non-wasm targets, we still use `whoami` crate because it's needed for all other applications (like `FreeRDP`) that work with `sspi-rs` using FFI.