### PR TITLE
fix(ffi): Fix ios-net6 package issues

### DIFF
--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -5,7 +5,7 @@
     <Description>Portable Rust SSPI library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2022.12.13.0</Version>
+    <Version>2023.1.26.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -26,9 +26,6 @@
     <NativeLibPath_android_x64>$(RuntimesPath)/android-x64/native/libDevolutionsSspi.so</NativeLibPath_android_x64>
     <NativeLibPath_android_arm>$(RuntimesPath)/android-arm/native/libDevolutionsSspi.so</NativeLibPath_android_arm>
     <NativeLibPath_android_arm64>$(RuntimesPath)/android-arm64/native/libDevolutionsSspi.so</NativeLibPath_android_arm64>
-    <NativeLibPath_ios_x64>$(RuntimesPath)/ios-x64/native/libDevolutionsSspi.dylib</NativeLibPath_ios_x64>
-    <NativeLibPath_ios_arm64>$(RuntimesPath)/ios-arm64/native/libDevolutionsSspi.dylib</NativeLibPath_ios_arm64>
-    <NativeLibPath_ios_universal>$(RuntimesPath)/ios-universal/native/libDevolutionsSspi.dylib</NativeLibPath_ios_universal>
     <NativeLibPath_ios_framework>$(RuntimesPath)/ios-universal/native/libDevolutionsSspi.framework</NativeLibPath_ios_framework>
   </PropertyGroup>
 
@@ -126,33 +123,6 @@
     <Content Include="$(NativeLibPath_android_arm64)">
       <Link>%(Filename)%(Extension)</Link>
       <PackagePath>runtimes/android-arm64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_x64)')">
-    <Content Include="$(NativeLibPath_ios_x64)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-x64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_arm64)')">
-    <Content Include="$(NativeLibPath_ios_arm64)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-arm64/native/%(Filename)%(Extension)</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup Condition="Exists('$(NativeLibPath_ios_universal)')">
-    <Content Include="$(NativeLibPath_ios_universal)">
-      <Link>%(Filename)%(Extension)</Link>
-      <PackagePath>runtimes/ios-universal/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.targets
@@ -3,9 +3,15 @@
   <PropertyGroup>
     <IsPowerShell Condition="$(DefineConstants.Contains('__POWERSHELL__'))">true</IsPowerShell>
     <IsAndroid Condition="$(TargetFramework.ToUpper().Contains('ANDROID'))">true</IsAndroid>
-    <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator'">true</IsIOS>
+    <IsIOS Condition="'$(Platform)' == 'iPhone' or '$(Platform)' == 'iPhoneSimulator' or $(TargetFramework.Contains('-ios'))">true</IsIOS>
     <IsNet6Mac Condition="$(TargetFramework.Contains('-macos'))">true</IsNet6Mac>
   </PropertyGroup>
+  <Target Name="DebugMessage" BeforeTargets="Build" >
+    <Message Text="PowerShell: $(IsPowerShell)" Importance="high"/>
+    <Message Text="Android: $(IsAndroid)" Importance="high"/>
+    <Message Text="iOS: $(IsIOS)" Importance="high"/>
+    <Message Text="Net6Mac: $(IsNet6Mac)" Importance="high"/>
+  </Target>
   <ItemGroup>
     <Content Condition="$([MSBuild]::IsOSPlatform('Windows')) OR '$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\win-x64\native\DevolutionsSspi.dll">
       <Link>runtimes\win-x64\native\DevolutionsSspi.dll</Link>
@@ -55,22 +61,6 @@
       <IncludeInVsix>true</IncludeInVsix>
       <Pack>false</Pack>
     </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\ios-x64\native\libDevolutionsSspi.dylib">
-      <Link>runtimes\ios-x64\native\libDevolutionsSspi.dylib</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
-    <Content Condition="'$(IsPowerShell)' == 'true'" Include="$(MSBuildThisFileDirectory)\..\runtimes\ios-arm64\native\libDevolutionsSspi.dylib">
-      <Link>runtimes\ios-arm64\native\libDevolutionsSspi.dylib</Link>
-      <PublishState>Included</PublishState>
-      <Visible>False</Visible>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVsix>true</IncludeInVsix>
-      <Pack>false</Pack>
-    </Content>
   </ItemGroup>
   <ItemGroup Condition="$(AndroidSupportedAbis.Contains('armeabi-v7a')) or $(RuntimeIdentifiers.Contains('android-arm'))">
       <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\..\runtimes\android-arm\native\libDevolutionsSspi.so">
@@ -95,7 +85,7 @@
           <Link>%(Filename)%(Extension)</Link>
           <Abi>x86_64</Abi>
       </AndroidNativeLibrary>
-  </ItemGroup> 
+  </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX')) AND '$(IsPowerShell)' != 'true' AND '$(IsIOS)' != 'true' AND '$(IsAndroid)' != 'true' AND '$(IsNet6Mac)' != 'true'">
     <NativeReference Include="$(MSBuildThisFileDirectory)\..\runtimes\osx-universal\native\libDevolutionsSspi.dylib">
       <Kind>Dynamic</Kind>


### PR DESCRIPTION
The ios-net6 build system packages _any_ dylibs it finds in the runtimes path, regardless of if they are referenced by the project build. This causes an issue for App Store uploads, where a dylib cannot be included in the final application bundle directly.

Since we aren't actually using the standalone .dylibs for iOS, I just remove them from the package.

Additionally, make some fixes for clarity in the .targets file.