### PR TITLE
ci: fix sspi-ffi test job for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
     name: Tests [${{ matrix.os }}] [${{ matrix.crate-name }}]
     runs-on: ${{ matrix.runner }}
     needs: formatting
+    env:
+      SSPI_RS_IS_RUNNING_TESTS: true
     strategy:
       fail-fast: true
       matrix:

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let is_running_tests = env::var("SSPI_RS_IS_RUNNING_TESTS").is_ok();
 
-    if target_os == "windows" {
+    if target_os == "windows" && !is_running_tests {
         // On Windows, we provide the linker with a .def file to rename exports.
         // This module definition file is used to rename some symbols
         // and avoid linkage conflicts with secur32.dll when building the library.


### PR DESCRIPTION
On Windows, we rename symbols using a .def file.
For that, we emit a cargo instruction.

> cargo:rustc-link-arg=/DEF:sspi.def

However, when attempting to run unit tests this causes an error.

```
Caused by:
  could not execute process `<redacted>` (never executed)

Caused by:
  %1 is not a valid Win32 application. (os error 193)
```

There is currently no built-in way to check if cargo is going to run the tests from the build.rs itself:
https://github.com/rust-lang/cargo/issues/4001

This commit adds a new environment variable that when set prevent the instruction emission.