### PR TITLE
fixes dns_query_srv_records() for MacOS

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -133,7 +133,6 @@ cfg_if::cfg_if! {
     if #[cfg(any(target_os="macos", target_os="ios"))] {
         use std::time::Duration;
         use std::thread;
-        use std::sync::mpsc::channel;
         use tokio::time::timeout;
         use tokio::runtime;
         use futures::stream::{StreamExt};

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
+use futures::FutureExt;
+
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         use windows::{
@@ -132,6 +134,8 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(any(target_os="macos", target_os="ios"))] {
         use std::time::Duration;
+        use std::thread;
+        use std::sync::mpsc::channel;
         use tokio::time::timeout;
         use tokio::runtime;
         use futures::stream::{StreamExt};
@@ -179,12 +183,9 @@ cfg_if::cfg_if! {
 
         pub fn dns_query_srv_records(name: &str) -> Vec<DnsSrvRecord> {
             let query_timeout = 1000;
-            let mut dns_records: Vec<DnsSrvRecord> = Vec::new();
-
-            let rt = runtime::Builder::new_current_thread().enable_all().build().unwrap();
-
-            rt.block_on(async {
-                let mut query = query_record(name, Type::SRV);
+            async fn query_with_timeout(name: String, query_timeout: u64) -> Vec<DnsSrvRecord> {
+                let mut dns_records: Vec<DnsSrvRecord> = Vec::new();
+                let mut query = query_record(&name, Type::SRV);
 
                 loop {
                     match timeout(Duration::from_millis(query_timeout), query.next()).await {
@@ -208,9 +209,35 @@ cfg_if::cfg_if! {
                         }
                     }
                 }
-            });
 
-            dns_records
+                dns_records
+            }
+
+            match runtime::Handle::try_current() {
+                Ok(handle) => {
+                    // Tokio runtime already exists, cannot block again on the same thread.
+                    // Spawn a new thread to run the blocking code.
+                    let (sender, receiver) = channel();
+                    let name = name.to_owned();
+                    thread::spawn(move || {
+                        let dns_records = handle.block_on(query_with_timeout(name, query_timeout));
+                        // Send the dns_records back to the main thread.
+                        sender.send(dns_records).unwrap();
+                    });
+
+                    // Wait for the dns_records to be sent back from the blocking thread.
+                    receiver.recv().unwrap()
+                },
+                Err(err) => {
+                    if err.is_missing_context() {
+                        // No existing tokio runtime context, block on a new one.
+                        let rt = runtime::Builder::new_current_thread().enable_all().build().unwrap();
+                        return rt.block_on(query_with_timeout(name.to_owned(), query_timeout));
+                    }
+                    // ThreadLocalDestroyed error should never happen.
+                    panic!("Unexpected error when trying to get current runtime: {}", err);
+                }
+            }
         }
 
         pub fn detect_kdc_hosts_from_dns_apple(domain: &str) -> Vec<String> {

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-use futures::FutureExt;
-
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         use windows::{
@@ -139,7 +137,7 @@ cfg_if::cfg_if! {
         use tokio::time::timeout;
         use tokio::runtime;
         use futures::stream::{StreamExt};
-        use async_dnssd::{query_record,QueryRecordResult,QueriedRecordFlags,Type};
+        use async_dnssd::{query_record, QueryRecordResult, QueriedRecordFlags, Type};
 
         #[derive(Clone)]
         pub struct DnsSrvRecord {


### PR DESCRIPTION
Makes it possible to call the MacOS version of dns_query_srv_records() from an existing tokio runtime.