### PR TITLE
fix(ffi): create log file if it does not exist

### DIFF
--- a/ffi/src/logging.rs
+++ b/ffi/src/logging.rs
@@ -18,7 +18,7 @@ pub fn setup_logger() {
             return;
         };
 
-        let file = match OpenOptions::new().read(true).append(true).open(path) {
+        let file = match OpenOptions::new().create(true).append(true).open(path) {
             Ok(f) => f,
             Err(e) => {
                 println!("[SSPI-DEBUG] Couldn’t open log file: {e}");


### PR DESCRIPTION
We probably want to create the file if it doesn’t already exist.