### PR TITLE
fix(ffi): Fix stack corruption on decrypt message

### DIFF
--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -1,6 +1,6 @@
 use std::slice::from_raw_parts;
 
-use libc::{c_ulong, c_ulonglong, c_void};
+use libc::{c_uint, c_ulong, c_ulonglong, c_void};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use sspi::credssp::SspiContext;
 use sspi::{
@@ -40,11 +40,11 @@ pub unsafe extern "system" fn AcceptSecurityContext(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_input: PSecBufferDesc,
-    f_context_req: c_ulong,
-    target_data_rep: c_ulong,
+    f_context_req: c_uint,
+    target_data_rep: c_uint,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut c_uint,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -102,11 +102,11 @@ pub type AcceptSecurityContextFn = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     PSecBufferDesc,
-    c_ulong,
-    c_ulong,
+    c_uint,
+    c_uint,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut c_uint,
     PTimeStamp,
 ) -> SecurityStatus;
 
@@ -295,11 +295,6 @@ pub unsafe extern "system" fn EncryptMessage(
 
 pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SecurityStatus;
 
-#[cfg(target_os = "windows")]
-pub type QualityOfProtection = libc::c_ulong;
-#[cfg(not(target_os = "windows"))]
-pub type QualityOfProtection = libc::c_uint;
-
 #[allow(clippy::useless_conversion)]
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_DecryptMessage"))]
@@ -308,7 +303,7 @@ pub unsafe extern "system" fn DecryptMessage(
     mut ph_context: PCtxtHandle,
     p_message: PSecBufferDesc,
     message_seq_no: c_ulong,
-    pf_qop: *mut QualityOfProtection,
+    pf_qop: *mut c_uint,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_context);
@@ -345,4 +340,4 @@ pub unsafe extern "system" fn DecryptMessage(
 }
 
 pub type DecryptMessageFn =
-    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut QualityOfProtection) -> SecurityStatus;
+    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_uint) -> SecurityStatus;

--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -295,6 +295,11 @@ pub unsafe extern "system" fn EncryptMessage(
 
 pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SecurityStatus;
 
+#[cfg(target_os = "windows")]
+pub type QualityOfProtection = libc::c_ulong;
+#[cfg(not(target_os = "windows"))]
+pub type QualityOfProtection = libc::c_uint;
+
 #[allow(clippy::useless_conversion)]
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_DecryptMessage"))]
@@ -303,7 +308,7 @@ pub unsafe extern "system" fn DecryptMessage(
     mut ph_context: PCtxtHandle,
     p_message: PSecBufferDesc,
     message_seq_no: c_ulong,
-    pf_qop: *mut c_ulong,
+    pf_qop: *mut QualityOfProtection,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_context);
@@ -340,4 +345,4 @@ pub unsafe extern "system" fn DecryptMessage(
 }
 
 pub type DecryptMessageFn =
-    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_ulong) -> SecurityStatus;
+    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut QualityOfProtection) -> SecurityStatus;

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 use std::mem::size_of;
 use std::slice::from_raw_parts;
 
-use libc::{c_ulong, c_ulonglong, c_void};
+use libc::{c_uint, c_ulong, c_ulonglong, c_void};
 use num_traits::{FromPrimitive, ToPrimitive};
 use sspi::builders::{ChangePasswordBuilder, EmptyInitializeSecurityContext};
 #[cfg(feature = "tsssp")]
@@ -322,14 +322,14 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecChar,
-    f_context_req: c_ulong,
+    f_context_req: c_uint,
     _reserved1: c_ulong,
-    target_data_rep: c_ulong,
+    target_data_rep: c_uint,
     p_input: PSecBufferDesc,
     _reserved2: c_ulong,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut c_uint,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -403,14 +403,14 @@ pub type InitializeSecurityContextFnA = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SecChar,
+    c_uint,
     c_ulong,
-    c_ulong,
-    c_ulong,
+    c_uint,
     PSecBufferDesc,
     c_ulong,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut c_uint,
     PTimeStamp,
 ) -> SecurityStatus;
 
@@ -422,14 +422,14 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecWChar,
-    f_context_req: c_ulong,
+    f_context_req: c_uint,
     _reserved1: c_ulong,
-    target_data_rep: c_ulong,
+    target_data_rep: c_uint,
     p_input: PSecBufferDesc,
     _reserved2: c_ulong,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut c_uint,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -502,14 +502,14 @@ pub type InitializeSecurityContextFnW = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SecWChar,
+    c_uint,
     c_ulong,
-    c_ulong,
-    c_ulong,
+    c_uint,
     PSecBufferDesc,
     c_ulong,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut c_uint,
     PTimeStamp,
 ) -> SecurityStatus;
 

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -384,7 +384,7 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
             .with_output(&mut output_tokens);
         let result_status = sspi_context.initialize_security_context_impl(&mut builder);
 
-        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req as u32);
+        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req);
         let allocate = context_requirements.contains(ClientRequestFlags::ALLOCATE_MEMORY);
 
         copy_to_c_sec_buffer((*p_output).p_buffers, &output_tokens, allocate);
@@ -483,7 +483,7 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
             .with_output(&mut output_tokens);
         let result_status = sspi_context.initialize_security_context_impl(&mut builder);
 
-        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req as u32);
+        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req);
         let allocate = context_requirements.contains(ClientRequestFlags::ALLOCATE_MEMORY);
 
         copy_to_c_sec_buffer((*p_output).p_buffers, &output_tokens, allocate);

--- a/ffi/src/sec_pkg_info.rs
+++ b/ffi/src/sec_pkg_info.rs
@@ -158,7 +158,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
 
         let packages = try_execute!(enumerate_security_packages());
 
-        *pc_packages = packages.len() as c_ulong;
+        *pc_packages = packages.len() as c_uint;
 
         let mut size = size_of::<SecPkgInfoA>() * packages.len();
 
@@ -217,7 +217,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
 
         let packages = try_execute!(enumerate_security_packages());
 
-        *pc_packages = packages.len() as c_ulong;
+        *pc_packages = packages.len() as c_uint;
 
         let mut size = size_of::<SecPkgInfoW>() * packages.len();
         let mut names = Vec::with_capacity(packages.len());

--- a/ffi/src/sec_pkg_info.rs
+++ b/ffi/src/sec_pkg_info.rs
@@ -149,7 +149,7 @@ pub struct SecNegoInfoA {
 #[cfg_attr(windows, rename_symbol(to = "Rust_EnumerateSecurityPackagesA"))]
 #[no_mangle]
 pub unsafe extern "system" fn EnumerateSecurityPackagesA(
-    pc_packages: *mut c_ulong,
+    pc_packages: *mut c_uint,
     pp_package_info: *mut PSecPkgInfoA,
 ) -> SecurityStatus {
     catch_panic! {
@@ -202,13 +202,13 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
     }
 }
 
-pub type EnumerateSecurityPackagesFnA = unsafe extern "system" fn(*mut c_ulong, *mut PSecPkgInfoA) -> SecurityStatus;
+pub type EnumerateSecurityPackagesFnA = unsafe extern "system" fn(*mut c_uint, *mut PSecPkgInfoA) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_EnumerateSecurityPackagesW"))]
 #[no_mangle]
 pub unsafe extern "system" fn EnumerateSecurityPackagesW(
-    pc_packages: *mut c_ulong,
+    pc_packages: *mut c_uint,
     pp_package_info: *mut *mut SecPkgInfoW,
 ) -> SecurityStatus {
     catch_panic! {
@@ -267,7 +267,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
     }
 }
 
-pub type EnumerateSecurityPackagesFnW = unsafe extern "system" fn(*mut c_ulong, *mut PSecPkgInfoW) -> SecurityStatus;
+pub type EnumerateSecurityPackagesFnW = unsafe extern "system" fn(*mut c_uint, *mut PSecPkgInfoW) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QuerySecurityPackageInfoA"))]


### PR DESCRIPTION
On Linux `c_ulong` is 8 bytes but `FreeRDP` provides a pointer to the 4-byte number. So, if we use c_ulong, we overwrite 4 bytes on the stack during the assigning. This PR fixes it. 
I refactored code to use just `c_uint` which is always 4 bytes wide instead of  `c_ulong`.