### PR TITLE
fix stack corruption on decrypt message

### DIFF
--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -40,11 +40,11 @@ pub unsafe extern "system" fn AcceptSecurityContext(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_input: PSecBufferDesc,
-    f_context_req: c_ulong,
-    target_data_rep: c_ulong,
+    f_context_req: u32,
+    target_data_rep: u32,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut u32,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -102,11 +102,11 @@ pub type AcceptSecurityContextFn = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     PSecBufferDesc,
-    c_ulong,
-    c_ulong,
+    u32,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SecurityStatus;
 
@@ -303,7 +303,7 @@ pub unsafe extern "system" fn DecryptMessage(
     mut ph_context: PCtxtHandle,
     p_message: PSecBufferDesc,
     message_seq_no: c_ulong,
-    pf_qop: *mut c_ulong,
+    pf_qop: *mut u32,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_context);
@@ -339,5 +339,4 @@ pub unsafe extern "system" fn DecryptMessage(
     }
 }
 
-pub type DecryptMessageFn =
-    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_ulong) -> SecurityStatus;
+pub type DecryptMessageFn = unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut u32) -> SecurityStatus;

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -322,14 +322,14 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecChar,
-    f_context_req: c_ulong,
+    f_context_req: u32,
     _reserved1: c_ulong,
-    target_data_rep: c_ulong,
+    target_data_rep: u32,
     p_input: PSecBufferDesc,
     _reserved2: c_ulong,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut u32,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -384,7 +384,7 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
             .with_output(&mut output_tokens);
         let result_status = sspi_context.initialize_security_context_impl(&mut builder);
 
-        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req as u32);
+        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req);
         let allocate = context_requirements.contains(ClientRequestFlags::ALLOCATE_MEMORY);
 
         copy_to_c_sec_buffer((*p_output).p_buffers, &output_tokens, allocate);
@@ -403,14 +403,14 @@ pub type InitializeSecurityContextFnA = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SecChar,
+    u32,
     c_ulong,
-    c_ulong,
-    c_ulong,
+    u32,
     PSecBufferDesc,
     c_ulong,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SecurityStatus;
 
@@ -422,14 +422,14 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
     ph_credential: PCredHandle,
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecWChar,
-    f_context_req: c_ulong,
+    f_context_req: u32,
     _reserved1: c_ulong,
-    target_data_rep: c_ulong,
+    target_data_rep: u32,
     p_input: PSecBufferDesc,
     _reserved2: c_ulong,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
-    pf_context_attr: *mut c_ulong,
+    pf_context_attr: *mut u32,
     _pts_expiry: PTimeStamp,
 ) -> SecurityStatus {
     catch_panic! {
@@ -483,7 +483,7 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
             .with_output(&mut output_tokens);
         let result_status = sspi_context.initialize_security_context_impl(&mut builder);
 
-        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req as u32);
+        let context_requirements = ClientRequestFlags::from_bits_unchecked(f_context_req);
         let allocate = context_requirements.contains(ClientRequestFlags::ALLOCATE_MEMORY);
 
         copy_to_c_sec_buffer((*p_output).p_buffers, &output_tokens, allocate);
@@ -502,14 +502,14 @@ pub type InitializeSecurityContextFnW = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SecWChar,
+    u32,
     c_ulong,
-    c_ulong,
-    c_ulong,
+    u32,
     PSecBufferDesc,
     c_ulong,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SecurityStatus;
 


### PR DESCRIPTION
Updated fix from https://github.com/Devolutions/sspi-rs/pull/124 to use u32 instead of c_uint, which guarantees us that an unsigned integer of 32-bit, same as ULONG on Windows. We aim to keep ABI stability with the SSPI API as if on Windows, and ULONG on Windows is always 32-bit, unlike "unsigned long" which can be 64-bit on non-Windows. This is just the updated fix, I will need to make a second pass to eliminate *all* usage of c_ulong in the current SSPI FFI, as there are many others that could explain why MemorySanitizer is still complaining when using sspi-rs in FreeRDP.