### PR TITLE
eliminate c_ulong, c_uint usage

### DIFF
--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -1,6 +1,6 @@
 use std::slice::from_raw_parts;
 
-use libc::{c_ulong, c_ulonglong, c_void};
+use libc::{c_ulonglong, c_void};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use sspi::credssp::SspiContext;
 use sspi::{
@@ -196,14 +196,14 @@ pub type RevertSecurityContextFn = extern "system" fn(PCtxtHandle) -> SecuritySt
 #[no_mangle]
 pub extern "system" fn MakeSignature(
     _ph_context: PCtxtHandle,
-    _f_qop: c_ulong,
+    _f_qop: u32,
     _p_message: PSecBufferDesc,
-    _message_seq_no: c_ulong,
+    _message_seq_no: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type MakeSignatureFn = extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SecurityStatus;
+pub type MakeSignatureFn = extern "system" fn(PCtxtHandle, u32, PSecBufferDesc, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_VerifySignature"))]
@@ -211,13 +211,13 @@ pub type MakeSignatureFn = extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDe
 pub extern "system" fn VerifySignature(
     _ph_context: PCtxtHandle,
     _message: PSecBufferDesc,
-    _message_seq_no: c_ulong,
-    _pf_qop: *mut c_ulong,
+    _message_seq_no: u32,
+    _pf_qop: *mut u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_ulong) -> SecurityStatus;
+pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, u32, *mut u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_FreeContextBuffer"))]
@@ -235,15 +235,14 @@ pub type FreeContextBufferFn = unsafe extern "system" fn(*mut c_void) -> Securit
 #[no_mangle]
 pub extern "system" fn ExportSecurityContext(
     _ph_context: PCtxtHandle,
-    _f_flags: c_ulong,
+    _f_flags: u32,
     _p_packed_context: PSecBuffer,
     _p_token: *mut *mut c_void,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type ExportSecurityContextFn =
-    extern "system" fn(PCtxtHandle, c_ulong, PSecBuffer, *mut *mut c_void) -> SecurityStatus;
+pub type ExportSecurityContextFn = extern "system" fn(PCtxtHandle, u32, PSecBuffer, *mut *mut c_void) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QuerySecurityContextToken"))]
@@ -260,9 +259,9 @@ pub type QuerySecurityContextTokenFn = extern "system" fn(PCtxtHandle, *mut *mut
 #[no_mangle]
 pub unsafe extern "system" fn EncryptMessage(
     mut ph_context: PCtxtHandle,
-    f_qop: c_ulong,
+    f_qop: u32,
     p_message: PSecBufferDesc,
-    message_seq_no: c_ulong,
+    message_seq_no: u32,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_context);
@@ -293,7 +292,7 @@ pub unsafe extern "system" fn EncryptMessage(
     }
 }
 
-pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SecurityStatus;
+pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, u32, PSecBufferDesc, u32) -> SecurityStatus;
 
 #[allow(clippy::useless_conversion)]
 #[instrument(skip_all)]
@@ -302,7 +301,7 @@ pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, c_ulong, PSec
 pub unsafe extern "system" fn DecryptMessage(
     mut ph_context: PCtxtHandle,
     p_message: PSecBufferDesc,
-    message_seq_no: c_ulong,
+    message_seq_no: u32,
     pf_qop: *mut u32,
 ) -> SecurityStatus {
     catch_panic! {
@@ -339,4 +338,4 @@ pub unsafe extern "system" fn DecryptMessage(
     }
 }
 
-pub type DecryptMessageFn = unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut u32) -> SecurityStatus;
+pub type DecryptMessageFn = unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, u32, *mut u32) -> SecurityStatus;

--- a/ffi/src/credentials_attributes.rs
+++ b/ffi/src/credentials_attributes.rs
@@ -1,4 +1,4 @@
-use libc::{c_uint, c_ulong, c_ushort};
+use libc::c_ushort;
 
 use crate::sspi_data_types::{SecChar, SecWChar};
 
@@ -42,8 +42,8 @@ impl CredentialsAttributes {
 
 #[repr(C)]
 pub struct SecPkgCredentialsKdcProxySettingsA {
-    pub version: c_uint,
-    pub flags: c_uint,
+    pub version: u32,
+    pub flags: u32,
     pub proxy_server_offset: c_ushort,
     pub proxy_server_length: c_ushort,
     pub client_tls_cred_offset: c_ushort,
@@ -52,8 +52,8 @@ pub struct SecPkgCredentialsKdcProxySettingsA {
 
 #[repr(C)]
 pub struct SecPkgCredentialsKdcProxySettingsW {
-    pub version: c_ulong,
-    pub flags: c_ulong,
+    pub version: u32,
+    pub flags: u32,
     pub proxy_server_offset: c_ushort,
     pub proxy_server_length: c_ushort,
     pub client_tls_cred_offset: c_ushort,

--- a/ffi/src/sec_buffer.rs
+++ b/ffi/src/sec_buffer.rs
@@ -2,46 +2,24 @@ use std::alloc::{alloc, Layout};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use libc::c_char;
-#[cfg(not(target_os = "windows"))]
-use libc::c_uint;
-#[cfg(target_os = "windows")]
-use libc::c_ulong;
 use num_traits::{FromPrimitive, ToPrimitive};
 use sspi::{SecurityBuffer, SecurityBufferType};
 
-#[cfg(target_os = "windows")]
-#[repr(C)]
-pub struct SecBuffer {
-    pub cb_buffer: c_ulong,
-    pub buffer_type: c_ulong,
-    pub pv_buffer: *mut c_char,
-}
-
-#[cfg(not(target_os = "windows"))]
 #[derive(Debug)]
 #[repr(C)]
 pub struct SecBuffer {
-    pub cb_buffer: c_uint,
-    pub buffer_type: c_uint,
+    pub cb_buffer: u32,
+    pub buffer_type: u32,
     pub pv_buffer: *mut c_char,
 }
 
 pub type PSecBuffer = *mut SecBuffer;
 
 #[derive(Debug)]
-#[cfg(target_os = "windows")]
 #[repr(C)]
 pub struct SecBufferDesc {
-    pub ul_version: c_ulong,
-    pub c_buffers: c_ulong,
-    pub p_buffers: PSecBuffer,
-}
-
-#[cfg(not(target_os = "windows"))]
-#[repr(C)]
-pub struct SecBufferDesc {
-    pub ul_version: c_uint,
-    pub c_buffers: c_uint,
+    pub ul_version: u32,
+    pub c_buffers: u32,
     pub p_buffers: PSecBuffer,
 }
 

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 use std::mem::size_of;
 use std::slice::from_raw_parts;
 
-use libc::{c_ulong, c_ulonglong, c_void};
+use libc::{c_ulonglong, c_void};
 use num_traits::{FromPrimitive, ToPrimitive};
 use sspi::builders::{ChangePasswordBuilder, EmptyInitializeSecurityContext};
 #[cfg(feature = "tsssp")]
@@ -68,11 +68,11 @@ pub const SECPKG_ATTR_CONNECTION_INFO: u32 = 0x5a;
 
 // Sets the name of a credential
 // In our library, we use this attribute to set the workstation for auth identity
-const SECPKG_CRED_ATTR_NAMES: c_ulong = 1;
+const SECPKG_CRED_ATTR_NAMES: u32 = 1;
 // Sets the Kerberos proxy setting
-const SECPKG_CRED_ATTR_KDC_PROXY_SETTINGS: c_ulong = 3;
+const SECPKG_CRED_ATTR_KDC_PROXY_SETTINGS: u32 = 3;
 
-const SECPKG_CRED_ATTR_KDC_URL: c_ulong = 501;
+const SECPKG_CRED_ATTR_KDC_URL: u32 = 501;
 
 #[repr(C)]
 pub struct SecHandle {
@@ -197,7 +197,7 @@ pub(crate) unsafe fn p_ctxt_handle_to_sspi_context(
 pub unsafe extern "system" fn AcquireCredentialsHandleA(
     _psz_principal: LpStr,
     psz_package: LpStr,
-    _f_aredential_use: c_ulong,
+    _f_aredential_use: u32,
     _pv_logon_id: *const c_void,
     p_auth_data: *const c_void,
     _p_get_key_fn: SecGetKeyFn,
@@ -231,7 +231,7 @@ pub unsafe extern "system" fn AcquireCredentialsHandleA(
 pub type AcquireCredentialsHandleFnA = unsafe extern "system" fn(
     LpStr,
     LpStr,
-    c_ulong,
+    u32,
     *const c_void,
     *const c_void,
     SecGetKeyFn,
@@ -246,7 +246,7 @@ pub type AcquireCredentialsHandleFnA = unsafe extern "system" fn(
 pub unsafe extern "system" fn AcquireCredentialsHandleW(
     _psz_principal: LpcWStr,
     psz_package: LpcWStr,
-    _f_credential_use: c_ulong,
+    _f_credential_use: u32,
     _pv_logon_id: *const c_void,
     p_auth_data: *const c_void,
     _p_get_key_fn: SecGetKeyFn,
@@ -279,7 +279,7 @@ pub unsafe extern "system" fn AcquireCredentialsHandleW(
 pub type AcquireCredentialsHandleFnW = unsafe extern "system" fn(
     LpcWStr,
     LpcWStr,
-    c_ulong,
+    u32,
     *const c_void,
     *const c_void,
     SecGetKeyFn,
@@ -293,26 +293,26 @@ pub type AcquireCredentialsHandleFnW = unsafe extern "system" fn(
 #[no_mangle]
 pub extern "system" fn QueryCredentialsAttributesA(
     _ph_credential: PCredHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryCredentialsAttributesFnA = extern "system" fn(PCredHandle, c_ulong, *mut c_void) -> SecurityStatus;
+pub type QueryCredentialsAttributesFnA = extern "system" fn(PCredHandle, u32, *mut c_void) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QueryCredentialsAttributesW"))]
 #[no_mangle]
 pub extern "system" fn QueryCredentialsAttributesW(
     _ph_credential: PCredHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryCredentialsAttributesFnW = extern "system" fn(PCredHandle, c_ulong, *mut c_void) -> SecurityStatus;
+pub type QueryCredentialsAttributesFnW = extern "system" fn(PCredHandle, u32, *mut c_void) -> SecurityStatus;
 
 #[allow(clippy::useless_conversion)]
 #[instrument(skip_all)]
@@ -323,10 +323,10 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecChar,
     f_context_req: u32,
-    _reserved1: c_ulong,
+    _reserved1: u32,
     target_data_rep: u32,
     p_input: PSecBufferDesc,
-    _reserved2: c_ulong,
+    _reserved2: u32,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
     pf_context_attr: *mut u32,
@@ -404,10 +404,10 @@ pub type InitializeSecurityContextFnA = unsafe extern "system" fn(
     PCtxtHandle,
     *const SecChar,
     u32,
-    c_ulong,
+    u32,
     u32,
     PSecBufferDesc,
-    c_ulong,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
     *mut u32,
@@ -423,10 +423,10 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
     mut ph_context: PCtxtHandle,
     p_target_name: *const SecWChar,
     f_context_req: u32,
-    _reserved1: c_ulong,
+    _reserved1: u32,
     target_data_rep: u32,
     p_input: PSecBufferDesc,
-    _reserved2: c_ulong,
+    _reserved2: u32,
     ph_new_context: PCtxtHandle,
     p_output: PSecBufferDesc,
     pf_context_attr: *mut u32,
@@ -503,10 +503,10 @@ pub type InitializeSecurityContextFnW = unsafe extern "system" fn(
     PCtxtHandle,
     *const SecWChar,
     u32,
-    c_ulong,
+    u32,
     u32,
     PSecBufferDesc,
-    c_ulong,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
     *mut u32,
@@ -516,7 +516,7 @@ pub type InitializeSecurityContextFnW = unsafe extern "system" fn(
 #[allow(clippy::useless_conversion)]
 unsafe fn query_context_attributes_common(
     mut ph_context: PCtxtHandle,
-    ul_attribute: c_ulong,
+    ul_attribute: u32,
     p_buffer: *mut c_void,
     is_wide: bool,
 ) -> SecurityStatus {
@@ -684,26 +684,26 @@ unsafe fn query_context_attributes_common(
 #[no_mangle]
 pub unsafe extern "system" fn QueryContextAttributesA(
     ph_context: PCtxtHandle,
-    ul_attribute: c_ulong,
+    ul_attribute: u32,
     p_buffer: *mut c_void,
 ) -> SecurityStatus {
     query_context_attributes_common(ph_context, ul_attribute, p_buffer, false)
 }
 
-pub type QueryContextAttributesFnA = unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void) -> SecurityStatus;
+pub type QueryContextAttributesFnA = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QueryContextAttributesW"))]
 #[no_mangle]
 pub unsafe extern "system" fn QueryContextAttributesW(
     ph_context: PCtxtHandle,
-    ul_attribute: c_ulong,
+    ul_attribute: u32,
     p_buffer: *mut c_void,
 ) -> SecurityStatus {
     query_context_attributes_common(ph_context, ul_attribute, p_buffer, true)
 }
 
-pub type QueryContextAttributesFnW = unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void) -> SecurityStatus;
+pub type QueryContextAttributesFnW = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_ImportSecurityContextA"))]
@@ -742,7 +742,7 @@ pub extern "system" fn AddCredentialsA(
     _ph_credential: PCredHandle,
     _s1: *mut SecChar,
     _s2: *mut SecChar,
-    _n1: c_ulong,
+    _n1: u32,
     _p1: *mut c_void,
     _f: SecGetKeyFn,
     _p2: *mut c_void,
@@ -755,7 +755,7 @@ pub type AddCredentialsFnA = extern "system" fn(
     PCredHandle,
     *mut SecChar,
     *mut SecChar,
-    c_ulong,
+    u32,
     *mut c_void,
     SecGetKeyFn,
     *mut c_void,
@@ -769,7 +769,7 @@ pub extern "system" fn AddCredentialsW(
     _ph_credential: PCredHandle,
     _s1: *mut SecWChar,
     _s2: *mut SecWChar,
-    _n1: c_ulong,
+    _n1: u32,
     _p1: *mut c_void,
     _f: SecGetKeyFn,
     _p2: *mut c_void,
@@ -782,7 +782,7 @@ pub type AddCredentialsFnW = extern "system" fn(
     PCredHandle,
     *mut SecWChar,
     *mut SecWChar,
-    c_ulong,
+    u32,
     *mut c_void,
     SecGetKeyFn,
     *mut c_void,
@@ -794,36 +794,36 @@ pub type AddCredentialsFnW = extern "system" fn(
 #[no_mangle]
 pub extern "system" fn SetContextAttributesA(
     _ph_context: PCtxtHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type SetContextAttributesFnA = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type SetContextAttributesFnA = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SetContextAttributesW"))]
 #[no_mangle]
 pub extern "system" fn SetContextAttributesW(
     _ph_context: PCtxtHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type SetContextAttributesFnW = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type SetContextAttributesFnW = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_SetCredentialsAttributesA"))]
 #[no_mangle]
 pub unsafe extern "system" fn SetCredentialsAttributesA(
     ph_credential: PCtxtHandle,
-    ul_attribute: c_ulong,
+    ul_attribute: u32,
     p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_credential);
@@ -879,17 +879,16 @@ pub unsafe extern "system" fn SetCredentialsAttributesA(
     }
 }
 
-pub type SetCredentialsAttributesFnA =
-    unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type SetCredentialsAttributesFnA = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_SetCredentialsAttributesW"))]
 #[no_mangle]
 pub unsafe extern "system" fn SetCredentialsAttributesW(
     ph_credential: PCtxtHandle,
-    ul_attribute: c_ulong,
+    ul_attribute: u32,
     p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     catch_panic! {
         check_null!(ph_credential);
@@ -938,8 +937,7 @@ pub unsafe extern "system" fn SetCredentialsAttributesW(
     }
 }
 
-pub type SetCredentialsAttributesFnW =
-    unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type SetCredentialsAttributesFnW = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_ChangeAccountPasswordA"))]
@@ -951,7 +949,7 @@ pub unsafe extern "system" fn ChangeAccountPasswordA(
     psz_old_password: *mut SecChar,
     psz_new_password: *mut SecChar,
     _b_impersonating: bool,
-    _dw_reserved: c_ulong,
+    _dw_reserved: u32,
     p_output: PSecBufferDesc,
 ) -> SecurityStatus {
     catch_panic! {
@@ -1022,7 +1020,7 @@ pub type ChangeAccountPasswordFnA = unsafe extern "system" fn(
     *mut SecChar,
     *mut SecChar,
     bool,
-    c_ulong,
+    u32,
     PSecBufferDesc,
 ) -> SecurityStatus;
 
@@ -1036,7 +1034,7 @@ pub unsafe extern "system" fn ChangeAccountPasswordW(
     psz_old_password: *mut SecWChar,
     psz_new_password: *mut SecWChar,
     b_impersonating: bool,
-    dw_reserved: c_ulong,
+    dw_reserved: u32,
     p_output: PSecBufferDesc,
 ) -> SecurityStatus {
     catch_panic! {
@@ -1074,7 +1072,7 @@ pub type ChangeAccountPasswordFnW = unsafe extern "system" fn(
     *mut SecWChar,
     *mut SecWChar,
     bool,
-    c_ulong,
+    u32,
     PSecBufferDesc,
 ) -> SecurityStatus;
 
@@ -1083,55 +1081,53 @@ pub type ChangeAccountPasswordFnW = unsafe extern "system" fn(
 #[no_mangle]
 pub extern "system" fn QueryContextAttributesExA(
     _ph_context: PCtxtHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryContextAttributesExFnA = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type QueryContextAttributesExFnA = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QueryContextAttributesExW"))]
 #[no_mangle]
 pub extern "system" fn QueryContextAttributesExW(
     _ph_context: PCtxtHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _cb_buffer: c_ulong,
+    _cb_buffer: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryContextAttributesExFnW = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type QueryContextAttributesExFnW = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QueryCredentialsAttributesExA"))]
 #[no_mangle]
 pub extern "system" fn QueryCredentialsAttributesExA(
     _ph_credential: PCredHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _c_buffers: c_ulong,
+    _c_buffers: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryCredentialsAttributesExFnA =
-    extern "system" fn(PCredHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type QueryCredentialsAttributesExFnA = extern "system" fn(PCredHandle, u32, *mut c_void, u32) -> SecurityStatus;
 
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_QueryCredentialsAttributesExW"))]
 #[no_mangle]
 pub extern "system" fn QueryCredentialsAttributesExW(
     _ph_aredential: PCredHandle,
-    _ul_attribute: c_ulong,
+    _ul_attribute: u32,
     _p_buffer: *mut c_void,
-    _c_buffers: c_ulong,
+    _c_buffers: u32,
 ) -> SecurityStatus {
     ErrorKind::UnsupportedFunction.to_u32().unwrap()
 }
 
-pub type QueryCredentialsAttributesExFnW =
-    extern "system" fn(PCredHandle, c_ulong, *mut c_void, c_ulong) -> SecurityStatus;
+pub type QueryCredentialsAttributesExFnW = extern "system" fn(PCredHandle, u32, *mut c_void, u32) -> SecurityStatus;

--- a/ffi/src/security_tables.rs
+++ b/ffi/src/security_tables.rs
@@ -2,7 +2,7 @@
 
 use std::ptr::null;
 
-use libc::{c_ulong, c_void};
+use libc::c_void;
 use sspi::KERBEROS_VERSION;
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
@@ -37,7 +37,7 @@ use crate::utils::into_raw_ptr;
 
 #[repr(C)]
 pub struct SecurityFunctionTableA {
-    pub dwVersion: c_ulong,
+    pub dwVersion: u32,
     pub EnumerateSecurityPackagesA: EnumerateSecurityPackagesFnA,
     pub QueryCredentialsAttributesA: QueryCredentialsAttributesFnA,
     pub AcquireCredentialsHandleA: AcquireCredentialsHandleFnA,
@@ -78,7 +78,7 @@ pub type PSecurityFunctionTableA = *mut SecurityFunctionTableA;
 
 #[repr(C)]
 pub struct SecurityFunctionTableW {
-    pub dwVersion: c_ulong,
+    pub dwVersion: u32,
     pub EnumerateSecurityPackagesW: EnumerateSecurityPackagesFnW,
     pub QueryCredentialsAttributesW: QueryCredentialsAttributesFnW,
     pub AcquireCredentialsHandleW: AcquireCredentialsHandleFnW,
@@ -124,7 +124,7 @@ pub extern "system" fn InitSecurityInterfaceA() -> PSecurityFunctionTableA {
     crate::logging::setup_logger();
 
     into_raw_ptr(SecurityFunctionTableA {
-        dwVersion: KERBEROS_VERSION as c_ulong,
+        dwVersion: KERBEROS_VERSION as u32,
         EnumerateSecurityPackagesA,
         QueryCredentialsAttributesA,
         AcquireCredentialsHandleA,
@@ -167,7 +167,7 @@ pub extern "system" fn InitSecurityInterfaceW() -> PSecurityFunctionTableW {
     crate::logging::setup_logger();
 
     into_raw_ptr(SecurityFunctionTableW {
-        dwVersion: KERBEROS_VERSION as c_ulong,
+        dwVersion: KERBEROS_VERSION as u32,
         EnumerateSecurityPackagesW,
         QueryCredentialsAttributesW,
         AcquireCredentialsHandleW,

--- a/ffi/src/sspi_data_types.rs
+++ b/ffi/src/sspi_data_types.rs
@@ -1,4 +1,4 @@
-use libc::{c_char, c_long, c_uint, c_ulong, c_ushort, c_void};
+use libc::{c_char, c_ushort, c_void};
 use sspi::CertTrustStatus as SspiCertTrustStatus;
 
 pub type SecChar = c_char;
@@ -13,8 +13,8 @@ pub type SecurityStatus = u32;
 
 #[repr(C)]
 pub struct SecurityInteger {
-    pub low_part: c_ulong,
-    pub high_part: c_long,
+    pub low_part: u32,
+    pub high_part: i32,
 }
 
 pub type PTimeStamp = *mut SecurityInteger;
@@ -28,22 +28,12 @@ pub struct SecurityString {
 
 pub type PSecurityString = *mut SecurityString;
 
-#[cfg(target_os = "windows")]
 #[repr(C)]
 pub struct SecPkgContextSizes {
-    pub cb_max_token: c_ulong,
-    pub cb_max_signature: c_ulong,
-    pub cb_block_size: c_ulong,
-    pub cb_security_trailer: c_ulong,
-}
-
-#[cfg(not(target_os = "windows"))]
-#[repr(C)]
-pub struct SecPkgContextSizes {
-    pub cb_max_token: c_uint,
-    pub cb_max_signature: c_uint,
-    pub cb_block_size: c_uint,
-    pub cb_security_trailer: c_uint,
+    pub cb_max_token: u32,
+    pub cb_max_signature: u32,
+    pub cb_block_size: u32,
+    pub cb_security_trailer: u32,
 }
 
 /// [SecPkgContext_StreamSizes](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secpkgcontext_streamsizes)
@@ -57,24 +47,13 @@ pub struct SecPkgContextSizes {
 ///   unsigned long cbBlockSize;
 /// } SecPkgContext_StreamSizes, *PSecPkgContext_StreamSizes;
 /// ```
-#[cfg(target_os = "windows")]
 #[repr(C)]
 pub struct SecPkgContextStreamSizes {
-    pub cb_header: c_ulong,
-    pub cb_trailer: c_ulong,
-    pub cb_maximum_message: c_ulong,
-    pub c_buffers: c_ulong,
-    pub cb_block_size: c_ulong,
-}
-
-#[cfg(not(target_os = "windows"))]
-#[repr(C)]
-pub struct SecPkgContextStreamSizes {
-    pub cb_header: c_uint,
-    pub cb_trailer: c_uint,
-    pub cb_maximum_message: c_uint,
-    pub c_buffers: c_uint,
-    pub cb_block_size: c_uint,
+    pub cb_header: u32,
+    pub cb_trailer: u32,
+    pub cb_maximum_message: u32,
+    pub c_buffers: u32,
+    pub cb_block_size: u32,
 }
 
 pub type SecGetKeyFn = extern "system" fn(*mut c_void, *mut c_void, u32, *mut *mut c_void, *mut i32);
@@ -88,12 +67,12 @@ pub type SecGetKeyFn = extern "system" fn(*mut c_void, *mut c_void, u32, *mut *m
 /// ```
 #[repr(C)]
 pub struct SecPkgContextFlags {
-    pub flags: c_ulong,
+    pub flags: u32,
 }
 
 /// [ALG_ID](https://learn.microsoft.com/en-us/windows/win32/seccrypto/alg-id)
 /// typedef unsigned int ALG_ID;
-pub type AlgId = c_uint;
+pub type AlgId = u32;
 
 /// [_SecPkgContext_ConnectionInfo](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-secpkgcontext_connectioninfo)
 ///

--- a/src/winapi/mod.rs
+++ b/src/winapi/mod.rs
@@ -7,7 +7,7 @@ use std::{io, ptr, slice};
 
 use chrono::{NaiveDate, NaiveDateTime};
 use num_traits::{FromPrimitive, ToPrimitive};
-use winapi::ctypes::{c_ulong, c_void};
+use winapi::ctypes::c_void;
 use winapi::shared::sspi::{
     CredHandle, FreeContextBuffer, FreeCredentialsHandle, PSecPkgInfoW, QuerySecurityPackageInfoW, SecBuffer,
     SecBufferDesc, SecPkgInfoW, TimeStamp, SECBUFFER_VERSION,
@@ -21,7 +21,7 @@ use crate::{
     PackageCapabilities, PackageInfo, SecurityBuffer, SecurityBufferType, SecurityPackageType, SecurityStatus,
 };
 
-const SEC_WINNT_AUTH_IDENTITY_UNICODE: c_ulong = 0x2;
+const SEC_WINNT_AUTH_IDENTITY_UNICODE: u32 = 0x2;
 
 /// Retrieves information about a specified security package. This information includes credentials and contexts.
 ///
@@ -112,7 +112,7 @@ impl From<&mut SecurityBuffer> for SecBuffer {
     fn from(b: &mut SecurityBuffer) -> Self {
         Self {
             BufferType: b.buffer_type.to_u32().unwrap(),
-            cbBuffer: b.buffer.len() as c_ulong,
+            cbBuffer: b.buffer.len() as u32,
             pvBuffer: b.buffer.as_mut_ptr() as *mut c_void,
         }
     }
@@ -189,7 +189,7 @@ impl From<&PackageInfo> for SecPkgInfoW {
 fn construct_buffer_desc(sec_buffers: &mut [SecBuffer]) -> SecBufferDesc {
     SecBufferDesc {
         ulVersion: SECBUFFER_VERSION,
-        cBuffers: sec_buffers.len() as c_ulong,
+        cBuffers: sec_buffers.len() as u32,
         pBuffers: sec_buffers.as_mut_ptr(),
     }
 }

--- a/tools/sspi-ffi-attacker/src/types.rs
+++ b/tools/sspi-ffi-attacker/src/types.rs
@@ -1,53 +1,33 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use libc::{c_char, c_long, c_uint, c_ulong, c_ushort, c_void};
+use libc::{c_char, c_ushort, c_void};
 
 pub type SEC_GET_KEY_FN = *mut c_void;
 
 #[repr(C)]
 pub struct SECURITY_INTEGER {
-    pub low_part: c_ulong,
-    pub high_part: c_long,
+    pub low_part: u32,
+    pub high_part: i32,
 }
 
 pub type PTimeStamp = *mut SECURITY_INTEGER;
 
-#[cfg(target_os = "windows")]
 #[derive(Debug)]
 #[repr(C)]
 pub struct SecBuffer {
-    pub cb_buffer: c_ulong,
-    pub buffer_type: c_ulong,
-    pub pv_buffer: *mut c_char,
-}
-
-#[cfg(not(target_os = "windows"))]
-#[derive(Debug)]
-#[repr(C)]
-pub struct SecBuffer {
-    pub cb_buffer: c_uint,
-    pub buffer_type: c_uint,
+    pub cb_buffer: u32,
+    pub buffer_type: u32,
     pub pv_buffer: *mut c_char,
 }
 
 type PSecBuffer = *mut SecBuffer;
 
 #[derive(Debug)]
-#[cfg(target_os = "windows")]
 #[repr(C)]
 pub struct SecBufferDesc {
-    pub ul_version: c_ulong,
-    pub c_buffers: c_ulong,
-    pub p_buffers: PSecBuffer,
-}
-
-#[derive(Debug)]
-#[cfg(not(target_os = "windows"))]
-#[repr(C)]
-pub struct SecBufferDesc {
-    pub ul_version: c_uint,
-    pub c_buffers: c_uint,
+    pub ul_version: u32,
+    pub c_buffers: u32,
     pub p_buffers: PSecBuffer,
 }
 
@@ -69,10 +49,10 @@ pub type PCtxtHandle = *mut CtxtHandle;
 #[derive(Debug)]
 #[repr(C)]
 pub struct SecPkgInfoA {
-    pub fCapabilities: c_uint,
+    pub fCapabilities: u32,
     pub wVersion: c_ushort,
     pub wRPCID: c_ushort,
-    pub cbMaxToken: c_uint,
+    pub cbMaxToken: u32,
     pub Name: *mut SEC_CHAR,
     pub Comment: *mut SEC_CHAR,
 }
@@ -81,10 +61,10 @@ pub type PSecPkgInfoA = *mut SecPkgInfoA;
 #[derive(Debug)]
 #[repr(C)]
 pub struct SecPkgInfoW {
-    pub fCapabilities: c_ulong,
+    pub fCapabilities: u32,
     pub wVersion: c_ushort,
     pub wRPCID: c_ushort,
-    pub cbMaxToken: c_ulong,
+    pub cbMaxToken: u32,
     pub Name: *mut SEC_WCHAR,
     pub Comment: *mut SEC_WCHAR,
 }
@@ -97,16 +77,16 @@ pub type LPSTR = *mut SEC_CHAR;
 pub type LPWSTR = *mut WCHAR;
 pub type SECURITY_STATUS = u32;
 
-pub type EnumerateSecurityPackagesFnW = unsafe extern "system" fn(*mut c_ulong, *mut PSecPkgInfoW) -> SECURITY_STATUS;
-pub type EnumerateSecurityPackagesFnA = unsafe extern "system" fn(*mut c_ulong, *mut PSecPkgInfoA) -> SECURITY_STATUS;
+pub type EnumerateSecurityPackagesFnW = unsafe extern "system" fn(*mut u32, *mut PSecPkgInfoW) -> SECURITY_STATUS;
+pub type EnumerateSecurityPackagesFnA = unsafe extern "system" fn(*mut u32, *mut PSecPkgInfoA) -> SECURITY_STATUS;
 
-pub type QueryCredentialsAttributesFnW = extern "system" fn(PCredHandle, c_ulong, *mut c_void) -> SECURITY_STATUS;
-pub type QueryCredentialsAttributesFnA = extern "system" fn(PCredHandle, c_ulong, *mut c_void) -> SECURITY_STATUS;
+pub type QueryCredentialsAttributesFnW = extern "system" fn(PCredHandle, u32, *mut c_void) -> SECURITY_STATUS;
+pub type QueryCredentialsAttributesFnA = extern "system" fn(PCredHandle, u32, *mut c_void) -> SECURITY_STATUS;
 
 pub type AcquireCredentialsHandleFnW = unsafe extern "system" fn(
     LPWSTR,
     LPWSTR,
-    c_ulong,
+    u32,
     *const c_void,
     *const c_void,
     SEC_GET_KEY_FN,
@@ -117,7 +97,7 @@ pub type AcquireCredentialsHandleFnW = unsafe extern "system" fn(
 pub type AcquireCredentialsHandleFnA = unsafe extern "system" fn(
     LPSTR,
     LPSTR,
-    c_ulong,
+    u32,
     *const c_void,
     *const c_void,
     SEC_GET_KEY_FN,
@@ -132,28 +112,28 @@ pub type InitializeSecurityContextFnW = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SEC_WCHAR,
-    c_ulong,
-    c_ulong,
-    c_ulong,
+    u32,
+    u32,
+    u32,
     PSecBufferDesc,
-    c_ulong,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SECURITY_STATUS;
 pub type InitializeSecurityContextFnA = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     *const SEC_CHAR,
-    c_ulong,
-    c_ulong,
-    c_ulong,
+    u32,
+    u32,
+    u32,
     PSecBufferDesc,
-    c_ulong,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SECURITY_STATUS;
 
@@ -161,11 +141,11 @@ pub type AcceptSecurityContextFn = unsafe extern "system" fn(
     PCredHandle,
     PCtxtHandle,
     PSecBufferDesc,
-    c_ulong,
-    c_ulong,
+    u32,
+    u32,
     PCtxtHandle,
     PSecBufferDesc,
-    *mut c_ulong,
+    *mut u32,
     PTimeStamp,
 ) -> SECURITY_STATUS;
 
@@ -175,16 +155,16 @@ pub type DeleteSecurityContextFn = unsafe extern "system" fn(PCtxtHandle) -> SEC
 
 pub type ApplyControlTokenFn = extern "system" fn(PCtxtHandle, PSecBufferDesc) -> SECURITY_STATUS;
 
-pub type QueryContextAttributesFnW = unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void) -> SECURITY_STATUS;
-pub type QueryContextAttributesFnA = unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void) -> SECURITY_STATUS;
+pub type QueryContextAttributesFnW = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void) -> SECURITY_STATUS;
+pub type QueryContextAttributesFnA = unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void) -> SECURITY_STATUS;
 
 pub type ImpersonateSecurityContextFn = extern "system" fn(PCtxtHandle) -> SECURITY_STATUS;
 
 pub type RevertSecurityContextFn = extern "system" fn(PCtxtHandle) -> SECURITY_STATUS;
 
-pub type MakeSignatureFn = extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SECURITY_STATUS;
+pub type MakeSignatureFn = extern "system" fn(PCtxtHandle, u32, PSecBufferDesc, u32) -> SECURITY_STATUS;
 
-pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_ulong) -> SECURITY_STATUS;
+pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, u32, *mut u32) -> SECURITY_STATUS;
 
 pub type FreeContextBufferFn = unsafe extern "system" fn(*mut c_void) -> SECURITY_STATUS;
 
@@ -193,7 +173,7 @@ pub type QuerySecurityPackageInfoFnW =
 pub type QuerySecurityPackageInfoFnA = unsafe extern "system" fn(*const SEC_CHAR, *mut PSecPkgInfoA) -> SECURITY_STATUS;
 
 pub type ExportSecurityContextFn =
-    extern "system" fn(PCtxtHandle, c_ulong, PSecBuffer, *mut *mut c_void) -> SECURITY_STATUS;
+    extern "system" fn(PCtxtHandle, u32, PSecBuffer, *mut *mut c_void) -> SECURITY_STATUS;
 
 pub type ImportSecurityContextFnW = extern "system" fn(LPWSTR, PSecBuffer, *mut c_void, PCtxtHandle) -> SECURITY_STATUS;
 pub type ImportSecurityContextFnA = extern "system" fn(LPSTR, PSecBuffer, *mut c_void, PCtxtHandle) -> SECURITY_STATUS;
@@ -202,7 +182,7 @@ pub type AddCredentialsFnW = extern "system" fn(
     PCredHandle,
     *mut SEC_WCHAR,
     *mut SEC_WCHAR,
-    c_ulong,
+    u32,
     *mut c_void,
     SEC_GET_KEY_FN,
     *mut c_void,
@@ -212,7 +192,7 @@ pub type AddCredentialsFnA = extern "system" fn(
     PCredHandle,
     *mut SEC_CHAR,
     *mut SEC_CHAR,
-    c_ulong,
+    u32,
     *mut c_void,
     SEC_GET_KEY_FN,
     *mut c_void,
@@ -221,18 +201,18 @@ pub type AddCredentialsFnA = extern "system" fn(
 
 pub type QuerySecurityContextTokenFn = extern "system" fn(PCtxtHandle, *mut *mut c_void) -> SECURITY_STATUS;
 
-pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, c_ulong, PSecBufferDesc, c_ulong) -> SECURITY_STATUS;
+pub type EncryptMessageFn = unsafe extern "system" fn(PCtxtHandle, u32, PSecBufferDesc, u32) -> SECURITY_STATUS;
 
 pub type DecryptMessageFn =
-    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, c_ulong, *mut c_ulong) -> SECURITY_STATUS;
+    unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, u32, *mut u32) -> SECURITY_STATUS;
 
-pub type SetContextAttributesFnW = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
-pub type SetContextAttributesFnA = extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+pub type SetContextAttributesFnW = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
+pub type SetContextAttributesFnA = extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 
 pub type SetCredentialsAttributesFnW =
-    unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 pub type SetCredentialsAttributesFnA =
-    unsafe extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    unsafe extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 
 pub type ChangeAccountPasswordFnW = unsafe extern "system" fn(
     *mut SEC_WCHAR,
@@ -241,7 +221,7 @@ pub type ChangeAccountPasswordFnW = unsafe extern "system" fn(
     *mut SEC_WCHAR,
     *mut SEC_WCHAR,
     bool,
-    c_ulong,
+    u32,
     PSecBufferDesc,
 ) -> SECURITY_STATUS;
 pub type ChangeAccountPasswordFnA = unsafe extern "system" fn(
@@ -251,19 +231,19 @@ pub type ChangeAccountPasswordFnA = unsafe extern "system" fn(
     *mut SEC_CHAR,
     *mut SEC_CHAR,
     bool,
-    c_ulong,
+    u32,
     PSecBufferDesc,
 ) -> SECURITY_STATUS;
 
 pub type QueryContextAttributesExFnW =
-    extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 pub type QueryContextAttributesExFnA =
-    extern "system" fn(PCtxtHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    extern "system" fn(PCtxtHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 
 pub type QueryCredentialsAttributesExFnW =
-    extern "system" fn(PCredHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    extern "system" fn(PCredHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 pub type QueryCredentialsAttributesExFnA =
-    extern "system" fn(PCredHandle, c_ulong, *mut c_void, c_ulong) -> SECURITY_STATUS;
+    extern "system" fn(PCredHandle, u32, *mut c_void, u32) -> SECURITY_STATUS;
 
 pub type SspiEncodeStringsAsAuthIdentityFn =
     extern "system" fn(*const SEC_WCHAR, *const SEC_WCHAR, *const SEC_WCHAR, *mut *mut c_void) -> SECURITY_STATUS;
@@ -294,7 +274,7 @@ pub struct SecWinntAuthIdentityW {
 
 #[repr(C)]
 pub struct SecurityFunctionTableA {
-    pub dwVersion: c_ulong,
+    pub dwVersion: u32,
     pub EnumerateSecurityPackagesA: EnumerateSecurityPackagesFnA,
     pub QueryCredentialsAttributesA: QueryCredentialsAttributesFnA,
     pub AcquireCredentialsHandleA: AcquireCredentialsHandleFnA,
@@ -335,7 +315,7 @@ pub type InitSecurityInterfaceA = extern "system" fn() -> PSecurityFunctionTable
 
 #[repr(C)]
 pub struct SecurityFunctionTableW {
-    pub dwVersion: c_ulong,
+    pub dwVersion: u32,
     pub EnumerateSecurityPackagesW: EnumerateSecurityPackagesFnW,
     pub QueryCredentialsAttributesW: QueryCredentialsAttributesFnW,
     pub AcquireCredentialsHandleW: AcquireCredentialsHandleFnW,


### PR DESCRIPTION
yeet c_ulong, c_uint usage into the sun, including conditional Windows/non-Windows definitions meant to ensure an unsigned integer of 32-bits on all platforms, and use u32 consistently for all platforms. ULONG / unsigned long on Windows is always 32-bit and FreeRDP maintains this ABI property everywhere, there is no point in going with the unsigned long C type which sometimes grows to 64-bits like on Linux.