### PR TITLE
Fix usage of Kerberos use-session-key flag with KRB5 U2U

### DIFF
--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -5,7 +5,7 @@
     <Description>Portable Rust SSPI library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2023.6.5.0</Version>
+    <Version>2023.6.7.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -557,9 +557,9 @@ pub fn generate_neg_token_init(username: &str, service_name: &str) -> Result<App
     }))
 }
 
-pub fn generate_neg_ap_req(ap_req: ApReq) -> Result<ExplicitContextTag1<NegTokenTarg>> {
+pub fn generate_neg_ap_req(ap_req: ApReq, mech_id: oid::ObjectIdentifier) -> Result<ExplicitContextTag1<NegTokenTarg>> {
     let krb_blob: ApplicationTag<_, 0> = ApplicationTag(KrbMessage {
-        krb5_oid: ObjectIdentifierAsn1::from(oids::krb5_user_to_user()),
+        krb5_oid: ObjectIdentifierAsn1::from(mech_id),
         krb5_token_id: AP_REQ_TOKEN_ID,
         krb_msg: ap_req,
     });


### PR DESCRIPTION
KRB5 U2U (1.2.840.113554.1.2.2.3) requires the use-session-key flag, but FreeRDP doesn't explicitly set ISC_REQ_USE_SESSION_KEY in the InitializeSecurityContext flags. mstsc always sets ISC_REQ_USE_SESSION_KEY, but also always selects KRB5 U2U. With FreeRDP + Windows SSPI, it looks like setting ISC_REQ_USE_SESSION_KEY forces KRB5 U2U, while not setting it defaults to regular Kerberos. The FreeRDP WinPR Kerberos implementation sets the use-session-key flag based on the negotiated mech id (U2U or not) rather than expect the ISC_REQ_USE_SESSION_KEY flag to be passed to the Negotiate module. We're going for a similar fix on our side, and I suspect we may only support KRB5 U2U at this point anyway.