### PR TITLE
refactor(network_client): Refactor NetworkClient trait

### DIFF
--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -92,7 +92,7 @@ fn create_negotiate_context(attributes: &CredentialsAttributes) -> Result<Negoti
 
     if let Some(kdc_url) = attributes.kdc_url() {
         let kerberos_config =
-            KerberosConfig::new(&kdc_url, Box::new(ReqwestNetworkClient::default()), hostname.clone());
+            KerberosConfig::new(&kdc_url, Box::<ReqwestNetworkClient>::default(), hostname.clone());
         let negotiate_config = NegotiateConfig::new(
             Box::new(kerberos_config),
             attributes.package_list.clone(),
@@ -155,7 +155,7 @@ pub(crate) unsafe fn p_ctxt_handle_to_sspi_context(
                 if let Some(kdc_url) = attributes.kdc_url() {
                     SspiContext::Kerberos(Kerberos::new_client_from_config(KerberosConfig::new(
                         &kdc_url,
-                        Box::new(ReqwestNetworkClient::default()),
+                        Box::<ReqwestNetworkClient>::default(),
                         hostname,
                     ))?)
                 } else {

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -91,8 +91,7 @@ fn create_negotiate_context(attributes: &CredentialsAttributes) -> Result<Negoti
     let hostname = attributes.workstation.clone().unwrap_or_else(whoami::hostname);
 
     if let Some(kdc_url) = attributes.kdc_url() {
-        let kerberos_config =
-            KerberosConfig::new(&kdc_url, Box::<ReqwestNetworkClient>::default(), hostname.clone());
+        let kerberos_config = KerberosConfig::new(&kdc_url, Box::<ReqwestNetworkClient>::default(), hostname.clone());
         let negotiate_config = NegotiateConfig::new(
             Box::new(kerberos_config),
             attributes.package_list.clone(),

--- a/ffi/src/sec_handle.rs
+++ b/ffi/src/sec_handle.rs
@@ -91,7 +91,8 @@ fn create_negotiate_context(attributes: &CredentialsAttributes) -> Result<Negoti
     let hostname = attributes.workstation.clone().unwrap_or_else(whoami::hostname);
 
     if let Some(kdc_url) = attributes.kdc_url() {
-        let kerberos_config = KerberosConfig::new(&kdc_url, Box::new(ReqwestNetworkClient::new()), hostname.clone());
+        let kerberos_config =
+            KerberosConfig::new(&kdc_url, Box::new(ReqwestNetworkClient::default()), hostname.clone());
         let negotiate_config = NegotiateConfig::new(
             Box::new(kerberos_config),
             attributes.package_list.clone(),
@@ -154,7 +155,7 @@ pub(crate) unsafe fn p_ctxt_handle_to_sspi_context(
                 if let Some(kdc_url) = attributes.kdc_url() {
                     SspiContext::Kerberos(Kerberos::new_client_from_config(KerberosConfig::new(
                         &kdc_url,
-                        Box::new(ReqwestNetworkClient::new()),
+                        Box::new(ReqwestNetworkClient::default()),
                         hostname,
                     ))?)
                 } else {

--- a/src/kerberos/config.rs
+++ b/src/kerberos/config.rs
@@ -72,8 +72,7 @@ impl KerberosConfig {
     pub fn from_env() -> Self {
         use crate::network_client::reqwest_network_client::ReqwestNetworkClient;
 
-        let network_client = Box::new(ReqwestNetworkClient::new());
-        Self::new_with_network_client(network_client)
+        Self::new_with_network_client(Box::<ReqwestNetworkClient>::default())
     }
 
     pub fn from_kdc_url(url: &str, network_client: Box<dyn NetworkClient>) -> Self {
@@ -96,7 +95,7 @@ impl Clone for KerberosConfig {
     fn clone(&self) -> Self {
         Self {
             url: self.url.clone(),
-            network_client: self.network_client.clone(),
+            network_client: self.network_client.box_clone(),
             hostname: self.hostname.clone(),
         }
     }

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -213,7 +213,7 @@ impl Negotiate {
     fn filter_protocol(
         negotiated_protocol: &NegotiatedProtocol,
         package_list: &Option<String>,
-        hostname: &str,
+        #[allow(unused_variables)] hostname: &str, // Unused if `network_client` feature is disabled
     ) -> Result<Option<NegotiatedProtocol>> {
         let mut filtered_protocol = None;
         let PackageListConfig {

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -78,7 +78,7 @@ impl Clone for NegotiateConfig {
             protocol_config: self.protocol_config.clone(),
             package_list: None,
             hostname: self.hostname.clone(),
-            network_client_factory: self.network_client_factory.clone(),
+            network_client_factory: self.network_client_factory.box_clone(),
         }
     }
 }
@@ -117,7 +117,7 @@ impl Clone for Negotiate {
             package_list: self.package_list.clone(),
             auth_identity: self.auth_identity.clone(),
             hostname: self.hostname.clone(),
-            network_client_factory: self.network_client_factory.clone(),
+            network_client_factory: self.network_client_factory.box_clone(),
         }
     }
 }

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -28,7 +28,7 @@ impl NetworkProtocol {
 
 pub trait NetworkClientFactory: Debug + Send + Sync {
     fn network_client(&self) -> Box<dyn NetworkClient>;
-    fn clone(&self) -> Box<dyn NetworkClientFactory>;
+    fn box_clone(&self) -> Box<dyn NetworkClientFactory>;
 }
 
 pub trait NetworkClient: Send + Sync {
@@ -181,7 +181,7 @@ pub mod reqwest_network_client {
             Box::<ReqwestNetworkClient>::default()
         }
 
-        fn clone(&self) -> Box<dyn NetworkClientFactory> {
+        fn box_clone(&self) -> Box<dyn NetworkClientFactory> {
             Box::new(Clone::clone(self))
         }
     }

--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -81,7 +81,7 @@ impl AuthenticateMessageFields {
 }
 
 pub fn write_authenticate(
-    mut context: &mut Ntlm,
+    context: &mut Ntlm,
     credentials: &AuthIdentityBuffers,
     mut transport: impl io::Write,
 ) -> crate::Result<SecurityStatus> {

--- a/src/ntlm/messages/client/challenge.rs
+++ b/src/ntlm/messages/client/challenge.rs
@@ -14,7 +14,7 @@ struct ChallengeMessageFields {
     target_info: MessageFields,
 }
 
-pub fn read_challenge(mut context: &mut Ntlm, mut stream: impl io::Read) -> crate::Result<SecurityStatus> {
+pub fn read_challenge(context: &mut Ntlm, mut stream: impl io::Read) -> crate::Result<SecurityStatus> {
     check_state(context.state)?;
 
     let mut buffer = Vec::with_capacity(HEADER_SIZE);

--- a/src/ntlm/messages/server/authenticate.rs
+++ b/src/ntlm/messages/server/authenticate.rs
@@ -23,7 +23,7 @@ struct AuthenticateMessageFields {
     nt_challenge_response: MessageFields,
 }
 
-pub fn read_authenticate(mut context: &mut Ntlm, mut stream: impl io::Read) -> crate::Result<SecurityStatus> {
+pub fn read_authenticate(context: &mut Ntlm, mut stream: impl io::Read) -> crate::Result<SecurityStatus> {
     check_state(context.state)?;
 
     let mut buffer = Vec::with_capacity(HEADER_SIZE);

--- a/src/ntlm/messages/server/challenge.rs
+++ b/src/ntlm/messages/server/challenge.rs
@@ -36,7 +36,7 @@ impl ChallengeMessageFields {
     }
 }
 
-pub fn write_challenge(mut context: &mut Ntlm, mut transport: impl io::Write) -> crate::Result<SecurityStatus> {
+pub fn write_challenge(context: &mut Ntlm, mut transport: impl io::Write) -> crate::Result<SecurityStatus> {
     check_state(context.state)?;
 
     let server_challenge = generate_challenge()?;

--- a/src/ntlm/messages/server/complete_authenticate.rs
+++ b/src/ntlm/messages/server/complete_authenticate.rs
@@ -4,7 +4,7 @@ use crate::ntlm::messages::{CLIENT_SEAL_MAGIC, CLIENT_SIGN_MAGIC, SERVER_SEAL_MA
 use crate::ntlm::{Mic, NegotiateFlags, Ntlm, NtlmState, MESSAGE_INTEGRITY_CHECK_SIZE, SESSION_KEY_SIZE};
 use crate::SecurityStatus;
 
-pub fn complete_authenticate(mut context: &mut Ntlm) -> crate::Result<SecurityStatus> {
+pub fn complete_authenticate(context: &mut Ntlm) -> crate::Result<SecurityStatus> {
     check_state(context.state)?;
 
     let negotiate_message = context

--- a/tools/wasm-testcompile/src/lib.rs
+++ b/tools/wasm-testcompile/src/lib.rs
@@ -10,7 +10,7 @@ impl NetworkClientFactory for DummyNetworkClientFactory {
         unimplemented!()
     }
 
-    fn clone(&self) -> Box<dyn NetworkClientFactory> {
+    fn box_clone(&self) -> Box<dyn NetworkClientFactory> {
         Box::new(Clone::clone(self))
     }
 }


### PR DESCRIPTION
Refactored `NetworkClient` API as required by https://github.com/Devolutions/IronRDP/issues/155#issuecomment-1593724348

- Added the `NetworkClient::supported_protocols` method to discover if the underlying network client implementation supports the given protocol
- Added the `NetworkClient::name` method to provide more context for the error messages
- Moved ASN.1 messages serialization/deserialization for `NetworkClient::send_http` from implementors to sspi-rs internal code.
- Removed `NetworkClient::send_http` and squashed it to single`NetworkClient::send` (now a signature for all tcp/udp/http/https methods is the same) 