### PR TITLE
fix(ffi): unsound FreeContextBuffer

### DIFF
--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -223,14 +223,8 @@ pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, u32
 #[cfg_attr(windows, rename_symbol(to = "Rust_FreeContextBuffer"))]
 #[no_mangle]
 pub unsafe extern "system" fn FreeContextBuffer(pv_context_buffer: *mut c_void) -> SecurityStatus {
-    // FIXME(SAFETY): this is unsound because `c_void` does not have the same memory layout as the original types.
-    // It’s likely we need to use `libc::malloc` and `libc::free` instead of Rust’s default global allocator.
-    // Indeed, libc allocator is writing a metadata chunk in front of the user data chunk, and this
-    // metadata chunk is used to find the size of the user data chunk so that it’s possible to free the
-    // memory using a void pointer. In Rust, knowledge of the original type is required. Alternatively,
-    // we could allocate a global table holding type metadata so we can cast back into the original type at this point.
-    #[allow(clippy::from_raw_with_void_ptr)]
-    let _ = Box::from_raw(pv_context_buffer as *mut _);
+    // NOTE: see #XXX for rationale behind libc usage at this place
+    libc::free(pv_context_buffer);
 
     0
 }

--- a/ffi/src/common.rs
+++ b/ffi/src/common.rs
@@ -223,7 +223,7 @@ pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, u32
 #[cfg_attr(windows, rename_symbol(to = "Rust_FreeContextBuffer"))]
 #[no_mangle]
 pub unsafe extern "system" fn FreeContextBuffer(pv_context_buffer: *mut c_void) -> SecurityStatus {
-    // NOTE: see #XXX for rationale behind libc usage at this place
+    // NOTE: see https://github.com/Devolutions/sspi-rs/pull/141 for rationale behind libc usage.
     libc::free(pv_context_buffer);
 
     0

--- a/ffi/src/sec_buffer.rs
+++ b/ffi/src/sec_buffer.rs
@@ -1,4 +1,3 @@
-use std::alloc::{alloc, Layout};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use libc::c_char;
@@ -47,8 +46,7 @@ pub(crate) unsafe fn copy_to_c_sec_buffer(to_buffers: PSecBuffer, from_buffers: 
         to_buffers[i].cb_buffer = buffer_size.try_into().unwrap();
         to_buffers[i].buffer_type = buffer.buffer_type.to_u32().unwrap();
         if allocate || to_buffers[i].pv_buffer.is_null() {
-            let memory_layout = Layout::from_size_align_unchecked(buffer_size, 8);
-            to_buffers[i].pv_buffer = alloc(memory_layout) as *mut c_char;
+            to_buffers[i].pv_buffer = libc::malloc(buffer_size) as *mut c_char;
         }
         let to_buffer = from_raw_parts_mut(to_buffers[i].pv_buffer, buffer_size);
         to_buffer.copy_from_slice(from_raw_parts(buffer.buffer.as_ptr() as *const c_char, buffer_size));

--- a/tools/sspi-ffi-attacker/Cargo.toml
+++ b/tools/sspi-ffi-attacker/Cargo.toml
@@ -3,7 +3,8 @@ name = "sspi-ffi-attacker"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+debug = 1
 
 [dependencies]
 libc = "0.2.137"

--- a/tools/sspi-ffi-attacker/src/attack.rs
+++ b/tools/sspi-ffi-attacker/src/attack.rs
@@ -43,7 +43,7 @@ pub unsafe fn init_a_table(path_to_library: &str) -> PSecurityFunctionTableA {
     security_table
 }
 
-pub unsafe fn attac_auth_identity(path_to_dll: &str) {
+pub unsafe fn attack_auth_identity(path_to_dll: &str) {
     let sspi_handle = load_library(path_to_dll);
 
     if sspi_handle.is_null() {

--- a/tools/sspi-ffi-attacker/src/main.rs
+++ b/tools/sspi-ffi-attacker/src/main.rs
@@ -5,7 +5,7 @@ mod utils;
 use std::env;
 use std::path::Path;
 
-use attack::{attac_auth_identity, attack_a, attack_w, init_a_table, init_w_table};
+use attack::{attack_a, attack_auth_identity, attack_w, init_a_table, init_w_table};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -29,6 +29,6 @@ fn main() {
         attack_a(sec_a_table);
         let _ = Box::from_raw(sec_a_table);
 
-        attac_auth_identity(path_to_library);
+        attack_auth_identity(path_to_library);
     }
 }


### PR DESCRIPTION
The `FreeContextBuffer` function is using `Box::<T>::from_raw` to free
memory from a raw pointer of type `*mut c_void`. Sadly, this is unsound.

Indeed, knowledge of the original type is required when deallocating memory in
Rust. At the bare minimum, knowledge of the original type’s `Layout` is required
since this information is required by the default global allocator (actually
it is a safety invariant of [_any_ global allocator](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html) in Rust).
The correct layout for a given type can easily be retrieved by using
`Layout::new::<T>` or `Layout::for_value::<T>`, but this requires knowledge of
the concrete type `T`. That’s why `Box::<T>::from_raw` safety invariant is defined
as follows:

> For non-zero-sized values, a ``Box`` will use the ``Global`` allocator for its
> allocation. It is valid to convert both ways between a `Box` and a raw pointer
> allocated with the ``Global`` allocator, given that the `Layout` used with the
> allocator is correct for the type. More precisely, a value: `*mut T` that has
> been allocated with the `Global` allocator with `Layout::for_value(&*value)`
> may be converted into a box using `Box::<T>::from_raw(value)`. Conversely,
> the memory backing a value: `*mut T` obtained from `Box::<T>::into_raw` may be
> deallocated using the `Global` allocator with `Layout::for_value(&*value)`.

References:
- https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw
- https://doc.rust-lang.org/std/boxed/index.html#memory-layout

This invariant is violated because `c_void` definitely does not have the same
layout as structs such as `SecPkgInfoW` or `SecurityBuffer`.

We could allocate a global table protected by a `Mutex`. This table would
associate each address pointing to a block we allocated with the layout or some
hint for the original type, and using that information we could cast back into
the original type when freeing the memory. However, I finally settled on using
libc allocator:

1/ libc allocator is doing its own bookkeeping by reserving a metadata chunk in
  front of the actual "user" data chunk so that it can retrieve the length of the
  allocated block later when `free` is called. By using libc allocator, we don’t
  have to re-invent our own bookkeeping logic.

2/ Currently, some structures are tightly packed in memory by allocating a
  bigger chunk in order to hold both the "top level" struct as well as
  other data that fields from the said top level struct are pointing to.
  The [sec_pkg_info.rs file contains several occurrence](https://github.com/Devolutions/sspi-rs/blob/31f13c1c2e94066fd9c0f99d0a025c687410be1c/ffi/src/sec_pkg_info.rs#L39-L69)
  of this pattern. A `Layout` is manually constructed: its size is set to the
  sum of the sizes of all the elements packed together and the aligment is
  assumed to be the same as the top level struct (hardcoded to 8). There is
  no comment explaining why this "crime" is safe, but this doesn’t sound quite
  right to me. This also breaks the invariant for `Box::<T>::from_raw` even if
  we know the type of the original ("top level") type, because we didn’t use the
  correct layout for a `T` when allocating the memory in the first place.

That’s why, as of now, I think that using libc allocator is best.

I was able to inject the patched dll into FreeRDP and connect to my Devolutions Lab
without getting any crash, so it doesn’t appear to break anything so far.
![image](https://github.com/Devolutions/sspi-rs/assets/3809077/62e27475-7049-4191-86b8-75bbd95c5835)
(Note: username and password on this screenshot are not sensitive
since this is a [local Devolutions Lab](https://github.com/Devolutions/devolutions-labs))

It’s likely that we still need to audit the unsafe code more in depth.

cc @RRRadicalEdward
I’m not very familiar with sspi-rs codebase, so if you spot anything wrong let me know. Thank you!