### PR TITLE
refac(sspi): return proper SSPI error

### DIFF
--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -347,7 +347,7 @@ impl CredSspClient {
                 Ok(ClientState::FinalMessage(ts_request))
             }
             CredSspState::Final => Err(Error::new(
-                ErrorKind::InternalError,
+                ErrorKind::OutOfSequence,
                 "CredSSP client's 'process' method must not be fired after the 'Finished' state",
             )),
         }
@@ -558,7 +558,7 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity>> CredSspServer<C> {
             CredSspState::Final => Err(ServerError {
                 ts_request,
                 error: Error::new(
-                    ErrorKind::InternalError,
+                    ErrorKind::UnsupportedFunction,
                     "CredSSP server's 'process' method must not be fired after the 'Finished' state",
                 ),
             }),

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -83,7 +83,7 @@ impl SspiCredSsp {
                 certificates.into_iter().map(rustls::Certificate).collect(),
                 rustls::PrivateKey(private_key),
             )
-            .map_err(|err| Error::new(ErrorKind::InternalError, err.to_string()))?;
+            .map_err(|err| Error::new(ErrorKind::InvalidParameter, err.to_string()))?;
         let config = Arc::new(server_config);
 
         Ok(Self {

--- a/src/credssp/sspi_cred_ssp/tls_connection.rs
+++ b/src/credssp/sspi_cred_ssp/tls_connection.rs
@@ -70,7 +70,7 @@ impl TlsConnection {
 
                 let tls_state = tls_connection
                     .process_new_packets()
-                    .map_err(|err| Error::new(ErrorKind::InternalError, err.to_string()))?;
+                    .map_err(|err| Error::new(ErrorKind::DecryptFailure, err.to_string()))?;
 
                 let mut reader = tls_connection.reader();
 
@@ -100,7 +100,7 @@ impl TlsConnection {
 
                 let _io_status = tls_connection
                     .process_new_packets()
-                    .map_err(|err| Error::new(ErrorKind::InternalError, err.to_string()))?;
+                    .map_err(|err| Error::new(ErrorKind::EncryptFailure, err.to_string()))?;
 
                 let mut tls_buffer = Vec::new();
                 let bytes_written = tls_connection.write_tls(&mut tls_buffer)?;
@@ -148,7 +148,10 @@ impl TlsConnection {
         match self {
             TlsConnection::Rustls(tls_connection) => {
                 let protocol_version = tls_connection.protocol_version().ok_or_else(|| {
-                    Error::new(ErrorKind::InternalError, "Can not acquire connection protocol version")
+                    Error::new(
+                        ErrorKind::InvalidParameter,
+                        "Can not acquire connection protocol version",
+                    )
                 })?;
 
                 let protocol = match tls_connection {
@@ -193,7 +196,7 @@ impl TlsConnection {
                     rustls::BulkAlgorithm::Aes256Gcm => (ConnectionCipher::CalgAes256, 256),
                     rustls::BulkAlgorithm::Chacha20Poly1305 => {
                         return Err(Error::new(
-                            ErrorKind::InternalError,
+                            ErrorKind::UnsupportedFunction,
                             "alg_id for CHACHA20_POLY1305 does not exist",
                         ))
                     }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -344,6 +344,7 @@ where
     Fut::Output: Send,
 {
     use std::thread;
+
     use tokio::runtime::{Builder, Handle};
 
     match Handle::try_current() {

--- a/src/kerberos/client/extractors.rs
+++ b/src/kerberos/client/extractors.rs
@@ -65,7 +65,7 @@ pub fn extract_session_key_from_tgs_rep(
 
     let enc_data = cipher
         .decrypt(session_key, TGS_REP_ENC_SESSION_KEY, &tgs_rep.0.enc_part.0.cipher.0 .0)
-        .map_err(|e| Error::new(ErrorKind::InternalError, format!("{:?}", e)))?;
+        .map_err(|e| Error::new(ErrorKind::DecryptFailure, format!("{:?}", e)))?;
 
     let enc_as_rep_part: EncTgsRepPart = picky_asn1_der::from_bytes(&enc_data)?;
 
@@ -92,7 +92,7 @@ pub fn extract_encryption_params_from_as_rep(as_rep: &AsRep) -> Result<(u8, Stri
             let pa_etype_info2 = pa_etype_info2
                 .0
                 .get(0)
-                .ok_or_else(|| Error::new(ErrorKind::InternalError, "Missing EtypeInto2Entry in EtypeInfo2"))?;
+                .ok_or_else(|| Error::new(ErrorKind::InvalidParameter, "Missing EtypeInto2Entry in EtypeInfo2"))?;
 
             Ok((
                 pa_etype_info2.etype.0 .0.first().copied().unwrap(),
@@ -101,7 +101,7 @@ pub fn extract_encryption_params_from_as_rep(as_rep: &AsRep) -> Result<(u8, Stri
                     .0
                     .as_ref()
                     .map(|salt| salt.0.to_string())
-                    .ok_or_else(|| Error::new(ErrorKind::InternalError, "Missing salt in EtypeInto2Entry"))?,
+                    .ok_or_else(|| Error::new(ErrorKind::InvalidParameter, "Missing salt in EtypeInto2Entry"))?,
             ))
         }
         None => Err(Error::new(

--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -404,7 +404,7 @@ pub fn generate_authenticator(options: GenerateAuthenticatorOptions) -> Result<A
         if checksum_type == AUTHENTICATOR_CHECKSUM_TYPE && channel_bindings.is_some() {
             if checksum_value.len() < 20 {
                 return Err(Error::new(
-                    ErrorKind::InternalError,
+                    ErrorKind::InvalidParameter,
                     format!(
                         "Invalid authenticator checksum length: expected >= 20 but got {}. ",
                         checksum_value.len()

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -231,7 +231,7 @@ impl Kerberos {
             error!("KDC replied with AS_REP to the AS_REQ without the encrypted timestamp. The KRB_ERROR expected.");
 
             return Err(Error::new(
-                ErrorKind::InternalError,
+                ErrorKind::InvalidToken,
                 "KDC server should not process AS_REQ without the pa-pac data",
             ));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1845,7 +1845,10 @@ impl From<picky_krb::crypto::KerberosCryptoError> for Error {
                 ErrorKind::InvalidParameter,
                 format!("invalid key length. actual: {}. expected: {}", actual, expected),
             ),
-            KerberosCryptoError::CipherLength(_, _) => todo!(),
+            KerberosCryptoError::CipherLength(actual, expected) => Self::new(
+                ErrorKind::InvalidParameter,
+                format!("invalid cipher length. actual: {}. expected: {}", actual, expected),
+            ),
             KerberosCryptoError::AlgorithmIdentifier(identifier) => Self::new(
                 ErrorKind::InvalidParameter,
                 format!("unknown algorithm identifier: {}", identifier),

--- a/src/pku2u/cert_utils/win_extraction.rs
+++ b/src/pku2u/cert_utils/win_extraction.rs
@@ -171,7 +171,7 @@ unsafe fn export_certificate_private_key(cert: *const CERT_CONTEXT) -> Result<Pr
         );
 
         return Err(Error::new(
-            ErrorKind::InternalError,
+            ErrorKind::InvalidHandle,
             "Cannot extract certificate private key: invalid handle",
         ));
     }
@@ -199,13 +199,36 @@ unsafe fn export_certificate_private_key(cert: *const CERT_CONTEXT) -> Result<Pr
     if status != 0 {
         NCryptFreeObject(private_key_handle);
 
-        return Err(Error::new(
-            ErrorKind::InternalError,
-            format!(
-                "Cannot extract certificate private key: unsuccessful extraction: {:x?}",
-                status
-            ),
-        ));
+        return match status {
+            Foundation::NTE_BAD_TYPE => Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Cannot extract certificate private key: provided key cannot be exported into the specified BLOB type: {:x?}",
+                    status
+                ),
+            )),
+            Foundation::NTE_INVALID_HANDLE => Err(Error::new(
+                ErrorKind::InvalidHandle,
+                format!(
+                    "Cannot extract certificate private key: key or export key handle is invalid: {:x?}",
+                    status
+                ),
+            )),
+            Foundation::NTE_INVALID_PARAMETER => Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Cannot extract certificate private key: invalid parameter: {:x?}",
+                    status
+                ),
+            )),
+            _ => Err(Error::new(
+                ErrorKind::InternalError,
+                format!(
+                    "Cannot extract certificate private key: unsuccessful extraction: {:x?}",
+                    status
+                ),
+            )),
+        };
     }
 
     let mut private_key_blob = vec![0; private_key_buffer_len as usize];
@@ -224,13 +247,36 @@ unsafe fn export_certificate_private_key(cert: *const CERT_CONTEXT) -> Result<Pr
     NCryptFreeObject(private_key_handle);
 
     if status != 0 {
-        return Err(Error::new(
-            ErrorKind::InternalError,
-            format!(
-                "Cannot extract certificate private key: unsuccessful extraction: {:x?}",
-                status
-            ),
-        ));
+        return match status {
+            Foundation::NTE_BAD_TYPE => Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Cannot extract certificate private key: provided key cannot be exported into the specified BLOB type: {:x?}",
+                    status
+                ),
+            )),
+            Foundation::NTE_INVALID_HANDLE => Err(Error::new(
+                ErrorKind::InvalidHandle,
+                format!(
+                    "Cannot extract certificate private key: key or export key handle is invalid: {:x?}",
+                    status
+                ),
+            )),
+            Foundation::NTE_INVALID_PARAMETER => Err(Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Cannot extract certificate private key: invalid parameter: {:x?}",
+                    status
+                ),
+            )),
+            _ => Err(Error::new(
+                ErrorKind::InternalError,
+                format!(
+                    "Cannot extract certificate private key: unsuccessful extraction: {:x?}",
+                    status
+                ),
+            )),
+        };
     }
 
     debug!("The certificate private key exported");

--- a/src/pku2u/macros.rs
+++ b/src/pku2u/macros.rs
@@ -15,7 +15,7 @@ macro_rules! check_conversation_id {
 macro_rules! check_auth_scheme {
     ($actual:expr, $expected:expr) => {
         if $expected.is_none() {
-            return Err(Error::new(ErrorKind::InternalError, "auth scheme id is not set"));
+            return Err(Error::new(ErrorKind::InvalidParameter, "auth scheme id is not set"));
         }
 
         if $actual != $expected.unwrap() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,7 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
     use picky_krb::constants::error_codes::*;
 
     match krb_error_code {
-        KDC_ERR_NONE => (ErrorKind::InternalError, "No error".into()),
+        KDC_ERR_NONE => (ErrorKind::Unknown, "No error".into()),
         KDC_ERR_NAME_EXP => (
             ErrorKind::InvalidParameter,
             "Client's entry in database has expired".into(),


### PR DESCRIPTION
I revisited a bunch of places where `sspi-rs` returns `ErrorKind::InternalError` and changed them to return more meaningful and proper errors.