### PR TITLE
Kerberos smart logon fixes

### DIFF
--- a/src/cert_utils.rs
+++ b/src/cert_utils.rs
@@ -266,11 +266,11 @@ pub unsafe fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<Smar
             }
         }
 
-        CryptReleaseContext(crypt_context_handle, 0);
-
         index += 1;
         is_first = false;
     }
+
+    CryptReleaseContext(crypt_context_handle, 0);
 
     Err(Error::new(ErrorKind::InternalError, "Cannot get smart card info"))
 }

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -356,7 +356,7 @@ impl SspiImpl for SspiCredSsp {
                         .with_credentials_handle(builder.credentials_handle.take().ok_or_else(|| {
                             Error::new(ErrorKind::WrongCredentialHandle, "credentials handle is not present")
                         })?)
-                        .with_context_requirements(ClientRequestFlags::empty())
+                        .with_context_requirements(builder.context_requirements)
                         .with_target_data_representation(DataRepresentation::Native);
                 if let Some(target_name) = &builder.target_name {
                     inner_builder = inner_builder.with_target_name(target_name);

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -481,6 +481,23 @@ impl SspiImpl for Negotiate {
             }
         }
 
+        #[cfg(feature = "scard")]
+        if let Some(Some(CredentialsBuffers::SmartCard(identity))) = builder.credentials_handle {
+            if let NegotiatedProtocol::Ntlm(_) = &self.protocol {
+                let username = crate::utils::bytes_to_utf16_string(&identity.username);
+                let host = detect_kdc_url(&get_client_principal_realm(&username, ""))
+                    .ok_or_else(|| Error::new(ErrorKind::NoAuthenticatingAuthority, "Can not detect KDC url."))?;
+                info!("Negotiate: try Kerberos");
+
+                self.protocol =
+                    NegotiatedProtocol::Kerberos(Kerberos::new_client_from_config(crate::KerberosConfig {
+                        url: Some(host),
+                        network_client: self.network_client_factory.network_client(),
+                        hostname: Some(self.hostname.clone()),
+                    })?);
+            }
+        }
+
         if let NegotiatedProtocol::Kerberos(kerberos) = &mut self.protocol {
             match kerberos.initialize_security_context_impl(builder) {
                 Result::Err(Error {


### PR DESCRIPTION
Hi,
I did the final dev testing. I found a few bugs, fixed them, and now all works well. I captured some videos to show how it works:

* `FreeRDP`. Smart card logon: 

https://github.com/Devolutions/sspi-rs/assets/43034350/05e66a5d-2df7-4a05-9314-5985e867b5df

* `mstsc`. Smart card logon: 

https://github.com/Devolutions/sspi-rs/assets/43034350/4e582642-b361-46ee-8b09-4e5ef05f7c9b

* `FreeRDP`. Password-based logon: 

https://github.com/Devolutions/sspi-rs/assets/43034350/ba80a24a-6247-4f51-8002-f58200d19d92

* `mstsc`. Password-based logon: 

https://github.com/Devolutions/sspi-rs/assets/43034350/f4058af6-8a67-4e7b-9299-770e25b595f4

Don't worry about credentials. It's just my internal test VM, so there is no risk.

сс @awakecoding 