### PR TITLE
Fix UPN handling

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -15,4 +15,4 @@ pub mod sec_pkg_info;
 pub mod sec_winnt_auth_identity;
 pub mod security_tables;
 pub mod sspi_data_types;
-pub mod utils;
+mod utils;

--- a/ffi/src/sec_winnt_auth_identity.rs
+++ b/ffi/src/sec_winnt_auth_identity.rs
@@ -472,7 +472,7 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
 }
 
 #[cfg(target_os = "windows")]
-#[instrument(level ="trace", ret)]
+#[instrument(level = "trace", ret)]
 pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w(p_auth_data: *const c_void) -> Result<CredentialsBuffers> {
     use std::ptr::null_mut;
 

--- a/ffi/src/sec_winnt_auth_identity.rs
+++ b/ffi/src/sec_winnt_auth_identity.rs
@@ -14,7 +14,9 @@ use winapi::um::wincred::CredIsMarshaledCredentialW;
 use windows_sys::Win32::Security::Authentication::Identity::SspiIsAuthIdentityEncrypted;
 
 use crate::sspi_data_types::{SecWChar, SecurityStatus};
-use crate::utils::{c_w_str_to_string, into_raw_ptr, raw_str_into_bytes, raw_wide_str_trim_nulls};
+#[cfg(feature = "tsssp")]
+use crate::utils::raw_wide_str_trim_nulls;
+use crate::utils::{c_w_str_to_string, into_raw_ptr, raw_str_into_bytes};
 
 pub const SEC_WINNT_AUTH_IDENTITY_ANSI: u32 = 0x1;
 pub const SEC_WINNT_AUTH_IDENTITY_UNICODE: u32 = 0x2;
@@ -471,7 +473,7 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
     Ok(creds)
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(feature = "tsssp")]
 #[instrument(level = "trace", ret)]
 pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w(p_auth_data: *const c_void) -> Result<CredentialsBuffers> {
     use std::ptr::null_mut;

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -11,17 +11,6 @@ pub fn into_raw_ptr<T>(value: T) -> *mut T {
     Box::into_raw(Box::new(value))
 }
 
-pub fn vec_into_raw_ptr<T>(v: Vec<T>) -> *mut T {
-    Box::into_raw(v.into_boxed_slice()) as *mut T
-}
-
-pub unsafe fn raw_w_str_to_bytes(raw_buffer: *const u16, len: usize) -> Vec<u8> {
-    from_raw_parts(raw_buffer, len)
-        .iter()
-        .flat_map(|w_char| w_char.to_le_bytes())
-        .collect()
-}
-
 pub unsafe fn c_w_str_to_string(s: *const SecWChar) -> String {
     let mut len = 0;
 

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -40,15 +40,13 @@ pub unsafe fn transform_credentials_handle<'a>(
     }
 }
 
+// when encoding an UTF-16 character using two code units, the 16-bit values are chosen from the UTF-16 surrogate range 0xD800–0xDFFF,
+// and thus only \0 is encoded by two consecutive null bytes
 #[cfg(feature = "tsssp")]
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
     let mut len = raw_str.len();
-    while len > 2 {
-        if raw_str[len - 2..] == [0, 0] {
-            raw_str.truncate(len - 2);
-            len = raw_str.len();
-        } else {
-            break;
-        }
+    while len > 2 && raw_str[len - 2..] == [0, 0] {
+        raw_str.truncate(len - 2);
+        len = raw_str.len();
     }
 }

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -43,7 +43,7 @@ pub unsafe fn transform_credentials_handle<'a>(
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
     let mut len = raw_str.len();
     while len > 2 {
-        if &raw_str[len - 2..] == &[0, 0] {
+        if raw_str[len - 2..] == [0, 0] {
             raw_str.truncate(len - 2);
             len = raw_str.len();
         } else {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -40,6 +40,7 @@ pub unsafe fn transform_credentials_handle<'a>(
     }
 }
 
+#[cfg(feature = "tsssp")]
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
     let mut len = raw_str.len();
     while len > 2 {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -50,3 +50,15 @@ pub unsafe fn transform_credentials_handle<'a>(
         ))
     }
 }
+
+pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
+    let mut len = raw_str.len();
+    while len > 2 {
+        if &raw_str[len - 2..] == &[0, 0] {
+            raw_str.truncate(len - 2);
+            len = raw_str.len();
+        } else {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I fixed the UPN (user principal name) handling. closes #150 

The problem was in the trailing null characters at the end of the username buffer. In the case of UPN logon, the username buffer has two null bytes at the end.

Also, I recorded a little video demonstration:

* logon using UPN

https://github.com/Devolutions/sspi-rs/assets/43034350/1d3f99be-4d99-4cc4-8a9d-d01f19ac969b


* logon using domain + username

https://github.com/Devolutions/sspi-rs/assets/43034350/ec4ef518-6fca-487b-a35f-1f14dd9aac35

cc @awakecoding 