### PR TITLE
Fix `execute_future` not working with `tokio::spawn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 [features]
 default = []
 network_client = ["dep:reqwest", "dep:portpicker"]
-dns_resolver = ["dep:trust-dns-resolver", "dep:tokio"]
+dns_resolver = ["dep:trust-dns-resolver", "dep:tokio", "tokio/rt-multi-thread"]
 # TSSSP should be used only on Windows as a native CREDSSP replacement
 tsssp = ["dep:rustls"]
 # Turns on Kerberos smart card login (available only on Windows and users WinSCard API)
@@ -63,7 +63,7 @@ num-bigint-dig = "0.8"
 tracing = "0.1"
 rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
 zeroize = { version = "1.6", features = ["zeroize_derive"] }
-tokio = { version = "1.32", features = ["time", "rt", "rt-multi-thread"], optional = true }
+tokio = { version = "1.32", features = ["time", "rt"], optional = true }
 pcsc = { version = "2.8", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ num-bigint-dig = "0.8"
 tracing = "0.1"
 rustls = { version = "0.21", features = ["dangerous_configuration"], optional = true }
 zeroize = { version = "1.6", features = ["zeroize_derive"] }
-tokio = { version = "1.32", features = ["time", "rt"], optional = true }
+tokio = { version = "1.32", features = ["time", "rt", "rt-multi-thread"], optional = true }
 pcsc = { version = "2.8", optional = true }
 
 [target.'cfg(windows)'.dependencies]
@@ -75,7 +75,7 @@ windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Wi
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-dnssd = "0.5"
 futures = "0.3"
-tokio = { version = "1.32", features = ["time", "rt"] }
+tokio = { version = "1.32", features = ["time", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 static_assertions = "1"


### PR DESCRIPTION
In some cases (e.g. when using async IO, like TCP connection) resolving DNS queries for KDC will block when used in `tokio::spawn`-ed task. AFAICT this happens because we block thread that is used by IO and timers.
This change fixes that with use `block_in_place` so the thread we're on will be marked by tokio as blocked and other task will be moved to the new one.