### PR TITLE
Store and give access to session_key in Ntlm

### DIFF
--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -157,6 +157,7 @@ pub fn write_authenticate(
     context.recv_signing_key = generate_signing_key(session_key.as_ref(), SERVER_SIGN_MAGIC);
     context.send_sealing_key = Some(Rc4::new(&generate_signing_key(session_key.as_ref(), CLIENT_SEAL_MAGIC)));
     context.recv_sealing_key = Some(Rc4::new(&generate_signing_key(session_key.as_ref(), SERVER_SEAL_MAGIC)));
+    context.session_key = Some(session_key);
 
     context.authenticate_message = Some(AuthenticateMessage::new(
         message,

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -86,6 +86,8 @@ pub struct Ntlm {
     recv_signing_key: [u8; HASH_SIZE],
     send_sealing_key: Option<Rc4>,
     recv_sealing_key: Option<Rc4>,
+
+    pub session_key: Option<[u8; SESSION_KEY_SIZE]>,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +140,7 @@ impl Ntlm {
             recv_signing_key: [0x00; HASH_SIZE],
             send_sealing_key: None,
             recv_sealing_key: None,
+            session_key: None,
         }
     }
 
@@ -162,6 +165,7 @@ impl Ntlm {
             recv_signing_key: [0x00; HASH_SIZE],
             send_sealing_key: None,
             recv_sealing_key: None,
+            session_key: None,
         }
     }
 
@@ -186,6 +190,7 @@ impl Ntlm {
             recv_signing_key: [0x00; HASH_SIZE],
             send_sealing_key: None,
             recv_sealing_key: None,
+            session_key: None,
         }
     }
 

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -87,7 +87,7 @@ pub struct Ntlm {
     send_sealing_key: Option<Rc4>,
     recv_sealing_key: Option<Rc4>,
 
-    pub session_key: Option<[u8; SESSION_KEY_SIZE]>,
+    session_key: Option<[u8; SESSION_KEY_SIZE]>,
 }
 
 #[derive(Debug, Clone)]
@@ -200,6 +200,10 @@ impl Ntlm {
 
     pub fn set_version(&mut self, version: [u8; NTLM_VERSION_SIZE]) {
         self.version = version;
+    }
+
+    pub fn session_key(&self) -> Option<[u8; SESSION_KEY_SIZE]> {
+        self.session_key
     }
 }
 


### PR DESCRIPTION
I'm using this crate to add NTLM support to my SMB 3.1.1 client I'm developing.
The session_key is used as part of the calculation of the signing key. See this page for details https://learn.microsoft.com/en-us/archive/blogs/openspecification/smb-2-and-smb-3-security-in-windows-10-the-anatomy-of-signing-and-cryptographic-keys

This pull request stashes the session_key that was used in the Ntlm struct, and provides access to it with an accessor function.