### PR TITLE
Ntlm fixes for disabled sealing and signing

### DIFF
--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -123,7 +123,7 @@ pub fn write_authenticate(
     let mut encrypted_session_key = [0x00; ENCRYPTED_RANDOM_SESSION_KEY_SIZE];
     encrypted_session_key.clone_from_slice(encrypted_session_key_vec.as_ref());
 
-    context.flags = get_flags(&context, credentials);
+    context.flags = get_flags(context, credentials);
 
     if !context.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
         session_key = key_exchange_key;

--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -126,7 +126,7 @@ pub fn write_authenticate(
     context.flags = get_flags(&context, credentials);
 
     if !context.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
-        session_key = key_exchange_key;    
+        session_key = key_exchange_key;
     }
 
     let message_fields = AuthenticateMessageFields::new(

--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -123,7 +123,7 @@ pub fn write_authenticate(
     let mut encrypted_session_key = [0x00; ENCRYPTED_RANDOM_SESSION_KEY_SIZE];
     encrypted_session_key.clone_from_slice(encrypted_session_key_vec.as_ref());
 
-    context.flags = get_flags(context.flags, credentials);
+    context.flags = get_flags(&context, credentials);
     let message_fields = AuthenticateMessageFields::new(
         credentials,
         lm_challenge_response.as_ref(),
@@ -182,31 +182,35 @@ fn check_state(state: NtlmState) -> crate::Result<()> {
     }
 }
 
-fn get_flags(negotiate_flags: NegotiateFlags, identity: &AuthIdentityBuffers) -> NegotiateFlags {
+fn get_flags(context: &Ntlm, identity: &AuthIdentityBuffers) -> NegotiateFlags {
     // set KEY_EXCH flag if it was in the challenge message
-    let mut negotiate_flags = negotiate_flags & NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH;
+    let mut flags = context.flags & NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH;
 
     if !identity.domain.is_empty() {
-        negotiate_flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_DOMAIN_SUPPLIED;
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_DOMAIN_SUPPLIED;
     }
 
     // will not set workstation because it is not used anywhere
 
-    negotiate_flags
-    // NTLMv2
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE56
-    // ASC_REQ_CONFIDENTIALITY, ISC_REQ_CONFIDENTIALITY always set in the nla
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_SEAL
-    // other flags
+    flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE56
         | NegotiateFlags::NTLM_SSP_NEGOTIATE128
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_EXTENDED_SESSION_SECURITY
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_NTLM
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_REQUEST_TARGET
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_UNICODE
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_TARGET_INFO
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_VERSION
+        | NegotiateFlags::NTLM_SSP_NEGOTIATE_VERSION;
+
+    if context.sealing {
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SEAL;
+    }
+
+    if context.signing {
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN;
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN;
+    }
+
+    flags
 }
 
 fn write_header(

--- a/src/ntlm/messages/client/negotiate.rs
+++ b/src/ntlm/messages/client/negotiate.rs
@@ -76,10 +76,9 @@ pub fn write_negotiate(context: &mut Ntlm, mut transport: impl io::Write) -> cra
 
 fn get_flags(context: &Ntlm) -> NegotiateFlags {
     let mut flags = NegotiateFlags::NTLM_SSP_NEGOTIATE56
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_LM_KEY
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_OEM
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH
         | NegotiateFlags::NTLM_SSP_NEGOTIATE128
+        | NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_EXTENDED_SESSION_SECURITY
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_NTLM
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_REQUEST_TARGET
@@ -87,12 +86,13 @@ fn get_flags(context: &Ntlm) -> NegotiateFlags {
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_VERSION;
 
     if context.sealing {
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_LM_KEY;
         flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SEAL;
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH;
     }
 
     if context.signing {
         flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN;
-        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN;
     }
 
     if context.config().workstation.is_some() {

--- a/src/ntlm/messages/client/negotiate.rs
+++ b/src/ntlm/messages/client/negotiate.rs
@@ -75,22 +75,25 @@ pub fn write_negotiate(context: &mut Ntlm, mut transport: impl io::Write) -> cra
 }
 
 fn get_flags(context: &Ntlm) -> NegotiateFlags {
-    // NTLMv2
     let mut flags = NegotiateFlags::NTLM_SSP_NEGOTIATE56
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_LM_KEY
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_OEM
-    // ASC_REQ_CONFIDENTIALITY, ISC_REQ_CONFIDENTIALITY always set in the nla
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_SEAL
-    // other flags
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH
         | NegotiateFlags::NTLM_SSP_NEGOTIATE128
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_EXTENDED_SESSION_SECURITY
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_NTLM
-        | NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_REQUEST_TARGET
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_UNICODE
         | NegotiateFlags::NTLM_SSP_NEGOTIATE_VERSION;
+
+    if context.sealing {
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SEAL;
+    }
+
+    if context.signing {
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN;
+        flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_ALWAYS_SIGN;
+    }
 
     if context.config().workstation.is_some() {
         flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_WORKSTATION_SUPPLIED;

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -432,7 +432,7 @@ impl Sspi for Ntlm {
                 "Invalid encrypted message size!",
             ));
         }
-        
+
         let (signature, encrypted_message) = encrypted.split_at(16);
 
         *data.buffer.as_mut() = self.recv_sealing_key.as_mut().unwrap().process(encrypted_message);

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -426,10 +426,16 @@ impl Sspi for Ntlm {
         let data = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Data)?;
         encrypted.extend_from_slice(&data.buffer);
 
-        let signature = encrypted[0..16].to_vec();
-        let enc = encrypted[16..].to_vec();
+        if encrypted.len() < 16 {
+            return Err(crate::Error::new(
+                crate::ErrorKind::MessageAltered,
+                "Invalid encrypted message size!",
+            ));
+        }
+        
+        let (signature, encrypted_message) = encrypted.split_at(16);
 
-        *data.buffer.as_mut() = self.recv_sealing_key.as_mut().unwrap().process(enc.as_slice());
+        *data.buffer.as_mut() = self.recv_sealing_key.as_mut().unwrap().process(encrypted_message);
 
         let digest = compute_digest(&self.recv_signing_key, sequence_number, data.buffer.as_slice())?;
         let checksum = self
@@ -439,7 +445,7 @@ impl Sspi for Ntlm {
             .process(&digest[0..SIGNATURE_CHECKSUM_SIZE]);
         let expected_signature = compute_signature(&checksum, sequence_number);
 
-        if signature.as_slice() != expected_signature.as_ref() {
+        if signature != expected_signature.as_ref() {
             return Err(crate::Error::new(
                 crate::ErrorKind::MessageAltered,
                 "Signature verification failed, something nasty is going on!",


### PR DESCRIPTION
1) NTLM flags now allow to disable signing and sealing
2) MIC is now properly generated if key exchange is disabled (such as the case of disabled sealing)
3) NTLM DecryptMessage now supports STREAM decoding