### PR TITLE
refactor: clarify naming of user-facing options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +483,22 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -874,6 +905,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -1389,6 +1426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.1",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.7.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1488,6 +1554,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1606,6 +1678,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustls"
 version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +1731,18 @@ checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1909,6 +2006,7 @@ dependencies = [
  "picky-asn1-x509",
  "picky-krb",
  "portpicker",
+ "proptest",
  "rand",
  "reqwest",
  "rustls",
@@ -1994,6 +2092,19 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2239,6 +2350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2424,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ async-recursion = "1.0.5"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"
+# FIXME(#174): replace `winapi` crate by `windows` / `windows-sys` crates
 winapi = { version = "0.3", features = ["std", "sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 windows = { version = "0.51", features = [ "Win32_Foundation", "Win32_NetworkManagement_Dns"] }
 windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }
@@ -88,3 +89,4 @@ static_assertions = "1"
 whoami = "1.4"
 picky = { version = "7.0.0-rc.8", features = ["x509"] }
 tracing-subscriber = "0.3"
+proptest = "1.3.1"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -11,7 +11,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use sspi::builders::EmptyInitializeSecurityContext;
 use sspi::{
     AuthIdentity, ClientRequestFlags, CredentialUse, DataRepresentation, Ntlm, SecurityBuffer, SecurityBufferType,
-    SecurityStatus, Sspi, SspiImpl,
+    SecurityStatus, Sspi, SspiImpl, Username,
 };
 
 const IP: &str = "127.0.0.1:8080";
@@ -23,10 +23,14 @@ fn main() -> Result<(), io::Error> {
 
     let mut ntlm = Ntlm::new();
 
+    let account_name = whoami::username();
+    let computer_name = whoami::hostname();
+    let username =
+        Username::new(&account_name, Some(&computer_name)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
     let identity = AuthIdentity {
-        username: whoami::username(),
+        username,
         password: String::from("password").into(),
-        domain: Some(whoami::hostname()),
     };
 
     do_authentication(&mut ntlm, &identity, &mut stream).expect("Failed to authenticate connection");

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -9,7 +9,7 @@ use std::net::{TcpListener, TcpStream};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use sspi::{
     AuthIdentity, CredentialUse, DataRepresentation, EncryptionFlags, Ntlm, SecurityBuffer, SecurityBufferType,
-    SecurityStatus, ServerRequestFlags, Sspi,
+    SecurityStatus, ServerRequestFlags, Sspi, Username,
 };
 
 const IP: &str = "127.0.0.1:8080";
@@ -23,10 +23,14 @@ fn main() -> Result<(), io::Error> {
 
     let mut ntlm = Ntlm::new();
 
+    let account_name = whoami::username();
+    let computer_name = whoami::hostname();
+    let username =
+        Username::new(&account_name, Some(&computer_name)).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
     let identity = AuthIdentity {
-        username: whoami::username(),
+        username,
         password: String::from("password").into(),
-        domain: Some(whoami::hostname()),
     };
 
     do_authentication(&mut ntlm, &identity, &mut stream).expect("Failed to authenticate connection");

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -30,5 +30,5 @@ tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", 
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
-winapi = "0.3"
+winapi = "0.3" # FIXME: replace by windows / windows-sys crates
 windows-sys = { version = "0.48", features = ["Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }

--- a/proptest-regressions/auth_identity.txt
+++ b/proptest-regressions/auth_identity.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 22a32450b3cada4bb46952cb5109e3b305e8c756d58d37136a195c3bc3dee4cb # shrinks to account_name = "@", domain_name = "A"
+cc 7f7cdbd18aad0a1d970b6ff9ce7fbfaa7e4dabeb0b55cca0c7f7610f8f0e3cbf # shrinks to value = "A@\\.a"
+cc f946f1001aacc60322cba7ba063fa386f4e0c6d9497d8144e300f8b4652e378e # shrinks to value = "A\\a\\a"
+cc 033e00adafc5d7bc9402013f261b9f7de65938d4ce9f66f2ea4ec1419a0ae286 # shrinks to value = "A@0@a"

--- a/src/credssp/ts_request/test.rs
+++ b/src/credssp/ts_request/test.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 
 use super::*;
 use crate::credssp::CredSspMode;
-use crate::AuthIdentity;
+use crate::{AuthIdentity, Username};
 
 const NTLM_CLIENT_NONCE: [u8; 32] = [
     0x22, 0x10, 0x12, 0xad, 0x12, 0x5c, 0x7a, 0x15, 0xfe, 0xb6, 0x4b, 0x1f, 0xcb, 0x94, 0x83, 0x3a, 0xc5, 0x6f, 0x66,
@@ -199,37 +199,33 @@ const TS_CREDENTIALS_WITH_RESTRICTED_ADMIN_MODE_REQUIRED: [u8; 25] = [
 lazy_static! {
     static ref AUTH_IDENTITY_ONE_SYMBOL_USER_AND_PASSWORD: CredentialsBuffers = CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: String::from("a"),
+            username: Username::parse("a").unwrap(),
             password: String::from("1").into(),
-            domain: None
         }
         .into()
     );
     static ref AUTH_IDENTITY_STRONG_USERNAME_AND_PASSWORD: CredentialsBuffers = CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: String::from("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890"),
+            username: Username::new("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890", None).unwrap(),
             password: String::from(
                 "@#$%^&*()_+1234567890-=QWERTYUIOP{}qwertyuiop[]asdfghjkl;ASDFGHJKL:\\\"|zxcvbnm,.ZXCVBNM<>?"
             )
             .into(),
-            domain: None
         }
         .into()
     );
     static ref AUTH_IDENTITY_SIMPLE_WITH_USERNAME_AND_DOMAIN_AND_PASSWORD: CredentialsBuffers =
         CredentialsBuffers::AuthIdentity(
             AuthIdentity {
-                username: String::from("Username"),
+                username: Username::new("Username", Some("Domain")).unwrap(),
                 password: String::from("Password").into(),
-                domain: Some(String::from("Domain"))
             }
             .into()
         );
     static ref AUTH_IDENTITY_WITH_RESTRICTED_ADMIN_MODE_REQUIRED: CredentialsBuffers = CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: String::from(""),
+            username: Username::new("", Some("")).unwrap(),
             password: String::from("").into(),
-            domain: Some(String::from(""))
         }
         .into()
     );

--- a/src/kerberos/config.rs
+++ b/src/kerberos/config.rs
@@ -7,10 +7,25 @@ use crate::kdc::detect_kdc_url;
 use crate::negotiate::{NegotiatedProtocol, ProtocolConfig};
 use crate::{Kerberos, Result};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct KerberosConfig {
-    pub url: Option<Url>,
-    pub hostname: Option<String>,
+    /// KDC URL
+    ///
+    /// Depending on the scheme it is expected to be either:
+    /// - a (Kerberos) KDC address (e.g.: tcp://domain:88, udp://domain:88), or
+    /// - a KDC _Proxy_ URL (e.g.: https://gateway.devolutions.net/jet/KdcProxy?token=<…>)
+    ///
+    /// That is, when the scheme is `http` or `https`, the KDC Proxy Protocol ([KKDCP]) will be
+    /// used on top of the Kerberos protocol, wrapping the messages.
+    /// Otherwise, the scheme must be either `tcp` or `udp`, and the KDC protocol will be used
+    /// in order to communicate with the KDC server directly.
+    ///
+    /// [KKDCP]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kkdcp/5bcebb8d-b747-4ee5-9453-428aec1c5c38
+    pub kdc_url: Option<Url>,
+    /// Computer name, or "workstation name", of the client machine performing the authentication attempt
+    ///
+    /// This is also referred to as the "Source Workstation", i.e.: the name of the computer attempting to logon.
+    pub client_computer_name: Option<String>,
 }
 
 impl ProtocolConfig for KerberosConfig {
@@ -20,30 +35,31 @@ impl ProtocolConfig for KerberosConfig {
         )?))
     }
 
-    fn clone(&self) -> Box<dyn ProtocolConfig> {
+    fn box_clone(&self) -> Box<dyn ProtocolConfig> {
         Box::new(Clone::clone(self))
     }
 }
 
-pub fn parse_kdc_url(mut kdc: String) -> Option<Url> {
-    if !kdc.contains("://") {
-        kdc = format!("tcp://{}", kdc);
+pub fn parse_kdc_url(kdc_url: &str) -> Option<Url> {
+    if !kdc_url.contains("://") {
+        Url::from_str(&format!("tcp://{kdc_url}")).ok()
+    } else {
+        Url::from_str(kdc_url).ok()
     }
-    Url::from_str(&kdc).ok()
 }
 
 impl KerberosConfig {
-    pub fn new(url: &str, hostname: String) -> Self {
-        let kdc_url = parse_kdc_url(url.to_owned());
+    pub fn new(kdc_url: &str, client_computer_name: String) -> Self {
+        let kdc_url = parse_kdc_url(kdc_url);
 
         Self {
-            url: kdc_url,
-            hostname: Some(hostname),
+            kdc_url,
+            client_computer_name: Some(client_computer_name),
         }
     }
 
     pub fn get_kdc_url(self, domain: &str) -> Option<Url> {
-        if let Some(kdc_url) = self.url {
+        if let Some(kdc_url) = self.kdc_url {
             Some(kdc_url)
         } else {
             detect_kdc_url(domain)
@@ -51,20 +67,11 @@ impl KerberosConfig {
     }
 
     pub fn from_kdc_url(url: &str) -> Self {
-        let kdc_url = parse_kdc_url(url.to_owned());
+        let kdc_url = parse_kdc_url(url);
 
         Self {
-            url: kdc_url,
-            hostname: None,
-        }
-    }
-}
-
-impl Clone for KerberosConfig {
-    fn clone(&self) -> Self {
-        Self {
-            url: self.url.clone(),
-            hostname: self.hostname.clone(),
+            kdc_url,
+            client_computer_name: None,
         }
     }
 }

--- a/src/ntlm/config.rs
+++ b/src/ntlm/config.rs
@@ -3,13 +3,16 @@ use crate::{NegotiatedProtocol, Ntlm, Result};
 
 #[derive(Debug, Clone, Default)]
 pub struct NtlmConfig {
-    pub workstation: Option<String>,
+    /// Computer name, or "workstation name", of the client machine performing the authentication attempt
+    ///
+    /// This is also referred to as the "Source Workstation".
+    pub client_computer_name: Option<String>,
 }
 
 impl NtlmConfig {
-    pub fn new(workstation: String) -> Self {
+    pub fn new(client_machine_name: String) -> Self {
         Self {
-            workstation: Some(workstation),
+            client_computer_name: Some(client_machine_name),
         }
     }
 }
@@ -19,7 +22,7 @@ impl ProtocolConfig for NtlmConfig {
         Ok(NegotiatedProtocol::Ntlm(Ntlm::with_config(Clone::clone(self))))
     }
 
-    fn clone(&self) -> Box<dyn ProtocolConfig> {
+    fn box_clone(&self) -> Box<dyn ProtocolConfig> {
         Box::new(Clone::clone(self))
     }
 }

--- a/src/ntlm/messages/client/negotiate.rs
+++ b/src/ntlm/messages/client/negotiate.rs
@@ -52,7 +52,7 @@ pub fn write_negotiate(context: &mut Ntlm, mut transport: impl io::Write) -> cra
         NEGO_MESSAGE_OFFSET as u32,
         context
             .config
-            .workstation
+            .client_computer_name
             .as_ref()
             .map(|workstation| workstation.as_bytes().to_vec()),
     );
@@ -95,7 +95,7 @@ fn get_flags(context: &Ntlm) -> NegotiateFlags {
         flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_SIGN;
     }
 
-    if context.config().workstation.is_some() {
+    if context.config().client_computer_name.is_some() {
         flags |= NegotiateFlags::NTLM_SSP_NEGOTIATE_WORKSTATION_SUPPLIED;
     }
 

--- a/src/ntlm/messages/computations/test.rs
+++ b/src/ntlm/messages/computations/test.rs
@@ -4,6 +4,7 @@ use crate::ntlm::messages::av_pair::*;
 use crate::ntlm::messages::computations::*;
 use crate::ntlm::messages::test::*;
 use crate::AuthIdentity;
+use crate::Username;
 
 #[test]
 fn get_system_time_as_file_time_test_one_second_diff() {
@@ -221,11 +222,11 @@ fn compute_ntlmv2_hash_password_is_less_than_hash_len_offset() {
 #[test]
 fn compute_ntlmv2_hash_password_local_logon() {
     let identity = AuthIdentity {
-        username: String::from("username"),
+        username: Username::new("username", Some("win7")).unwrap(),
         password: String::from("password").into(),
-        domain: Some(String::from("win7")),
     }
     .into();
+
     let expected = [
         0xef, 0xc2, 0xc0, 0x9f, 0x06, 0x11, 0x3d, 0x71, 0x08, 0xd0, 0xd2, 0x29, 0xfa, 0x4d, 0xe6, 0x98,
     ];
@@ -236,11 +237,11 @@ fn compute_ntlmv2_hash_password_local_logon() {
 #[test]
 fn compute_ntlmv2_hash_password_domain_logon() {
     let identity = AuthIdentity {
-        username: String::from("Administrator"),
+        username: Username::new("Administrator", Some("AWAKECODING")).unwrap(),
         password: String::from("Password123!").into(),
-        domain: Some(String::from("AWAKECODING")),
     }
     .into();
+
     let expected = [
         0xf7, 0x46, 0x48, 0xaa, 0x78, 0x78, 0x2e, 0x92, 0x0f, 0x92, 0x9a, 0xed, 0x7f, 0x1d, 0xd5, 0x23,
     ];
@@ -251,14 +252,15 @@ fn compute_ntlmv2_hash_password_domain_logon() {
 #[test]
 fn compute_ntlmv2_hash_works_on_empty_password() {
     let identity = AuthIdentity {
-        username: String::from("Administrator"),
+        username: Username::new("Administrator", Some("AWAKECODING")).unwrap(),
         password: String::new().into(),
-        domain: Some(String::from("AWAKECODING")),
     }
     .into();
+
     let expected = [
         0xa0, 0x84, 0x29, 0x48, 0xa6, 0xb9, 0xac, 0xa7, 0x6c, 0xf5, 0x54, 0xdb, 0x5e, 0xc3, 0x17, 0x76,
     ];
+
     assert_eq!(compute_ntlm_v2_hash(&identity).unwrap(), expected);
 }
 
@@ -270,9 +272,8 @@ fn compute_ntlmv2_hash_with_large_password() {
     let password = String::from_utf8(password).unwrap();
 
     let identity = AuthIdentity {
-        username: String::from("Administrator"),
+        username: Username::new("Administrator", Some("AWAKECODING")).unwrap(),
         password: password.into(),
-        domain: Some(String::from("AWAKECODING")),
     }
     .into();
 

--- a/src/ntlm/messages/test.rs
+++ b/src/ntlm/messages/test.rs
@@ -119,9 +119,8 @@ lazy_static! {
         result
     };
     pub static ref TEST_CREDENTIALS: AuthIdentityBuffers = AuthIdentity {
-        username: String::from("User"),
+        username: Username::new("User", Some("Domain")).unwrap(),
         password: String::from("Password").into(),
-        domain: Some(String::from("Domain")),
     }
     .into();
 }

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -467,11 +467,12 @@ impl Sspi for Ntlm {
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self))]
     fn query_context_names(&mut self) -> crate::Result<ContextNames> {
-        if let Some(ref identity_buffers) = self.identity {
-            let identity: AuthIdentity = identity_buffers.clone().into();
+        if let Some(identity_buffers) = &self.identity {
+            let identity =
+                AuthIdentity::try_from(identity_buffers).map_err(|e| Error::new(ErrorKind::InvalidParameter, e))?;
+
             Ok(ContextNames {
                 username: identity.username,
-                domain: identity.domain,
             })
         } else {
             Err(crate::Error::new(

--- a/src/pku2u/config.rs
+++ b/src/pku2u/config.rs
@@ -42,7 +42,7 @@ impl ProtocolConfig for Pku2uConfig {
         ))?))
     }
 
-    fn clone(&self) -> Box<dyn ProtocolConfig> {
+    fn box_clone(&self) -> Box<dyn ProtocolConfig> {
         Box::new(Clone::clone(self))
     }
 }

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -320,11 +320,12 @@ impl Sspi for Pku2u {
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self))]
     fn query_context_names(&mut self) -> Result<ContextNames> {
-        if let Some(ref identity_buffers) = self.auth_identity {
-            let identity: AuthIdentity = identity_buffers.clone().into();
+        if let Some(identity_buffers) = &self.auth_identity {
+            let identity =
+                AuthIdentity::try_from(identity_buffers).map_err(|e| Error::new(ErrorKind::InvalidParameter, e))?;
+
             Ok(ContextNames {
                 username: identity.username,
-                domain: identity.domain,
             })
         } else {
             Err(crate::Error::new(

--- a/tools/wasm-testcompile/src/lib.rs
+++ b/tools/wasm-testcompile/src/lib.rs
@@ -1,18 +1,22 @@
 use sspi::ntlm::NtlmConfig;
-use sspi::{credssp, Credentials};
+use sspi::{credssp, AuthIdentity, Credentials, Username};
 use wasm_bindgen::prelude::*;
-
 
 #[wasm_bindgen]
 pub fn credssp_client() {
+    let identity = AuthIdentity {
+        username: Username::parse("NETBIOSDMN\\AccountName").unwrap(),
+        password: String::from("secret").into(),
+    };
+
     let mut cred_ssp_client = credssp::CredSspClient::new(
         Vec::new(),
-        Credentials::AuthIdentity(Default::default()),
+        Credentials::AuthIdentity(identity),
         credssp::CredSspMode::WithCredentials,
         credssp::ClientMode::Negotiate(sspi::NegotiateConfig {
             protocol_config: Box::<NtlmConfig>::default(),
             package_list: None,
-            hostname: "testhostname".into(),
+            client_computer_name: "win2017".into(),
         }),
         String::new(),
     )


### PR DESCRIPTION
- When appropriate, "hostname" was renamed into "client_computer_name"

- Likewise, "Kerberos::url" has been renamed to "Kerberos::kdc_url" and the meaning of the field has been documented (KDC url vs KKDCP url)

- A wrapper around username is exposed to the library user to make it clear that there are different formats:

  - User Principal Name (UPN)
  - Down-Level Logon Name

  Convenience functions are provided to help the user building
  proper usernames.