### PR TITLE
Fix: NTLM not working in IronRDP, Add Flag to enforce sign and seal

### DIFF
--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -290,7 +290,12 @@ impl CredSspClient {
                 let cred_ssp_context = self.context.as_mut().unwrap();
                 let mut builder = EmptyInitializeSecurityContext::<<SspiContext as SspiImpl>::CredentialsHandle>::new()
                     .with_credentials_handle(&mut credentials_handle)
-                    .with_context_requirements(ClientRequestFlags::MUTUAL_AUTH | ClientRequestFlags::USE_SESSION_KEY)
+                    .with_context_requirements(
+                        ClientRequestFlags::MUTUAL_AUTH
+                            | ClientRequestFlags::USE_SESSION_KEY
+                            | ClientRequestFlags::INTEGRITY
+                            | ClientRequestFlags::CONFIDENTIALITY,
+                    )
                     .with_target_data_representation(DataRepresentation::Native)
                     .with_target_name(&self.service_principal_name)
                     .with_input(&mut input_token)


### PR DESCRIPTION
This PR is currently for discussion only. we could hard code the flag in CredSSP, but might not be desired. 

This fixes problem in [IronRDP PR, Enable Kerberos](https://github.com/Devolutions/IronRDP/pull/260).

The changes will force CredSSP to sign and seal the message, which allows it to have the same behavior as before