### PR TITLE
Fix: the GSS Flags were hard coded, which does not work for Ldaps,Fixed.

### DIFF
--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -362,9 +362,9 @@ impl Default for ChecksumValues {
     }
 }
 
-impl Into<Vec<u8>> for ChecksumValues {
-    fn into(self) -> Vec<u8> {
-        self.inner
+impl From<ChecksumValues> for Vec<u8> {
+    fn from(val: ChecksumValues) -> Self {
+        val.inner
     }
 }
 

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -33,7 +33,7 @@ use self::client::generators::{
     generate_ap_req, generate_as_req, generate_as_req_kdc_body, generate_krb_priv_request, generate_neg_ap_req,
     generate_neg_token_init, generate_pa_datas_for_as_req, generate_tgs_req, get_client_principal_name_type,
     get_client_principal_realm, ChecksumOptions,ChecksumValues, EncKey, GenerateAsPaDataOptions, GenerateAsReqOptions,
-    GenerateAuthenticatorOptions, AUTHENTICATOR_DEFAULT_CHECKSUM,
+    GenerateAuthenticatorOptions,
 };
 use self::config::KerberosConfig;
 use self::pa_datas::AsReqPaDataOptions;
@@ -44,7 +44,7 @@ use crate::builders::ChangePassword;
 use crate::generator::{GeneratorChangePassword, GeneratorInitSecurityContext, NetworkRequest, YieldPointLocal};
 use crate::kerberos::client::extractors::{extract_salt_from_krb_error, extract_status_code_from_krb_priv_response};
 use crate::kerberos::client::generators::{
-    generate_authenticator, generate_final_neg_token_targ, get_mech_list, GenerateTgsReqOptions, GssFlags,
+    generate_authenticator, generate_final_neg_token_targ, get_mech_list, GenerateTgsReqOptions,
 };
 use crate::kerberos::pa_datas::AsRepSessionKeyExtractor;
 use crate::kerberos::server::extractors::{extract_ap_rep_from_neg_token_targ, extract_sub_session_key_from_ap_rep};
@@ -888,7 +888,7 @@ impl<'a> Kerberos {
 
                     checksum: Some(ChecksumOptions {
                         checksum_type: AUTHENTICATOR_CHECKSUM_TYPE.to_vec(),
-                        checksum_value: checksum_value,
+                        checksum_value,
                     }),
                     channel_bindings: self.channel_bindings.as_ref(),
                     extensions: Vec::new(),

--- a/src/pku2u/generators.rs
+++ b/src/pku2u/generators.rs
@@ -251,9 +251,10 @@ pub fn generate_authenticator(options: GenerateAuthenticatorOptions) -> Result<A
 
     let cksum = if let Some(ChecksumOptions {
         checksum_type,
-        mut checksum_value,
+        checksum_value,
     }) = checksum
     {
+        let mut checksum_value = checksum_value.get_inner();
         if checksum_type == AUTHENTICATOR_CHECKSUM_TYPE && channel_bindings.is_some() {
             if checksum_value.len() < 20 {
                 return Err(Error::new(

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -665,7 +665,7 @@ impl Pku2u {
                     }),
                     checksum: Some(ChecksumOptions {
                         checksum_type: AUTHENTICATOR_CHECKSUM_TYPE.to_vec(),
-                        checksum_value: AUTHENTICATOR_DEFAULT_CHECKSUM.to_vec(),
+                        checksum_value: AUTHENTICATOR_DEFAULT_CHECKSUM.into(),
                     }),
                     channel_bindings: None,
                     extensions: vec![generate_authenticator_extension(


### PR DESCRIPTION
Note: This change might be breaking. Confidentiality and integrity is not implied anymore. User needs to actively specify these two flag to get sign and seal. 

This change is critical for LDAPs, as Active Directory does not accept Kerberos with sign and seal flags.

This implementation requires reviewers attention, in particular, at line 408 of src/kerberos/client/generators.rs. Where windows never specified how these flags map to the GSS checksum flags. This is purely guessed from their[ Kerberos documentation](https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-KILE/%5bMS-KILE%5d.pdf) at section 3.2.5.2. and the [SSPI documentation ](https://learn.microsoft.com/en-us/windows/win32/secauthn/context-requirements). 

Whether this implementation is correct or not, we need a way for caller to change that flag.
