### PR TITLE
Fix Negotiate failure to fallback to NTLM

### DIFF
--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -508,6 +508,7 @@ impl<'a> Negotiate {
             let account_name = auth_identity.username.account_name();
             let domain_name = auth_identity.username.domain_name().unwrap_or("");
             self.negotiate_protocol(account_name, domain_name)?;
+            self.auth_identity = Some(CredentialsBuffers::AuthIdentity(auth_identity.into()));
         }
 
         #[cfg(feature = "scard")]


### PR DESCRIPTION
When the first time InitializeSercurityContext is called for negotiate, the variable `self.auth_identity` is always None, but latter used when switching to NTLM or PKU2U, which of course will not work since it is None. Fixed the problem so Negotiate could properly fallback to NTLM with authentication information from the builder.