### PR TITLE
Expose RustSspiSetupLogger

### DIFF
--- a/ffi/sspi.def
+++ b/ffi/sspi.def
@@ -19,6 +19,7 @@ EXPORTS
     QueryContextAttributesW=Rust_QueryContextAttributesW
     ImpersonateSecurityContext=Rust_ImpersonateSecurityContext
     RevertSecurityContext=Rust_RevertSecurityContext
+    RustSspiSetupLogger=RustSspiSetupLogger
     MakeSignature=Rust_MakeSignature
     VerifySignature=Rust_VerifySignature
     FreeContextBuffer=Rust_FreeContextBuffer


### PR DESCRIPTION
Forget to add it to sspi.def before, now correctly expose it to the caller.