### PR TITLE
Fix Kerberos ApReq Authenticator Checksum Flags

### DIFF
--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -885,9 +885,16 @@ impl<'a> Kerberos {
                 // GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG | GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG
                 // we want to be able to turn of sign and seal, so we leave confidentiality and integrity flags out
                 // FIXME: CredSSP fails when flags are included in the checksum.
-                // let flags = builder.context_requirements.into();
-                let checksum_value = ChecksumValues::default();
-                // checksum_value.set_flags(flags);
+                use crate::kerberos::client::generators::GssFlags;
+                let mut flags: GssFlags = builder.context_requirements.into();
+                if flags.contains(GssFlags::GSS_C_DELEG_FLAG) {
+                    warn!("GssFlags::GSS_C_DELEG_FLAG is not supported.");
+                    flags.remove(GssFlags::GSS_C_DELEG_FLAG);
+                }
+                info!(?flags, "ApReq Authenticator checksum flags");
+
+                let mut checksum_value = ChecksumValues::default();
+                checksum_value.set_flags(flags);
 
                 let authenticator_options = GenerateAuthenticatorOptions {
                     kdc_rep: &tgs_rep.0,

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -44,7 +44,7 @@ use crate::builders::ChangePassword;
 use crate::generator::{GeneratorChangePassword, GeneratorInitSecurityContext, NetworkRequest, YieldPointLocal};
 use crate::kerberos::client::extractors::{extract_salt_from_krb_error, extract_status_code_from_krb_priv_response};
 use crate::kerberos::client::generators::{
-    generate_authenticator, generate_final_neg_token_targ, get_mech_list, GenerateTgsReqOptions,
+    generate_authenticator, generate_final_neg_token_targ, get_mech_list, GenerateTgsReqOptions, GssFlags,
 };
 use crate::kerberos::pa_datas::AsRepSessionKeyExtractor;
 use crate::kerberos::server::extractors::{extract_ap_rep_from_neg_token_targ, extract_sub_session_key_from_ap_rep};
@@ -881,14 +881,20 @@ impl<'a> Kerberos {
                     .unwrap_or(&DEFAULT_ENCRYPTION_TYPE);
                 let authenticator_sub_key = generate_random_symmetric_key(enc_type, &mut OsRng);
 
-                // the original flag is
-                // GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG | GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG
-                // we want to be able to turn of sign and seal, so we leave confidentiality and integrity flags out
-                // FIXME: CredSSP fails when flags are included in the checksum.
-                use crate::kerberos::client::generators::GssFlags;
                 let mut flags: GssFlags = builder.context_requirements.into();
                 if flags.contains(GssFlags::GSS_C_DELEG_FLAG) {
-                    warn!("GssFlags::GSS_C_DELEG_FLAG is not supported.");
+                    // Below are reasons why we turn off the GSS_C_DELEG_FLAG flag.
+                    //
+                    // RFC4121: The Kerberos Version 5 GSS-API. Section 4.1.1:  Authenticator Checksum
+                    // https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1.1
+                    //
+                    // "The length of the checksum field MUST be at least 24 octets when GSS_C_DELEG_FLAG is not set,
+                    // and at least 28 octets plus Dlgth octets when GSS_C_DELEG_FLAG is set."
+                    // Out implementation _always_ uses the 24 octets checksum and do not support Kerberos credentials delegation.
+                    //
+                    // "When delegation is used, a ticket-granting ticket will be transferred in a KRB_CRED message."
+                    // We do not support KRB_CRED messages. So, the GSS_C_DELEG_FLAG flags should be turned off.
+                    warn!("Kerberos ApReq Authenticator checksum GSS_C_DELEG_FLAG is not supported. Turning it off...");
                     flags.remove(GssFlags::GSS_C_DELEG_FLAG);
                 }
                 info!(?flags, "ApReq Authenticator checksum flags");


### PR DESCRIPTION
Hi,
In this pull request, I fixed the issue mentioned here: https://github.com/Devolutions/sspi-rs/pull/206#discussion_r1480849938 

During the issue investigation, I noticed that authentication works with all flags except the `GSS_C_DELEG_FLAG` one. It didn't seem related to the smart card authentication stuff. I tested the authentication with password-based logon and got the same error. So it's not related to the login type.

Then I reread the RFC that contains this flag explanation. [RFC 4121: Section 4.1.1:  Authenticator Checksum](https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1.1):

> The length of the checksum field MUST be at least 24 octets when GSS_C_DELEG_FLAG is not set,
> and at least 28 octets plus Dlgth octets when GSS_C_DELEG_FLAG is set.

Our authenticator checksum always has the 24 octets len (https://github.com/Devolutions/sspi-rs/blob/6dae2a5999088b8b8587a77b9c63c9473c0387c8/src/kerberos/client/generators.rs#L66 and https://github.com/Devolutions/sspi-rs/blob/6dae2a5999088b8b8587a77b9c63c9473c0387c8/src/kerberos/client/generators.rs#L360) and we don't support any checksum extensions yet. But the RFC requires at least 28 octets when the `GSS_C_DELEG_FLAG` is set. On the other hand, the same RFC says:

> When delegation is used, a ticket-granting ticket will be transferred in a KRB_CRED message.

In our current Kerberos implementation, we don't support the `KRB_CRED` message. So, my solution is to disable the `GSS_C_DELEG_FLAG` flag. I added a comment in the code with an explanation about this decision.

Docs & references:

* [RFC 4120: The Kerberos Network Authentication Service](https://datatracker.ietf.org/doc/html/rfc4120)
* [RFC 4121: The Kerberos Version 5 GSS-API](https://datatracker.ietf.org/doc/html/rfc4121)