### PR TITLE
Fix username handling in FFI during smart card logon

### DIFF
--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -16,8 +16,6 @@ use winapi::um::wincred::CredIsMarshaledCredentialW;
 use windows_sys::Win32::Security::Credentials::{CredUIPromptForWindowsCredentialsW, CREDUI_INFOW};
 
 use super::sspi_data_types::{SecWChar, SecurityStatus};
-#[cfg(feature = "tsssp")]
-use super::utils::raw_wide_str_trim_nulls;
 use crate::utils::{c_w_str_to_string, into_raw_ptr, raw_str_into_bytes};
 
 pub const SEC_WINNT_AUTH_IDENTITY_ANSI: u32 = 0x1;

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -544,6 +544,8 @@ pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w_sized(
 
     use windows_sys::Win32::Security::Credentials::{CredUnPackAuthenticationBufferW, CRED_PACK_PROTECTED_CREDENTIALS};
 
+    use super::utils::raw_wide_str_trim_nulls;
+
     if p_auth_data.is_null() {
         return Err(Error::new(
             ErrorKind::InvalidParameter,
@@ -601,6 +603,7 @@ pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w_sized(
 
         match SmartCardInfo::try_from_env() {
             Ok(smart_card_info) => {
+                raw_wide_str_trim_nulls(&mut username);
                 // In the `SmartCardIdentityBuffers` structure we hold credentials as raw wide string without NULL-terminator bytes.
                 // The `CredUnPackAuthenticationBufferW` function always returns credentials as strings.
                 // So, password data is a wide C string and we need to delete the NULL terminator.

--- a/ffi/src/sspi/utils.rs
+++ b/ffi/src/sspi/utils.rs
@@ -20,7 +20,7 @@ pub unsafe fn transform_credentials_handle<'a>(
 
 // when encoding an UTF-16 character using two code units, the 16-bit values are chosen from the UTF-16 surrogate range 0xD800–0xDFFF,
 // and thus only \0 is encoded by two consecutive null bytes
-#[cfg(feature = "tsssp")]
+#[cfg(any(feature = "tsssp", feature = "scard"))]
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
     let mut len = raw_str.len();
     while len > 2 && raw_str[len - 2..] == [0, 0] {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -27,7 +27,7 @@ pub fn str_to_w_buff(data: &str) -> Vec<u16> {
     data.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
-#[cfg(feature = "scard")]
+#[cfg(all(feature = "scard", feature = "tsssp"))]
 pub fn str_encode_utf16(data: &str) -> Vec<u8> {
     data.encode_utf16().flat_map(|c| c.to_le_bytes()).collect()
 }


### PR DESCRIPTION
Hi,
In this pull request, I've fixed username handling during the smart card logon.
The problem was in the null characters at the end of the username buffer. We had a similar situation during the password-based logon: https://github.com/Devolutions/sspi-rs/blob/winscard-rs-impl/ffi/src/sspi/sec_winnt_auth_identity.rs#L645-L646