### PR TITLE
chore(dotnet): prepare for 2023.15.2.0

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -183,7 +183,7 @@ jobs:
           }
           Set-Content -Path .\ffi\Cargo.toml -Value $CargoToml
 
-          $CargoArgs = @('build', '-p', 'sspi-ffi', '--target', $RustTarget)
+          $CargoArgs = @('build', '-p', 'sspi-ffi', '--target', $RustTarget, '--features', 'scard')
 
           if (-Not ($BuildType -Eq 'debug')) {
             $CargoArgs += @('--release')

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -183,10 +183,14 @@ jobs:
           }
           Set-Content -Path .\ffi\Cargo.toml -Value $CargoToml
 
-          $CargoArgs = @('build', '-p', 'sspi-ffi', '--target', $RustTarget, '--features', 'scard')
+          $CargoArgs = @('build', '-p', 'sspi-ffi', '--target', $RustTarget)
 
           if (-Not ($BuildType -Eq 'debug')) {
             $CargoArgs += @('--release')
+          }
+
+          if ($DotNetOs -Eq 'win') {
+            $CargoArgs += @('--features', 'scard')
           }
 
           $CargoCmd = $(@('cargo') + $CargoArgs) -Join ' '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,8 @@ jobs:
             additional-args: --features tsssp,scard
           - os: osx
             runner: macos-12
-            additional-args: --features scard
           - os: linux
             runner: ubuntu-20.04
-            additional-args: --features scard
 
     steps:
       - uses: actions/checkout@v3
@@ -72,10 +70,8 @@ jobs:
             additional-args: --features tsssp,scard
           - os: osx
             runner: macos-12
-            additional-args: --features scard
           - os: linux
             runner: ubuntu-20.04
-            additional-args: --features scard
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,10 @@ jobs:
             additional-args: --features tsssp,scard
           - os: osx
             runner: macos-12
+            additional-args: --features scard
           - os: linux
             runner: ubuntu-20.04
+            additional-args: --features scard
 
     steps:
       - uses: actions/checkout@v3
@@ -70,8 +72,10 @@ jobs:
             additional-args: --features tsssp,scard
           - os: osx
             runner: macos-12
+            additional-args: --features scard
           - os: linux
             runner: ubuntu-20.04
+            additional-args: --features scard
 
     steps:
       - uses: actions/checkout@v3

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -5,7 +5,7 @@
     <Description>Portable Rust SSPI library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2023.12.20.0</Version>
+    <Version>2023.15.2.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
The first release featuring the emulated WinSCard support. I also modified the CI to enable the `scard` feature.