### PR TITLE
fix(ffi): memory leak during message decryption

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -9,8 +9,8 @@ use std::net::TcpStream;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use sspi::{
-    AuthIdentity, ClientRequestFlags, CredentialUse, DataRepresentation, Ntlm, SecurityBuffer, SecurityBufferType,
-    SecurityStatus, Sspi, SspiImpl, Username,
+    AuthIdentity, ClientRequestFlags, CredentialUse, DataRepresentation, DecryptBuffer, Ntlm, SecurityBuffer,
+    SecurityBufferType, SecurityStatus, Sspi, SspiImpl, Username,
 };
 
 const IP: &str = "127.0.0.1:8080";
@@ -53,8 +53,8 @@ fn main() -> Result<(), io::Error> {
     println!("Encrypted message: {:?}", data);
 
     let mut msg_buffer = vec![
-        SecurityBuffer::new(trailer, SecurityBufferType::Token),
-        SecurityBuffer::new(data, SecurityBufferType::Data),
+        DecryptBuffer::new(&mut trailer, SecurityBufferType::Token),
+        DecryptBuffer::new(&mut data, SecurityBufferType::Data),
     ];
 
     let _decryption_flags = ntlm.decrypt_message(&mut msg_buffer, 0)?;
@@ -62,7 +62,7 @@ fn main() -> Result<(), io::Error> {
     println!("Decrypting...");
     println!(
         "Decrypted message: [{}]",
-        std::str::from_utf8(msg_buffer[1].buffer.as_slice()).unwrap()
+        std::str::from_utf8(msg_buffer[1].buffer).unwrap()
     );
 
     println!("Communication successfully finished.");

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -146,7 +146,7 @@ impl Sspi for SspiHandle {
 
     fn decrypt_message(
         &mut self,
-        message: &mut [sspi::SecurityBuffer],
+        message: &mut [sspi::DecryptBuffer],
         sequence_number: u32,
     ) -> Result<sspi::DecryptionFlags> {
         self.sspi_context.lock()?.decrypt_message(message, sequence_number)

--- a/src/builders/acq_cred_handle.rs
+++ b/src/builders/acq_cred_handle.rs
@@ -9,14 +9,6 @@ use crate::{CredentialUse, Luid, SspiPackage};
 pub type EmptyAcquireCredentialsHandle<'a, C, A> = AcquireCredentialsHandle<'a, C, A, WithoutCredentialUse>;
 pub type FilledAcquireCredentialsHandle<'a, C, A> = AcquireCredentialsHandle<'a, C, A, WithCredentialUse>;
 
-impl<'a, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData> {}
-
-impl<'a, C, A> Default for EmptyAcquireCredentialsHandle<'a, C, A> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Contains data returned by calling the `execute` method of
 /// the `AcquireCredentialsHandleBuilder` structure. The builder is returned by calling
 /// the `acquire_credentials_handle` method.

--- a/src/credssp/sspi_cred_ssp/tls_connection.rs
+++ b/src/credssp/sspi_cred_ssp/tls_connection.rs
@@ -10,6 +10,19 @@ use crate::{
 
 // type + version + length
 pub const TLS_PACKET_HEADER_LEN: usize = 1 /* ContentType */ + 2 /* ProtocolVersion */ + 2 /* length: uint16 */;
+
+// The Secure Sockets Layer (SSL) Protocol Version 3.0
+// https://datatracker.ietf.org/doc/html/rfc6101#page-14
+//
+// ...Sequence numbers are of type uint64 and may not exceed 2^64-1.
+const TLS_PACKET_SEQUENCE_NUMBER_LEN: usize = std::mem::size_of::<u64>();
+
+// The Secure Sockets Layer (SSL) Protocol Version 3.0
+// https://datatracker.ietf.org/doc/html/rfc6101#appendix-A.1
+//
+// application_data(23)
+const TLS_APPLICATION_CONTENT_TYPE: u8 = 0x17;
+
 // [Block Size and Padding](https://www.rfc-editor.org/rfc/rfc3826#section-3.1.1.3)
 // The block size of the AES cipher is 128 bits
 const AES_BLOCK_SIZE: usize = 16;
@@ -42,6 +55,54 @@ pub mod danger {
     }
 }
 
+/// Represents parsed part of the TLS traffic.
+///
+/// The input buffer can contain part of the TLS message, one TLS packet, or even more than one TLS packet.
+/// To decrypt the incoming buffer sometimes we need to split it into parts. If it contains more then one TLS packet,
+/// we should decrypt only first of them. This behavior corresponds to the SChannel behavior.
+#[derive(Debug)]
+struct TlsTrafficParts<'data> {
+    /// TLS packet header with a sequence number.
+    header: &'data mut [u8],
+    /// Decrypted part of the TLS packet.
+    ///
+    /// *Pay attention*: the TLS packet sequence number must be in the [header] buffer.
+    application_data: &'data mut [u8],
+    /// Unprocessed TLS packets.
+    extra: &'data mut [u8],
+}
+
+impl<'a> From<&'a mut [u8]> for TlsTrafficParts<'a> {
+    fn from(value: &'a mut [u8]) -> Self {
+        Self {
+            header: &mut [],
+            application_data: value,
+            extra: &mut [],
+        }
+    }
+}
+
+/// Represents buffers after the decryption.
+///
+/// We can not return just decrypted data because we also need a TLS header and unprocessed data buffers.
+/// More info: https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--schannel
+///
+/// After the decryption, the original SChannel produces four buffers (the order is important):
+/// * SECBUFFER_STREAM_HEADER. It contains TLS packet header with a sequence number.
+/// * SECBUFFER_DATA. It contains a decrypted data.
+/// * SECBUFFER_STREAM_TRAILER. It contains the TLS packet HMAC with all unprocessed data.
+/// * SECBUFFER_EXTRA. It contains the rest of the unprocessed TLS traffic. Usually, the start of this buffer
+///   points to the start of the next TLS packet in the input buffer.
+#[derive(Debug)]
+pub struct DecryptionResultBuffers<'data> {
+    /// TLS packet header with the sequence number.
+    pub header: &'data mut [u8],
+    /// Decrypted data.
+    pub decrypted: &'data mut [u8],
+    /// Unprocessed TLS packets.
+    pub extra: &'data mut [u8],
+}
+
 #[derive(Debug)]
 pub enum TlsConnection {
     Rustls(Connection),
@@ -63,21 +124,139 @@ impl TlsConnection {
         }
     }
 
-    pub fn decrypt_tls(&mut self, mut payload: &[u8]) -> Result<Vec<u8>> {
+    // This function extracts the application data (encrypted part) of the TLS packet.
+    // If the input buffer contains more than one TLS packet, then the application data of
+    // the first one will be returned.
+    // If the input buffer contains less than one TLS packet (only a part of it), then
+    // the whole input buffer will be returned.
+    fn find_tls_data_to_decrypt<'data>(connection: &Connection, payload: &'data mut [u8]) -> Result<&'data mut [u8]> {
+        if payload.len() < TLS_PACKET_HEADER_LEN + TLS_PACKET_SEQUENCE_NUMBER_LEN {
+            return Ok(payload);
+        }
+
+        let mut tls_packet_start = vec![TLS_APPLICATION_CONTENT_TYPE];
+        let tls_version = connection
+            .protocol_version()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Can not query negotiated TLS version"))?
+            .get_u16()
+            .to_be_bytes();
+        tls_packet_start.extend_from_slice(&tls_version);
+
+        // safe: payload length is checked above.
+        if payload[0..3] != tls_packet_start {
+            return Ok(payload);
+        }
+
+        // safe: payload length is checked above.
+        let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
+
+        if payload.len() < TLS_PACKET_HEADER_LEN + encrypted_application_data_len {
+            return Ok(payload);
+        }
+
+        let tls_packet_len = TLS_PACKET_HEADER_LEN + encrypted_application_data_len;
+
+        // safe: payload length is checked above.
+        Ok(&mut payload[0..tls_packet_len])
+    }
+
+    // This function splits the incoming TLS traffic into three parts (if possible):
+    // * header.
+    // * application_data.
+    // * extra.
+    // See the [TlsTrafficParts] documentation for a more detailed explanation of those buffers.
+    fn split_tls_traffic<'a>(connection: &Connection, payload: &'a mut [u8]) -> Result<TlsTrafficParts<'a>> {
+        const TLS_PACKET_PREFIX_LEN: usize = TLS_PACKET_HEADER_LEN + TLS_PACKET_SEQUENCE_NUMBER_LEN;
+        if payload.len() < TLS_PACKET_PREFIX_LEN {
+            return Ok(payload.into());
+        }
+
+        let mut tls_packet_start = vec![TLS_APPLICATION_CONTENT_TYPE];
+        let tls_version = connection
+            .protocol_version()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Can not query negotiated TLS version"))?
+            .get_u16()
+            .to_be_bytes();
+        tls_packet_start.extend_from_slice(&tls_version);
+
+        // safe: payload length is checked above.
+        if payload[0..3] != tls_packet_start {
+            return Ok(payload.into());
+        }
+
+        // safe: payload length is checked above.
+        let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
+
+        if payload.len() < TLS_PACKET_PREFIX_LEN + encrypted_application_data_len {
+            let (header, application_data) = payload.split_at_mut(TLS_PACKET_PREFIX_LEN);
+            return Ok(TlsTrafficParts {
+                header,
+                application_data,
+                extra: &mut [],
+            });
+        }
+
+        // safe: payload length is checked above.
+        let (header, rest) = payload.split_at_mut(TLS_PACKET_PREFIX_LEN);
+        // `encrypted_application_data_len` is a len of the encrypted data with the sequence number.
+        // But here we need the encrypted data WITHOUT a sequence number, so we extract TLS_PACKET_SEQUENCE_NUMBER_LEN
+        // from the overall data length.
+        let (application_data, extra) =
+            rest.split_at_mut(encrypted_application_data_len - TLS_PACKET_SEQUENCE_NUMBER_LEN);
+
+        Ok(TlsTrafficParts {
+            header,
+            application_data,
+            extra,
+        })
+    }
+
+    /// Decrypt a part of the incoming TLS traffic.
+    ///
+    /// If the input buffer contains more than one TLS message,then only the first one will be decrypted.
+    pub fn decrypt_tls<'a>(&mut self, payload: &'a mut [u8]) -> Result<DecryptionResultBuffers<'a>> {
         match self {
             TlsConnection::Rustls(tls_connection) => {
-                tls_connection.read_tls(&mut payload)?;
+                let tls_data_to_decrypt = TlsConnection::find_tls_data_to_decrypt(tls_connection, payload)?;
+                let mut tls_packet: &[u8] = tls_data_to_decrypt;
 
-                let tls_state = tls_connection
-                    .process_new_packets()
-                    .map_err(|err| Error::new(ErrorKind::DecryptFailure, err.to_string()))?;
+                let mut plain_data = Vec::with_capacity(tls_packet.len());
 
-                let mut reader = tls_connection.reader();
+                while !tls_packet.is_empty() {
+                    let _ = tls_connection.read_tls(&mut tls_packet)?;
 
-                let mut plain_data = vec![0; tls_state.plaintext_bytes_to_read()];
-                let _plain_data_len = reader.read(&mut plain_data)?;
+                    let tls_state = tls_connection
+                        .process_new_packets()
+                        .map_err(|err| Error::new(ErrorKind::DecryptFailure, err.to_string()))?;
 
-                Ok(plain_data)
+                    let decrypted_data_len = plain_data.len();
+                    plain_data.resize(decrypted_data_len + tls_state.plaintext_bytes_to_read(), 0);
+
+                    let mut reader = tls_connection.reader();
+                    let _plain_data_len = reader.read(&mut plain_data[decrypted_data_len..])?;
+                }
+
+                let TlsTrafficParts {
+                    header,
+                    application_data,
+                    extra,
+                } = TlsConnection::split_tls_traffic(tls_connection, payload)?;
+
+                if application_data.len() < plain_data.len() {
+                    return Err(Error::new(
+                        ErrorKind::DecryptFailure,
+                        "Decrypted data can not be larger then encrypted one.",
+                    ));
+                }
+
+                let decrypted = &mut application_data[0..plain_data.len()];
+                decrypted.copy_from_slice(&plain_data);
+
+                Ok(DecryptionResultBuffers {
+                    header,
+                    decrypted,
+                    extra,
+                })
             }
         }
     }

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -56,13 +56,16 @@ use crate::pk_init::{self, DhParameters};
 use crate::pku2u::generate_client_dh_parameters;
 #[cfg(feature = "scard")]
 use crate::smartcard::SmartCard;
-use crate::utils::{generate_random_symmetric_key, get_encryption_key, utf16_bytes_to_utf8_string};
+use crate::utils::{
+    extract_encrypted_data, generate_random_symmetric_key, get_encryption_key, save_decrypted_data,
+    utf16_bytes_to_utf8_string,
+};
 use crate::{
     check_if_empty, detect_kdc_url, AcceptSecurityContextResult, AcquireCredentialsHandleResult, AuthIdentity,
     ClientRequestFlags, ClientResponseFlags, ContextNames, ContextSizes, CredentialUse, Credentials,
-    CredentialsBuffers, DecryptionFlags, Error, ErrorKind, InitializeSecurityContextResult, PackageCapabilities,
-    PackageInfo, Result, SecurityBuffer, SecurityBufferType, SecurityPackageType, SecurityStatus, ServerResponseFlags,
-    Sspi, SspiEx, SspiImpl, PACKAGE_ID_NONE,
+    CredentialsBuffers, DecryptBuffer, DecryptionFlags, Error, ErrorKind, InitializeSecurityContextResult,
+    PackageCapabilities, PackageInfo, Result, SecurityBuffer, SecurityBufferType, SecurityPackageType, SecurityStatus,
+    ServerResponseFlags, Sspi, SspiEx, SspiImpl, PACKAGE_ID_NONE,
 };
 
 pub const PKG_NAME: &str = "Kerberos";
@@ -353,23 +356,10 @@ impl Sspi for Kerberos {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self, _sequence_number))]
-    fn decrypt_message(
-        &mut self,
-        message: &mut [SecurityBuffer],
-        _sequence_number: u32,
-    ) -> Result<crate::DecryptionFlags> {
+    fn decrypt_message(&mut self, message: &mut [DecryptBuffer], _sequence_number: u32) -> Result<DecryptionFlags> {
         trace!(encryption_params = ?self.encryption_params);
 
-        let mut encrypted = if let Ok(buffer) = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Token) {
-            buffer
-        } else {
-            SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Stream)?
-        }
-        .buffer
-        .clone();
-        let data = SecurityBuffer::find_buffer_mut(message, SecurityBufferType::Data)?;
-
-        encrypted.extend_from_slice(&data.buffer);
+        let encrypted = extract_encrypted_data(message)?;
 
         let cipher = self
             .encryption_params
@@ -390,23 +380,18 @@ impl Sspi for Kerberos {
         // remove wrap token header
         decrypted.truncate(decrypted.len() - WrapToken::header_len());
 
+        save_decrypted_data(&decrypted, message)?;
+
         match self.state {
             KerberosState::PubKeyAuth => {
                 self.state = KerberosState::Credentials;
-
-                *data.buffer.as_mut() = decrypted;
                 Ok(DecryptionFlags::empty())
             }
             KerberosState::Credentials => {
                 self.state = KerberosState::Final;
-
-                *data.buffer.as_mut() = decrypted;
                 Ok(DecryptionFlags::empty())
             }
-            _ => {
-                *data.buffer.as_mut() = decrypted;
-                Ok(DecryptionFlags::empty())
-            }
+            _ => Ok(DecryptionFlags::empty()),
         }
     }
 
@@ -1025,7 +1010,10 @@ mod tests {
     use super::EncryptionParams;
     use crate::generator::NetworkRequest;
     use crate::network_client::NetworkClient;
-    use crate::{EncryptionFlags, Kerberos, KerberosConfig, KerberosState, SecurityBuffer, SecurityBufferType, Sspi};
+    use crate::{
+        DecryptBuffer, EncryptionFlags, Kerberos, KerberosConfig, KerberosState, SecurityBuffer, SecurityBufferType,
+        Sspi,
+    };
 
     struct NetworkClientMock;
 
@@ -1112,18 +1100,18 @@ mod tests {
         let mut buffer = message[0].buffer.clone();
         buffer.extend_from_slice(&message[1].buffer);
         let mut message = [
-            SecurityBuffer {
-                buffer,
+            DecryptBuffer {
+                buffer: &mut buffer,
                 buffer_type: SecurityBufferType::Stream,
             },
-            SecurityBuffer {
-                buffer: Vec::new(),
+            DecryptBuffer {
+                buffer: &mut [],
                 buffer_type: SecurityBufferType::Data,
             },
         ];
 
         kerberos_client.decrypt_message(&mut message, 0).unwrap();
 
-        assert_eq!(message[1].buffer, plain_message);
+        assert_eq!(message[0].buffer, plain_message);
     }
 }

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -11,10 +11,10 @@ use crate::ntlm::NtlmConfig;
 use crate::utils::is_azure_ad_domain;
 use crate::{
     builders, kerberos, ntlm, pku2u, AcceptSecurityContextResult, AcquireCredentialsHandleResult, AuthIdentity,
-    CertTrustStatus, ContextNames, ContextSizes, CredentialUse, Credentials, CredentialsBuffers, DecryptionFlags,
-    Error, ErrorKind, InitializeSecurityContextResult, Kerberos, KerberosConfig, Ntlm, PackageCapabilities,
-    PackageInfo, Pku2u, Result, SecurityBuffer, SecurityPackageType, SecurityStatus, Sspi, SspiEx, SspiImpl,
-    PACKAGE_ID_NONE,
+    CertTrustStatus, ContextNames, ContextSizes, CredentialUse, Credentials, CredentialsBuffers, DecryptBuffer,
+    DecryptionFlags, Error, ErrorKind, InitializeSecurityContextResult, Kerberos, KerberosConfig, Ntlm,
+    PackageCapabilities, PackageInfo, Pku2u, Result, SecurityBuffer, SecurityPackageType, SecurityStatus, Sspi, SspiEx,
+    SspiImpl, PACKAGE_ID_NONE,
 };
 
 pub const PKG_NAME: &str = "Negotiate";
@@ -316,7 +316,11 @@ impl Sspi for Negotiate {
     }
 
     #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
-    fn decrypt_message(&mut self, message: &mut [SecurityBuffer], sequence_number: u32) -> Result<DecryptionFlags> {
+    fn decrypt_message<'data>(
+        &mut self,
+        message: &mut [DecryptBuffer<'data>],
+        sequence_number: u32,
+    ) -> Result<DecryptionFlags> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.decrypt_message(message, sequence_number),
             NegotiatedProtocol::Kerberos(kerberos) => kerberos.decrypt_message(message, sequence_number),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 
 use crate::kerberos::EncryptionParams;
-use crate::{Error, ErrorKind, Result};
+use crate::{DecryptBuffer, Error, ErrorKind, Result, SecurityBufferType};
 
 pub fn string_to_utf16(value: impl AsRef<str>) -> Vec<u8> {
     value
@@ -239,4 +239,49 @@ pub fn get_encryption_key(enc_params: &EncryptionParams) -> Result<&[u8]> {
 
         Err(Error::new(ErrorKind::EncryptFailure, "No encryption key provided"))
     }
+}
+
+/// Copies a decrypted data into the [SecurityBufferType::Data].
+///
+/// If the provided buffer is not large enough, then this function will return an error.
+/// If the provided buffers do not contain the [SecurityBufferType::Data] buffer,
+/// then this function will return an error.
+pub fn save_decrypted_data(decrypted: &[u8], buffers: &mut [DecryptBuffer]) -> Result<()> {
+    let mut data_buffer = DecryptBuffer::find_buffer_mut(buffers, SecurityBufferType::Data)?;
+
+    if data_buffer.buffer.len() < decrypted.len() {
+        let stream_buffer = DecryptBuffer::find_buffer_mut(buffers, SecurityBufferType::Stream)?;
+        if stream_buffer.buffer.len() < decrypted.len() {
+            return Err(Error::new(
+                ErrorKind::DecryptFailure,
+                "Decrypted data can not be larger then encrypted one.",
+            ));
+        } else {
+            data_buffer = stream_buffer;
+        }
+    }
+
+    let mut data = std::mem::take(&mut data_buffer.buffer);
+    data = &mut data[0..decrypted.len()];
+    data.copy_from_slice(decrypted);
+    data_buffer.buffer = data;
+
+    Ok(())
+}
+
+/// Extracts data to decrypt from the incoming buffers.
+///
+/// Data to decrypt is `Token`/`Stream` buffers + `Data` buffer concatenated together.
+pub fn extract_encrypted_data(buffers: &[DecryptBuffer]) -> Result<Vec<u8>> {
+    let mut encrypted = if let Ok(buffer) = DecryptBuffer::find_buffer(buffers, SecurityBufferType::Token) {
+        buffer
+    } else {
+        DecryptBuffer::find_buffer(buffers, SecurityBufferType::Stream)?
+    }
+    .buffer
+    .to_vec();
+
+    encrypted.extend_from_slice(DecryptBuffer::find_buffer(buffers, SecurityBufferType::Data)?.buffer);
+
+    Ok(encrypted)
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,8 +3,8 @@ use std::io;
 use lazy_static::lazy_static;
 use sspi::{
     credssp, AcquireCredentialsHandleResult, AuthIdentity, ClientRequestFlags, ContextNames, CredentialUse,
-    DataRepresentation, EncryptionFlags, SecurityBuffer, SecurityBufferType, SecurityStatus, ServerRequestFlags, Sspi,
-    SspiEx, Username,
+    DataRepresentation, DecryptBuffer, EncryptionFlags, SecurityBuffer, SecurityBufferType, SecurityStatus,
+    ServerRequestFlags, Sspi, SspiEx, Username,
 };
 use time::OffsetDateTime;
 
@@ -191,6 +191,19 @@ pub fn check_messages_encryption(client: &mut impl Sspi, server: &mut impl Sspi)
         "Message to client: {:x?}, encrypted message: {:x?}, token: {:x?}",
         *MESSAGE_TO_CLIENT, messages[0].buffer, messages[1].buffer
     );
+
+    let [mut data, mut token] = messages;
+
+    let mut messages = vec![
+        DecryptBuffer {
+            buffer: &mut data.buffer,
+            buffer_type: SecurityBufferType::Data,
+        },
+        DecryptBuffer {
+            buffer: &mut token.buffer,
+            buffer_type: SecurityBufferType::Token,
+        },
+    ];
 
     client.decrypt_message(&mut messages, sequence_number)?;
 


### PR DESCRIPTION
Hi,
In this pull request, I have fixed the memory leak during message decryption.

According to the [MSDN](https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--schannel):

> The encrypted message is decrypted in place, overwriting the original contents of its buffer.

Our previous implementation had allocated new buffers for the decrypted data. It had caused a memory leak because the caller didn't expect new allocations. This problem is fixed by introducing a special `DecryptBuffer` type that uses only mutable references to the provided buffers without any vectors and data cloning.

Note. I suggest refraining from paying a lot of attention to the `tls_connection` module, as I have implemented changes to the decryption process in the upcoming pull request.