### PR TITLE
fix(sspi): partial TLS buffers decryption

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -52,17 +52,14 @@ fn main() -> Result<(), io::Error> {
 
     println!("Encrypted message: {:?}", data);
 
-    let mut msg_buffer = vec![
-        DecryptBuffer::new(&mut trailer, SecurityBufferType::Token),
-        DecryptBuffer::new(&mut data, SecurityBufferType::Data),
-    ];
+    let mut msg_buffer = vec![DecryptBuffer::Token(&mut trailer), DecryptBuffer::Data(&mut data)];
 
     let _decryption_flags = ntlm.decrypt_message(&mut msg_buffer, 0)?;
 
     println!("Decrypting...");
     println!(
         "Decrypted message: [{}]",
-        std::str::from_utf8(msg_buffer[1].buffer).unwrap()
+        std::str::from_utf8(msg_buffer[1].data()).unwrap()
     );
 
     println!("Communication successfully finished.");

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -321,7 +321,7 @@ pub unsafe extern "system" fn DecryptMessage(
 
         let len = (*p_message).c_buffers as usize;
         let raw_buffers = from_raw_parts((*p_message).p_buffers, len);
-        let mut message = p_sec_buffers_to_decrypt_buffers(raw_buffers);
+        let mut message = try_execute!(p_sec_buffers_to_decrypt_buffers(raw_buffers));
 
         let (decryption_flags, result_status) =
             match sspi_context.decrypt_message(&mut message, message_seq_no.try_into().unwrap()) {
@@ -329,7 +329,7 @@ pub unsafe extern "system" fn DecryptMessage(
                 Err(error) => (DecryptionFlags::empty(), Err(error)),
             };
 
-        copy_decrypted_buffers((*p_message).p_buffers, &message);
+        try_execute!(copy_decrypted_buffers((*p_message).p_buffers, message));
         // `pf_qop` can be null if this library is used as a CredSsp security package
         if !pf_qop.is_null() {
             *pf_qop = decryption_flags.bits().try_into().unwrap();
@@ -341,34 +341,69 @@ pub unsafe extern "system" fn DecryptMessage(
     }
 }
 
+/// Creates a vector of [DecryptBuffer]s from the input C buffers.
+///
+/// *Attention*: after this function call, no one should touch [raw_buffers]. Otherwise, we can get UB.
+/// It's because this function creates exclusive (mutable) Rust references to the input buffers.
 #[allow(clippy::useless_conversion)]
-unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> Vec<DecryptBuffer> {
-    raw_buffers
-        .iter()
-        .map(|raw_buffer| DecryptBuffer {
-            buffer: from_raw_parts_mut(raw_buffer.pv_buffer as *mut u8, raw_buffer.cb_buffer as usize),
-            buffer_type: SecurityBufferType::from_u32(raw_buffer.buffer_type.try_into().unwrap()).unwrap(),
+unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> sspi::Result<Vec<DecryptBuffer>> {
+    let mut buffers = Vec::with_capacity(raw_buffers.len());
+
+    for raw_buffer in raw_buffers {
+        let buf = DecryptBuffer::with_security_buffer_type(
+            SecurityBufferType::from_u32(raw_buffer.buffer_type).ok_or_else(|| {
+                sspi::Error::new(
+                    ErrorKind::InternalError,
+                    format!("u32({}) to SecurityBufferType conversion error", raw_buffer.buffer_type),
+                )
+            })?,
+        )?;
+
+        buffers.push(if let DecryptBuffer::Missing(_) = buf {
+            // https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secbuffer
+            // SECBUFFER_MISSING: ...The pvBuffer member is ignored in this type.
+            DecryptBuffer::Missing(raw_buffer.cb_buffer.try_into()?)
+        } else {
+            // SAFETY: the safety contract [raw_buffers] must be upheld by the caller.
+            buf.with_data(unsafe {
+                from_raw_parts_mut(raw_buffer.pv_buffer as *mut u8, raw_buffer.cb_buffer.try_into()?)
+            })?
         })
-        .collect()
+    }
+
+    Ok(buffers)
 }
 
-unsafe fn copy_decrypted_buffers(to_buffers: PSecBuffer, from_buffers: &[DecryptBuffer]) {
-    let to_buffers = from_raw_parts_mut(to_buffers, from_buffers.len());
+/// Copies Rust-security-buffers into C-security-buffers.
+///
+/// This function accepts owned [from_buffers] to avoid UB and other errors. Rust-buffers should
+/// not be used after the data is copied into C-buffers.
+unsafe fn copy_decrypted_buffers(to_buffers: PSecBuffer, from_buffers: Vec<DecryptBuffer>) -> sspi::Result<()> {
+    // SAFETY: the safety contract [to_buffers] must be upheld by the caller.
+    let to_buffers = unsafe { from_raw_parts_mut(to_buffers, from_buffers.len()) };
 
-    let mut buff = to_buffers[0].pv_buffer;
+    for (to_buffer, mut from_buffer) in to_buffers.iter_mut().zip(from_buffers.into_iter()) {
+        let from_buffer_len = from_buffer.buf_len();
 
-    for i in 0..from_buffers.len() {
-        let from_buffer = from_buffers.get(i).unwrap();
-        let from_buffer_len = from_buffer.buffer.len();
-        let to_buffer = to_buffers.get_mut(i).unwrap();
+        to_buffer.buffer_type = from_buffer.security_buffer_type().to_u32().ok_or_else(|| {
+            sspi::Error::new(
+                ErrorKind::InternalError,
+                format!(
+                    "SecurityBufferType({:?}) to u32 conversion error",
+                    from_buffer.security_buffer_type()
+                ),
+            )
+        })?;
+        to_buffer.cb_buffer = from_buffer_len.try_into()?;
 
-        to_buffer.pv_buffer = buff;
-        to_buffer.buffer_type = from_buffer.buffer_type.to_u32().unwrap();
-        to_buffer.cb_buffer = from_buffer_len.try_into().unwrap();
-
-        from_raw_parts_mut(buff as *mut _, from_buffer_len).copy_from_slice(from_buffer.buffer);
-        buff = buff.add(from_buffer_len);
+        if !matches!(from_buffer, DecryptBuffer::Missing(_)) {
+            // We don't need to copy the actual content of the buffer because [from_buffer] is created
+            // from the C-input-buffer and all decryption is performed in-place.
+            to_buffer.pv_buffer = from_buffer.take_data().as_mut_ptr() as *mut _;
+        }
     }
+
+    Ok(())
 }
 
 pub type DecryptMessageFn = unsafe extern "system" fn(PCtxtHandle, PSecBufferDesc, u32, *mut u32) -> SecurityStatus;

--- a/ffi/src/sspi/utils.rs
+++ b/ffi/src/sspi/utils.rs
@@ -18,8 +18,8 @@ pub unsafe fn transform_credentials_handle<'a>(
     }
 }
 
-// when encoding an UTF-16 character using two code units, the 16-bit values are chosen from the UTF-16 surrogate range 0xD800–0xDFFF,
-// and thus only \0 is encoded by two consecutive null bytes
+// when encoding a UTF-16 character using two code units, the 16-bit values are chosen from
+// the UTF-16 surrogate range 0xD800–0xDFFF, and thus only \0 is encoded by two consecutive null bytes.
 #[cfg(any(feature = "tsssp", feature = "scard"))]
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {
     let mut len = raw_str.len();

--- a/ffi/src/sspi/utils.rs
+++ b/ffi/src/sspi/utils.rs
@@ -18,7 +18,7 @@ pub unsafe fn transform_credentials_handle<'a>(
     }
 }
 
-// when encoding a UTF-16 character using two code units, the 16-bit values are chosen from
+// When encoding a UTF-16 character using two code units, the 16-bit values are chosen from
 // the UTF-16 surrogate range 0xD800–0xDFFF, and thus only \0 is encoded by two consecutive null bytes.
 #[cfg(any(feature = "tsssp", feature = "scard"))]
 pub fn raw_wide_str_trim_nulls(raw_str: &mut Vec<u8>) {

--- a/src/credssp/sspi_cred_ssp/tls_connection.rs
+++ b/src/credssp/sspi_cred_ssp/tls_connection.rs
@@ -21,7 +21,7 @@ const TLS_PACKET_SEQUENCE_NUMBER_LEN: usize = std::mem::size_of::<u64>();
 // https://datatracker.ietf.org/doc/html/rfc6101#appendix-A.1
 //
 // application_data(23)
-const TLS_APPLICATION_CONTENT_TYPE: u8 = 0x17;
+const TLS_APPLICATION_DATA_CONTENT_TYPE: u8 = 0x17;
 
 // [Block Size and Padding](https://www.rfc-editor.org/rfc/rfc3826#section-3.1.1.3)
 // The block size of the AES cipher is 128 bits
@@ -72,16 +72,6 @@ struct TlsTrafficParts<'data> {
     extra: &'data mut [u8],
 }
 
-impl<'a> From<&'a mut [u8]> for TlsTrafficParts<'a> {
-    fn from(value: &'a mut [u8]) -> Self {
-        Self {
-            header: &mut [],
-            application_data: value,
-            extra: &mut [],
-        }
-    }
-}
-
 /// Represents buffers after the decryption.
 ///
 /// We can not return just decrypted data because we also need a TLS header and unprocessed data buffers.
@@ -103,10 +93,32 @@ pub struct DecryptionResultBuffers<'data> {
     pub extra: &'data mut [u8],
 }
 
+/// Represent a successful [decrypt_message] function result.
+///
+/// This helper structure exists because sometimes the decrypt function can get incomplete TLS packet
+/// and needs more bytes to perform the decryption. Such a situation is not an actual error but,
+/// on the other hand, there is no data to return. So, this is why the [DecryptionResult::IncompleteMessage] exists.
+#[derive(Debug)]
+pub enum DecryptionResult<'data> {
+    /// Indicated successful TLS packet decryption.
+    Success(DecryptionResultBuffers<'data>),
+    /// Indicated that the input buffer is too small to perform the decryption and
+    /// the function needs more bytes to do it.
+    IncompleteMessage(usize),
+}
+
 #[derive(Debug)]
 pub enum TlsConnection {
     Rustls(Connection),
     // Schannel
+}
+
+/// Represents a result of extracting the first TLS packet from the TLS traffic buffer.
+enum FindTlsPacketResult<'data> {
+    /// TLS packet.
+    TlsPacket(&'data mut [u8]),
+    /// Indicated how many bytes the input buffer lacks to represent a complete TLS packet.
+    Missing(usize),
 }
 
 impl TlsConnection {
@@ -124,17 +136,24 @@ impl TlsConnection {
         }
     }
 
-    // This function extracts the application data (encrypted part) of the TLS packet.
-    // If the input buffer contains more than one TLS packet, then the application data of
-    // the first one will be returned.
+    // This function extracts the first TLS packet from the TLS traffic buffer.
     // If the input buffer contains less than one TLS packet (only a part of it), then
-    // the whole input buffer will be returned.
-    fn find_tls_data_to_decrypt<'data>(connection: &Connection, payload: &'data mut [u8]) -> Result<&'data mut [u8]> {
-        if payload.len() < TLS_PACKET_HEADER_LEN + TLS_PACKET_SEQUENCE_NUMBER_LEN {
-            return Ok(payload);
+    // it returns how many bytes the input buffer lacks to represent a complete TLS packet.
+    fn find_tls_data_to_decrypt<'data>(
+        connection: &Connection,
+        payload: &'data mut [u8],
+    ) -> Result<FindTlsPacketResult<'data>> {
+        if payload.len() < TLS_PACKET_HEADER_LEN {
+            // We need at least TLS_PACKET_HEADER_LEN bytes to recognize the TLS packet, its type, and length.
+            return Ok(FindTlsPacketResult::Missing(TLS_PACKET_HEADER_LEN));
         }
 
-        let mut tls_packet_start = vec![TLS_APPLICATION_CONTENT_TYPE];
+        // In the decryption stage, we accept only TLS packets with TLS_APPLICATION_CONTENT_TYPE specified.
+        // Additional info: https://stackoverflow.com/a/65101172:
+        // "...DecryptMessage() only works if the record type is "application data". For any other
+        // record type (such as a TLS handshake "finished message"), DecryptMessage() won't even
+        // try to decrypt it -- it will just return a SEC_E_DECRYPT_FAILURE code."
+        let mut tls_packet_start = vec![TLS_APPLICATION_DATA_CONTENT_TYPE];
         let tls_version = connection
             .protocol_version()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "Can not query negotiated TLS version"))?
@@ -142,22 +161,23 @@ impl TlsConnection {
             .to_be_bytes();
         tls_packet_start.extend_from_slice(&tls_version);
 
-        // safe: payload length is checked above.
-        if payload[0..3] != tls_packet_start {
-            return Ok(payload);
+        // Safe: payload length is checked above.
+        if payload[0..1 /* ContentType */ + 2 /* ProtocolVersion */] != tls_packet_start {
+            return Err(Error::new(ErrorKind::InvalidToken, "Invalid TLS packet header."));
         }
 
-        // safe: payload length is checked above.
+        // Safe: payload length is checked above.
         let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
 
-        if payload.len() < TLS_PACKET_HEADER_LEN + encrypted_application_data_len {
-            return Ok(payload);
+        let tls_packet_len = TLS_PACKET_HEADER_LEN + encrypted_application_data_len;
+        if payload.len() < tls_packet_len {
+            return Ok(FindTlsPacketResult::Missing(
+                TLS_PACKET_HEADER_LEN + encrypted_application_data_len - payload.len(),
+            ));
         }
 
-        let tls_packet_len = TLS_PACKET_HEADER_LEN + encrypted_application_data_len;
-
-        // safe: payload length is checked above.
-        Ok(&mut payload[0..tls_packet_len])
+        // Safe: payload length is checked above.
+        Ok(FindTlsPacketResult::TlsPacket(&mut payload[0..tls_packet_len]))
     }
 
     // This function splits the incoming TLS traffic into three parts (if possible):
@@ -167,11 +187,17 @@ impl TlsConnection {
     // See the [TlsTrafficParts] documentation for a more detailed explanation of those buffers.
     fn split_tls_traffic<'a>(connection: &Connection, payload: &'a mut [u8]) -> Result<TlsTrafficParts<'a>> {
         const TLS_PACKET_PREFIX_LEN: usize = TLS_PACKET_HEADER_LEN + TLS_PACKET_SEQUENCE_NUMBER_LEN;
+
         if payload.len() < TLS_PACKET_PREFIX_LEN {
-            return Ok(payload.into());
+            return Err(Error::new(ErrorKind::InvalidToken, "Input TLS buffer is too short."));
         }
 
-        let mut tls_packet_start = vec![TLS_APPLICATION_CONTENT_TYPE];
+        // In the decryption stage, we accept only TLS packets with TLS_APPLICATION_CONTENT_TYPE specified.
+        // Additional info: https://stackoverflow.com/a/65101172:
+        // "...DecryptMessage() only works if the record type is "application data". For any other
+        // record type (such as a TLS handshake "finished message"), DecryptMessage() won't even
+        // try to decrypt it -- it will just return a SEC_E_DECRYPT_FAILURE code."
+        let mut tls_packet_start = vec![TLS_APPLICATION_DATA_CONTENT_TYPE];
         let tls_version = connection
             .protocol_version()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "Can not query negotiated TLS version"))?
@@ -179,27 +205,22 @@ impl TlsConnection {
             .to_be_bytes();
         tls_packet_start.extend_from_slice(&tls_version);
 
-        // safe: payload length is checked above.
-        if payload[0..3] != tls_packet_start {
-            return Ok(payload.into());
+        // Safe: payload length is checked above.
+        if payload[0..1 /* ContentType */ + 2 /* ProtocolVersion */] != tls_packet_start {
+            return Err(Error::new(ErrorKind::InvalidToken, "Invalid TLS packet header."));
         }
 
-        // safe: payload length is checked above.
+        // Safe: payload length is checked above.
         let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
 
-        if payload.len() < TLS_PACKET_PREFIX_LEN + encrypted_application_data_len {
-            let (header, application_data) = payload.split_at_mut(TLS_PACKET_PREFIX_LEN);
-            return Ok(TlsTrafficParts {
-                header,
-                application_data,
-                extra: &mut [],
-            });
+        if payload.len() < TLS_PACKET_HEADER_LEN + encrypted_application_data_len {
+            return Err(Error::new(ErrorKind::InvalidToken, "Input TLS buffer is too short."));
         }
 
-        // safe: payload length is checked above.
+        // Safe: payload length is checked above.
         let (header, rest) = payload.split_at_mut(TLS_PACKET_PREFIX_LEN);
         // `encrypted_application_data_len` is a len of the encrypted data with the sequence number.
-        // But here we need the encrypted data WITHOUT a sequence number, so we extract TLS_PACKET_SEQUENCE_NUMBER_LEN
+        // But here we need the encrypted data *WITHOUT* a sequence number, so we subtract TLS_PACKET_SEQUENCE_NUMBER_LEN
         // from the overall data length.
         let (application_data, extra) =
             rest.split_at_mut(encrypted_application_data_len - TLS_PACKET_SEQUENCE_NUMBER_LEN);
@@ -214,12 +235,15 @@ impl TlsConnection {
     /// Decrypt a part of the incoming TLS traffic.
     ///
     /// If the input buffer contains more than one TLS message,then only the first one will be decrypted.
-    pub fn decrypt_tls<'a>(&mut self, payload: &'a mut [u8]) -> Result<DecryptionResultBuffers<'a>> {
+    pub fn decrypt_tls<'a>(&mut self, payload: &'a mut [u8]) -> Result<DecryptionResult<'a>> {
         match self {
             TlsConnection::Rustls(tls_connection) => {
-                let tls_data_to_decrypt = TlsConnection::find_tls_data_to_decrypt(tls_connection, payload)?;
-                let mut tls_packet: &[u8] = tls_data_to_decrypt;
-
+                let mut tls_packet = match TlsConnection::find_tls_data_to_decrypt(tls_connection, payload)? {
+                    FindTlsPacketResult::TlsPacket(data) => data as &[u8],
+                    FindTlsPacketResult::Missing(needed_bytes_amount) => {
+                        return Ok(DecryptionResult::IncompleteMessage(needed_bytes_amount));
+                    }
+                };
                 let mut plain_data = Vec::with_capacity(tls_packet.len());
 
                 while !tls_packet.is_empty() {
@@ -252,11 +276,11 @@ impl TlsConnection {
                 let decrypted = &mut application_data[0..plain_data.len()];
                 decrypted.copy_from_slice(&plain_data);
 
-                Ok(DecryptionResultBuffers {
+                Ok(DecryptionResult::Success(DecryptionResultBuffers {
                     header,
                     decrypted,
                     extra,
-                })
+                }))
             }
         }
     }

--- a/src/decrypt_buffer.rs
+++ b/src/decrypt_buffer.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+use std::mem::take;
+
+use crate::{Error, ErrorKind, SecurityBufferType};
+
+/// A special security buffer type is used for the data decryption. Basically, it's almost the same
+/// as [SecurityBuffer] but for decryption.
+///
+/// [DecryptMessage](https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--general)
+/// "The encrypted message is decrypted in place, overwriting the original contents of its buffer."
+///
+/// So, the already defined [SecurityBuffer] is not suitable for decryption because it uses [Vec] inside.
+/// We use reference in the [DecryptionBuffer] structure to avoid data cloning as much as possible.
+/// Decryption input buffers can be very large. Even up to 32 KiB if we are using this crate as a CREDSSP security package.
+pub enum DecryptBuffer<'data> {
+    Data(&'data mut [u8]),
+    Token(&'data mut [u8]),
+    StreamHeader(&'data mut [u8]),
+    StreamTrailer(&'data mut [u8]),
+    Stream(&'data mut [u8]),
+    Extra(&'data mut [u8]),
+    Missing(usize),
+    Empty,
+}
+
+impl<'data> DecryptBuffer<'data> {
+    /// Created a [DecryptBuffer] from based on provided [SecurityBufferType].
+    ///
+    /// Inner buffers will be empty.
+    pub fn with_security_buffer_type(security_buffer_type: SecurityBufferType) -> crate::Result<Self> {
+        match security_buffer_type {
+            SecurityBufferType::Empty => Ok(DecryptBuffer::Empty),
+            SecurityBufferType::Data => Ok(DecryptBuffer::Data(&mut [])),
+            SecurityBufferType::Token => Ok(DecryptBuffer::Token(&mut [])),
+            SecurityBufferType::Missing => Ok(DecryptBuffer::Missing(0)),
+            SecurityBufferType::Extra => Ok(DecryptBuffer::Extra(&mut [])),
+            SecurityBufferType::StreamTrailer => Ok(DecryptBuffer::StreamTrailer(&mut [])),
+            SecurityBufferType::StreamHeader => Ok(DecryptBuffer::StreamHeader(&mut [])),
+            SecurityBufferType::Stream => Ok(DecryptBuffer::Stream(&mut [])),
+            _ => Err(Error::new(ErrorKind::UnsupportedFunction, "")),
+        }
+    }
+
+    /// Creates a new [DecryptBuffer] with the provided buffer data saving the old buffer type.
+    ///
+    /// *Attention*: the buffer type must not be [SecurityBufferType::Missing].
+    pub fn with_data(self, data: &'data mut [u8]) -> crate::Result<Self> {
+        Ok(match self {
+            DecryptBuffer::Data(_) => DecryptBuffer::Data(data),
+            DecryptBuffer::Token(_) => DecryptBuffer::Token(data),
+            DecryptBuffer::StreamHeader(_) => DecryptBuffer::StreamHeader(data),
+            DecryptBuffer::StreamTrailer(_) => DecryptBuffer::StreamTrailer(data),
+            DecryptBuffer::Stream(_) => DecryptBuffer::Stream(data),
+            DecryptBuffer::Extra(_) => DecryptBuffer::Extra(data),
+            DecryptBuffer::Missing(_) => {
+                return Err(Error::new(
+                    ErrorKind::InternalError,
+                    "The missing buffer type does not hold any buffers inside.",
+                ))
+            }
+            DecryptBuffer::Empty => DecryptBuffer::Empty,
+        })
+    }
+
+    /// Sets the buffer data.
+    ///
+    /// *Attention*: the buffer type must not be [SecurityBufferType::Missing].
+    pub fn set_data(&mut self, buf: &'data mut [u8]) -> crate::Result<()> {
+        match self {
+            DecryptBuffer::Data(data) => *data = buf,
+            DecryptBuffer::Token(data) => *data = buf,
+            DecryptBuffer::StreamHeader(data) => *data = buf,
+            DecryptBuffer::StreamTrailer(data) => *data = buf,
+            DecryptBuffer::Stream(data) => *data = buf,
+            DecryptBuffer::Extra(data) => *data = buf,
+            DecryptBuffer::Missing(_) => {
+                return Err(Error::new(
+                    ErrorKind::InternalError,
+                    "The missing buffer type does not hold any buffers inside.",
+                ))
+            }
+            DecryptBuffer::Empty => {}
+        };
+        Ok(())
+    }
+
+    /// Determines the [SecurityBufferType] of the decrypt buffer.
+    pub fn security_buffer_type(&self) -> SecurityBufferType {
+        match self {
+            DecryptBuffer::Data(_) => SecurityBufferType::Data,
+            DecryptBuffer::Token(_) => SecurityBufferType::Token,
+            DecryptBuffer::StreamHeader(_) => SecurityBufferType::StreamHeader,
+            DecryptBuffer::StreamTrailer(_) => SecurityBufferType::StreamTrailer,
+            DecryptBuffer::Stream(_) => SecurityBufferType::Stream,
+            DecryptBuffer::Extra(_) => SecurityBufferType::Extra,
+            DecryptBuffer::Missing(_) => SecurityBufferType::Missing,
+            DecryptBuffer::Empty => SecurityBufferType::Empty,
+        }
+    }
+
+    /// Returns the immutable reference to the [DecryptBuffer] with specified buffer type.
+    ///
+    /// If a slice contains more than one buffer with a specified buffer type, then the first one will be returned.
+    pub fn find_buffer<'a>(
+        buffers: &'a [DecryptBuffer<'data>],
+        buffer_type: SecurityBufferType,
+    ) -> crate::Result<&'a DecryptBuffer<'data>> {
+        buffers
+            .iter()
+            .find(|b| b.security_buffer_type() == buffer_type)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidToken,
+                    format!("No buffer was provided with type {:?}", buffer_type),
+                )
+            })
+    }
+
+    /// Returns the mutable reference to the [DecryptBuffer] with specified buffer type.
+    ///
+    /// If a slice contains more than one buffer with a specified buffer type, then the first one will be returned.
+    pub fn find_buffer_mut<'a>(
+        buffers: &'a mut [DecryptBuffer<'data>],
+        buffer_type: SecurityBufferType,
+    ) -> crate::Result<&'a mut DecryptBuffer<'data>> {
+        buffers
+            .iter_mut()
+            .find(|b| b.security_buffer_type() == buffer_type)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidToken,
+                    format!("No buffer was provided with type {:?}", buffer_type),
+                )
+            })
+    }
+
+    /// Returns the immutable reference to the inner buffer data.
+    pub fn buf_data<'a>(buffers: &'a [DecryptBuffer<'a>], buffer_type: SecurityBufferType) -> crate::Result<&'a [u8]> {
+        Ok(DecryptBuffer::find_buffer(buffers, buffer_type)?.data())
+    }
+
+    /// Returns the immutable reference to the inner data.
+    ///
+    /// Some buffer types can not hold the data, so the empty slice will be returned.
+    pub fn data(&self) -> &[u8] {
+        match self {
+            DecryptBuffer::Data(data) => data,
+            DecryptBuffer::Token(data) => data,
+            DecryptBuffer::StreamHeader(data) => data,
+            DecryptBuffer::StreamTrailer(data) => data,
+            DecryptBuffer::Stream(data) => data,
+            DecryptBuffer::Extra(data) => data,
+            DecryptBuffer::Missing(_) => &[],
+            DecryptBuffer::Empty => &[],
+        }
+    }
+
+    /// Calculates the buffer data length.
+    pub fn buf_len(&self) -> usize {
+        match self {
+            DecryptBuffer::Data(data) => data.len(),
+            DecryptBuffer::Token(data) => data.len(),
+            DecryptBuffer::StreamHeader(data) => data.len(),
+            DecryptBuffer::StreamTrailer(data) => data.len(),
+            DecryptBuffer::Stream(data) => data.len(),
+            DecryptBuffer::Extra(data) => data.len(),
+            DecryptBuffer::Missing(needed_bytes_amount) => *needed_bytes_amount,
+            DecryptBuffer::Empty => 0,
+        }
+    }
+
+    /// Returns the mutable reference to the inner buffer data leaving the empty buffer on its place.
+    pub fn take_buf_data_mut<'a>(
+        buffers: &'a mut [DecryptBuffer<'data>],
+        buffer_type: SecurityBufferType,
+    ) -> crate::Result<&'data mut [u8]> {
+        Ok(DecryptBuffer::find_buffer_mut(buffers, buffer_type)?.take_data())
+    }
+
+    /// Returns the mutable reference to the inner data leaving the empty buffer on its place.
+    ///
+    /// Some buffer types can not hold the data, so the empty slice will be returned.
+    pub fn take_data(&mut self) -> &'data mut [u8] {
+        match self {
+            DecryptBuffer::Data(data) => take(data),
+            DecryptBuffer::Token(data) => take(data),
+            DecryptBuffer::StreamHeader(data) => take(data),
+            DecryptBuffer::StreamTrailer(data) => take(data),
+            DecryptBuffer::Stream(data) => take(data),
+            DecryptBuffer::Extra(data) => take(data),
+            DecryptBuffer::Missing(_) => &mut [],
+            DecryptBuffer::Empty => &mut [],
+        }
+    }
+}
+
+impl fmt::Debug for DecryptBuffer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DecryptBuffer {{ ")?;
+        match self {
+            DecryptBuffer::Data(data) => write_buffer(data, "Data", f)?,
+            DecryptBuffer::Token(data) => write_buffer(data, "Token", f)?,
+            DecryptBuffer::StreamHeader(data) => write_buffer(data, "StreamHeader", f)?,
+            DecryptBuffer::StreamTrailer(data) => write_buffer(data, "StreamTrailer", f)?,
+            DecryptBuffer::Stream(data) => write_buffer(data, "Stream", f)?,
+            DecryptBuffer::Extra(data) => write_buffer(data, "Extra", f)?,
+            DecryptBuffer::Missing(needed_bytes_amount) => write!(f, "Missing({})", *needed_bytes_amount)?,
+            DecryptBuffer::Empty => f.write_str("Empty")?,
+        };
+        write!(f, " }}")
+    }
+}
+
+fn write_buffer(buf: &[u8], buf_name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}: ", buf_name)?;
+    f.write_str("0x")?;
+    buf.iter().try_for_each(|byte| write!(f, "{byte:02X}"))
+}

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -1099,19 +1099,10 @@ mod tests {
 
         let mut buffer = message[0].buffer.clone();
         buffer.extend_from_slice(&message[1].buffer);
-        let mut message = [
-            DecryptBuffer {
-                buffer: &mut buffer,
-                buffer_type: SecurityBufferType::Stream,
-            },
-            DecryptBuffer {
-                buffer: &mut [],
-                buffer_type: SecurityBufferType::Data,
-            },
-        ];
+        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Token(&mut [])];
 
         kerberos_client.decrypt_message(&mut message, 0).unwrap();
 
-        assert_eq!(message[0].buffer, plain_message);
+        assert_eq!(message[0].data(), plain_message);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ mod ber;
 #[cfg(feature = "scard")]
 pub mod cert_utils;
 mod crypto;
+mod decrypt_buffer;
 mod dns;
 mod kdc;
 mod krb;
@@ -91,6 +92,7 @@ use std::{error, fmt, io, result, str, string};
 use bitflags::bitflags;
 #[cfg(feature = "tsssp")]
 use credssp::sspi_cred_ssp;
+pub use decrypt_buffer::DecryptBuffer;
 use generator::{GeneratorChangePassword, GeneratorInitSecurityContext};
 use num_derive::{FromPrimitive, ToPrimitive};
 use picky_asn1::restricted_string::CharSetError;
@@ -697,8 +699,8 @@ where
     /// let [mut token, mut data] = msg;
     ///
     /// let mut msg_buffer = vec![
-    ///     sspi::DecryptBuffer::new(&mut token.buffer, sspi::SecurityBufferType::Token),
-    ///     sspi::DecryptBuffer::new(&mut data.buffer, sspi::SecurityBufferType::Data),
+    ///     sspi::DecryptBuffer::Token(&mut token.buffer),
+    ///     sspi::DecryptBuffer::Data(&mut data.buffer),
     /// ];
     ///
     /// #[allow(unused_variables)]
@@ -706,7 +708,7 @@ where
     ///     .decrypt_message(&mut msg_buffer, 0)
     ///     .unwrap();
     ///
-    /// println!("Decrypted message: {:?}", msg_buffer[1].buffer);
+    /// println!("Decrypted message: {:?}", msg_buffer[1].data());
     /// ```
     ///
     /// # MSDN
@@ -1318,73 +1320,6 @@ impl SecurityBuffer {
     }
 }
 
-/// A special security buffer type is used for the data decryption. Basically, it's almost the same
-/// as [SecurityBuffer] but for decryption.
-///
-/// [DecryptMessage](https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--general)
-/// "The encrypted message is decrypted in place, overwriting the original contents of its buffer."
-///
-/// So, the already defined [SecurityBuffer] is not suitable for decryption because it uses [Vec] inside.
-/// We use reference in the [DecryptionBuffer] structure to avoid data cloning as much as possible.
-/// Decryption input buffers can be very large. Even up to 32 KiB if we are using this crate as a CREDSSP security package.
-#[derive(Default)]
-pub struct DecryptBuffer<'data> {
-    /// Buffer that contains part of the data to be decrypted.
-    pub buffer: &'data mut [u8],
-    /// Buffer type.
-    pub buffer_type: SecurityBufferType,
-}
-
-impl<'data> DecryptBuffer<'data> {
-    /// Creates a new [DecryptBuffer] based on the input parameters.
-    pub fn new(buffer: &'data mut [u8], buffer_type: SecurityBufferType) -> Self {
-        Self { buffer, buffer_type }
-    }
-
-    /// Returns the immutable reference to the [DecryptBuffer] with specified buffer type.
-    ///
-    /// If a slice contains more than one buffer with a specified buffer type, then the first one will be returned.
-    pub fn find_buffer<'a>(
-        buffers: &'a [DecryptBuffer<'data>],
-        buffer_type: SecurityBufferType,
-    ) -> Result<&'a DecryptBuffer<'data>> {
-        buffers.iter().find(|b| b.buffer_type == buffer_type).ok_or_else(|| {
-            Error::new(
-                ErrorKind::InvalidToken,
-                format!("No buffer was provided with type {:?}", buffer_type),
-            )
-        })
-    }
-
-    /// Returns the mutable reference to the [DecryptBuffer] with specified buffer type.
-    ///
-    /// If a slice contains more than one buffer with a specified buffer type, then the first one will be returned.
-    pub fn find_buffer_mut<'a>(
-        buffers: &'a mut [DecryptBuffer<'data>],
-        buffer_type: SecurityBufferType,
-    ) -> Result<&'a mut DecryptBuffer<'data>> {
-        buffers
-            .iter_mut()
-            .find(|b| b.buffer_type == buffer_type)
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::InvalidToken,
-                    format!("No buffer was provided with type {:?}", buffer_type),
-                )
-            })
-    }
-}
-
-impl fmt::Debug for DecryptBuffer<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "DecryptBuffer {{ buffer_type: {:?}, buffer: 0x", self.buffer_type)?;
-        self.buffer.iter().try_for_each(|byte| write!(f, "{byte:02X}"))?;
-        write!(f, " }}")?;
-
-        Ok(())
-    }
-}
-
 /// Bit flags that indicate the type of buffer.
 ///
 /// # MSDN
@@ -1755,6 +1690,8 @@ pub struct ContextNames {
 }
 
 /// The kind of an SSPI related error. Enables to specify an error based on its type.
+///
+/// [SSPI Status Codes](https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-status-codes).
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum ErrorKind {

--- a/src/ntlm/test.rs
+++ b/src/ntlm/test.rs
@@ -97,15 +97,15 @@ fn decrypt_message_decrypts_data() {
     let mut signature_test_data = SIGNATURE_FOR_TEST_DATA.to_vec();
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut signature_test_data, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut signature_test_data),
     ];
     let expected = &*TEST_DATA;
 
     context.decrypt_message(&mut buffers, TEST_SEQ_NUM).unwrap();
     let data = DecryptBuffer::find_buffer(&buffers, SecurityBufferType::Data).unwrap();
 
-    assert_eq!(expected, &data.buffer);
+    assert_eq!(expected, data.data());
 }
 
 #[test]
@@ -118,8 +118,8 @@ fn decrypt_message_does_not_fail_on_correct_signature() {
     let mut signature_test_data = SIGNATURE_FOR_TEST_DATA.to_vec();
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut signature_test_data, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut signature_test_data),
     ];
 
     context.decrypt_message(&mut buffers, TEST_SEQ_NUM).unwrap();
@@ -137,8 +137,8 @@ fn decrypt_message_fails_on_incorrect_version() {
     ];
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut token, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut token),
     ];
 
     assert!(context.decrypt_message(&mut buffers, TEST_SEQ_NUM).is_err());
@@ -156,8 +156,8 @@ fn decrypt_message_fails_on_incorrect_checksum() {
     ];
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut token, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut token),
     ];
 
     assert!(context.decrypt_message(&mut buffers, TEST_SEQ_NUM).is_err());
@@ -175,8 +175,8 @@ fn decrypt_message_fails_on_incorrect_seq_num() {
     ];
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut token, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut token),
     ];
 
     assert!(context.decrypt_message(&mut buffers, TEST_SEQ_NUM).is_err());
@@ -193,8 +193,8 @@ fn decrypt_message_fails_on_incorrect_signing_key() {
     let mut signature_test_data = SIGNATURE_FOR_TEST_DATA.to_vec();
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut signature_test_data, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut signature_test_data),
     ];
 
     assert!(context.decrypt_message(&mut buffers, TEST_SEQ_NUM).is_err());
@@ -211,8 +211,8 @@ fn decrypt_message_fails_on_incorrect_sealing_key() {
     let mut signature_test_data = SIGNATURE_FOR_TEST_DATA.to_vec();
 
     let mut buffers = vec![
-        DecryptBuffer::new(&mut encrypted_test_data, SecurityBufferType::Data),
-        DecryptBuffer::new(&mut signature_test_data, SecurityBufferType::Token),
+        DecryptBuffer::Data(&mut encrypted_test_data),
+        DecryptBuffer::Token(&mut signature_test_data),
     ];
 
     assert!(context.decrypt_message(&mut buffers, TEST_SEQ_NUM).is_err());

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -977,19 +977,10 @@ xFnLp2UBrhxA9GYrpJ5i0onRmexQnTVSl5DDq07s+3dbr9YAKjrg9IDZYqLbdwP1
 
         let mut buffer = message[0].buffer.clone();
         buffer.extend_from_slice(&message[1].buffer);
-        let mut message = [
-            DecryptBuffer {
-                buffer: &mut buffer,
-                buffer_type: SecurityBufferType::Stream,
-            },
-            DecryptBuffer {
-                buffer: &mut [],
-                buffer_type: SecurityBufferType::Data,
-            },
-        ];
+        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Token(&mut [])];
 
         pku2u_client.decrypt_message(&mut message, 0).unwrap();
 
-        assert_eq!(message[0].buffer, plain_message);
+        assert_eq!(message[0].data(), plain_message);
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -195,19 +195,13 @@ pub fn check_messages_encryption(client: &mut impl Sspi, server: &mut impl Sspi)
     let [mut data, mut token] = messages;
 
     let mut messages = vec![
-        DecryptBuffer {
-            buffer: &mut data.buffer,
-            buffer_type: SecurityBufferType::Data,
-        },
-        DecryptBuffer {
-            buffer: &mut token.buffer,
-            buffer_type: SecurityBufferType::Token,
-        },
+        DecryptBuffer::Data(&mut data.buffer),
+        DecryptBuffer::Token(&mut token.buffer),
     ];
 
     client.decrypt_message(&mut messages, sequence_number)?;
 
-    assert_eq!(*MESSAGE_TO_CLIENT, messages[0].buffer);
+    assert_eq!(*MESSAGE_TO_CLIENT, messages[0].data());
 
     Ok(())
 }


### PR DESCRIPTION
Hi,
In this pull request, I have fixed the partial TLS packets decryption.
_Note._ Under the _"partial TLS packet"_ term I mean buffers that contain only some part of the TLS packet. For example, the first 130 bytes, where the full TLS packet is 240.

There can be a situation when `mstsc` can pass only some part of the TLS packet as an input buffer. Previously, we passed such buffers to the `rustls` and were waiting for the rest on the next decrypt function call. But after such n-step packet decryption, we may get a situation when the decrypted data buffer is larger than the encrypted one. It makes it impossible to properly return all decrypted data. Now, the `sspi-rs` behaves as the original `SChannel`:
In a case when it gets the partial TLS message, it'll return `SECBUFFER_MISSING` with a length equal to the needed bytes amount alongside the `SEC_E_INCOMPLETE_MESSAGE` status code.