### PR TITLE
chore(release): prepare publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "sspi"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-dnssd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sspi"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT/Apache-2.0"
@@ -70,7 +70,7 @@ zeroize = { version = "1.6", features = ["zeroize_derive"] }
 tokio = { version = "1.32", features = ["time", "rt", "rt-multi-thread"], optional = true }
 pcsc = { version = "2.8", optional = true }
 async-recursion = "1.0.5"
-winscard = { path = "./crates/winscard", optional = true }
+winscard = { version = "0.1", path = "./crates/winscard", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"

--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -5,7 +5,7 @@
     <Description>Portable Rust SSPI library</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>2023.15.2.0</Version>
+    <Version>2024.3.15.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
- sspi -> 0.12.0
- winscard -> 0.1.0
- Devolutions.Sspi -> 2024.3.15.0