### PR TITLE
chore(scard): add description key to the manifest

### DIFF
--- a/crates/winscard/Cargo.toml
+++ b/crates/winscard/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 homepage = "https://github.com/devolutions/sspi-rs"
 repository = "https://github.com/devolutions/sspi-rs"
 authors = ["Devolutions Inc. <infos@devolutions.net>"]
+description = "A Rust implementation of WinSCard"
 
 [features]
 std = ["tracing/std"]


### PR DESCRIPTION
We can’t publish the crate without this key.