### PR TITLE
refactor: replace remaining uses of winapi with windows_sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,6 @@ dependencies = [
  "url",
  "uuid",
  "whoami",
- "winapi",
  "windows",
  "windows-sys 0.48.0",
  "winreg 0.51.0",
@@ -2157,7 +2156,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "whoami",
- "winapi",
  "windows-sys 0.48.0",
  "winscard",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,6 @@ winscard = { version = "0.1", path = "./crates/winscard", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"
-# FIXME(#174): replace `winapi` crate by `windows` / `windows-sys` crates
-winapi = { version = "0.3", features = ["std", "sspi", "rpcdce", "impl-default", "timezoneapi", "wincrypt"] }
 windows = { version = "0.51", features = [ "Win32_Foundation", "Win32_NetworkManagement_Dns"] }
 windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -34,5 +34,4 @@ tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", 
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
-winapi = { version = "0.3", features = ["winerror"] } # FIXME: replace by windows / windows-sys crates
-windows-sys = { version = "0.48", features = ["Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }
+windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -19,7 +19,7 @@ use sspi::{
 };
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::Security::Cryptography::{
-    CertAddEncodedCertificateToStore, CertOpenStore, CERT_CONTEXT, CERT_STORE_ADD_REPLACE_EXISTING, 
+    CertAddEncodedCertificateToStore, CertOpenStore, CERT_CONTEXT, CERT_STORE_ADD_REPLACE_EXISTING,
     CERT_STORE_CREATE_NEW_FLAG, CERT_STORE_PROV_MEMORY,
 };
 

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -18,8 +18,8 @@ use sspi::{
     Sspi, SspiImpl, StreamSizes,
 };
 #[cfg(target_os = "windows")]
-use winapi::um::wincrypt::{
-    CertAddEncodedCertificateToStore, CertOpenStore, CERT_CONTEXT, CERT_STORE_ADD_REPLACE_EXISTING,
+use windows_sys::Win32::Security::Cryptography::{
+    CertAddEncodedCertificateToStore, CertOpenStore, CERT_CONTEXT, CERT_STORE_ADD_REPLACE_EXISTING, 
     CERT_STORE_CREATE_NEW_FLAG, CERT_STORE_PROV_MEMORY,
 };
 
@@ -706,7 +706,7 @@ unsafe fn query_context_attributes_common(
             SECPKG_ATTR_REMOTE_CERT_CONTEXT => {
                 cfg_if::cfg_if! {
                     if #[cfg(target_os = "windows")] {
-                        use std::ptr::null;
+                        use std::ptr::{null, null_mut};
 
                         let cert_context = try_execute!(sspi_context.query_context_remote_cert());
 
@@ -716,7 +716,7 @@ unsafe fn query_context_attributes_common(
                             return ErrorKind::InternalError.to_u32().unwrap();
                         }
 
-                        let mut p_cert_context = null();
+                        let mut p_cert_context = null_mut();
 
                         let result = CertAddEncodedCertificateToStore(
                             store,

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -465,9 +465,7 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
 
     use sspi::cert_utils::{finalize_smart_card_info, SmartCardInfo};
     use sspi::string_to_utf16;
-    use windows_sys::Win32::Security::Credentials::{
-        CertCredential, CredUnmarshalCredentialW, CERT_CREDENTIAL_INFO
-    };
+    use windows_sys::Win32::Security::Credentials::{CertCredential, CredUnmarshalCredentialW, CERT_CREDENTIAL_INFO};
 
     let mut cred_type = 0;
     let mut credential = null_mut();

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -11,7 +11,7 @@ use sspi::{AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind, Result};
 #[cfg(windows)]
 use symbol_rename_macro::rename_symbol;
 #[cfg(feature = "scard")]
-use winapi::um::wincred::CredIsMarshaledCredentialW;
+use windows_sys::Win32::Security::Credentials::CredIsMarshaledCredentialW;
 #[cfg(feature = "tsssp")]
 use windows_sys::Win32::Security::Credentials::{CredUIPromptForWindowsCredentialsW, CREDUI_INFOW};
 
@@ -172,7 +172,7 @@ pub unsafe fn get_auth_data_identity_version_and_flags(p_auth_data: *const c_voi
 #[cfg(feature = "tsssp")]
 unsafe fn credssp_auth_data_to_identity_buffers(p_auth_data: *const c_void) -> Result<CredentialsBuffers> {
     use sspi::string_to_utf16;
-    use winapi::shared::winerror::ERROR_SUCCESS;
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
 
     let credssp_cred = p_auth_data.cast::<CredSspCred>().as_ref().unwrap();
 
@@ -465,7 +465,9 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
 
     use sspi::cert_utils::{finalize_smart_card_info, SmartCardInfo};
     use sspi::string_to_utf16;
-    use winapi::um::wincred::{CertCredential, CredUnmarshalCredentialW, CERT_CREDENTIAL_INFO};
+    use windows_sys::Win32::Security::Credentials::{
+        CertCredential, CredUnmarshalCredentialW, CERT_CREDENTIAL_INFO
+    };
 
     let mut cred_type = 0;
     let mut credential = null_mut();

--- a/src/cert_utils.rs
+++ b/src/cert_utils.rs
@@ -1,16 +1,16 @@
+use std::ffi::c_void;
 use std::ptr::{null, null_mut};
 use std::slice::from_raw_parts;
 
 use picky_asn1::wrapper::Utf8StringAsn1;
 use picky_asn1_x509::{oids, Certificate, ExtensionView, GeneralName};
 use sha1::{Digest, Sha1};
-use winapi::ctypes::c_void;
-use winapi::um::ncrypt::HCRYPTKEY;
-use winapi::um::wincrypt::{
+use windows_sys::Win32::Security::Cryptography::{
     CertCloseStore, CertEnumCertificatesInStore, CertFreeCertificateContext, CertOpenStore, CryptAcquireContextW,
     CryptDestroyKey, CryptGetKeyParam, CryptGetProvParam, CryptGetUserKey, CryptReleaseContext, AT_KEYEXCHANGE,
     CERT_STORE_PROV_SYSTEM_W, CERT_SYSTEM_STORE_CURRENT_USER_ID, CERT_SYSTEM_STORE_LOCATION_SHIFT, CRYPT_FIRST,
-    CRYPT_NEXT, CRYPT_SILENT, HCRYPTPROV, KP_CERTIFICATE, PP_ENUMCONTAINERS, PP_SMARTCARD_READER, PROV_RSA_FULL,
+    CRYPT_NEXT, CRYPT_SILENT, KP_CERTIFICATE, PP_ENUMCONTAINERS, PP_SMARTCARD_READER, 
+    PROV_RSA_FULL,
 };
 
 // UTF-16 encoded "Microsoft Base Smart Card Crypto Provider\0"
@@ -20,6 +20,11 @@ const CSP_NAME_W: &[u8] = &[
     116, 0, 111, 0, 32, 0, 80, 0, 114, 0, 111, 0, 118, 0, 105, 0, 100, 0, 101, 0, 114, 0, 0, 0,
 ];
 const CSP_NAME: &str = "Microsoft Base Smart Card Crypto Provider";
+
+// https://learn.microsoft.com/en-us/windows/win32/seccrypto/hcryptprov
+pub type HCRYPTPROV = usize; // ULONG_PTR
+// https://learn.microsoft.com/en-us/windows/win32/seccrypto/hcryptkey
+pub type HCRYPTKEY = usize; // ULONG_PTR
 
 use crate::{Error, ErrorKind, Result};
 

--- a/src/cert_utils.rs
+++ b/src/cert_utils.rs
@@ -9,8 +9,7 @@ use windows_sys::Win32::Security::Cryptography::{
     CertCloseStore, CertEnumCertificatesInStore, CertFreeCertificateContext, CertOpenStore, CryptAcquireContextW,
     CryptDestroyKey, CryptGetKeyParam, CryptGetProvParam, CryptGetUserKey, CryptReleaseContext, AT_KEYEXCHANGE,
     CERT_STORE_PROV_SYSTEM_W, CERT_SYSTEM_STORE_CURRENT_USER_ID, CERT_SYSTEM_STORE_LOCATION_SHIFT, CRYPT_FIRST,
-    CRYPT_NEXT, CRYPT_SILENT, KP_CERTIFICATE, PP_ENUMCONTAINERS, PP_SMARTCARD_READER, 
-    PROV_RSA_FULL,
+    CRYPT_NEXT, CRYPT_SILENT, KP_CERTIFICATE, PP_ENUMCONTAINERS, PP_SMARTCARD_READER, PROV_RSA_FULL,
 };
 
 // UTF-16 encoded "Microsoft Base Smart Card Crypto Provider\0"
@@ -23,7 +22,7 @@ const CSP_NAME: &str = "Microsoft Base Smart Card Crypto Provider";
 
 // https://learn.microsoft.com/en-us/windows/win32/seccrypto/hcryptprov
 pub type HCRYPTPROV = usize; // ULONG_PTR
-// https://learn.microsoft.com/en-us/windows/win32/seccrypto/hcryptkey
+                             // https://learn.microsoft.com/en-us/windows/win32/seccrypto/hcryptkey
 pub type HCRYPTKEY = usize; // ULONG_PTR
 
 use crate::{Error, ErrorKind, Result};

--- a/src/pku2u/cert_utils/win_extraction.rs
+++ b/src/pku2u/cert_utils/win_extraction.rs
@@ -10,9 +10,11 @@ use picky_asn1_x509::{oids, AttributeTypeAndValueParameters, Certificate, Extens
 use windows_sys::Win32::Foundation;
 use windows_sys::Win32::Security::Cryptography::{
     CertCloseStore, CertEnumCertificatesInStore, CertFreeCertificateContext, CertOpenStore,
-    CryptAcquireCertificatePrivateKey, CERT_CONTEXT, CERT_STORE_PROV_SYSTEM_W, CERT_SYSTEM_STORE_CURRENT_USER_ID,
-    CERT_SYSTEM_STORE_LOCATION_SHIFT, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG, HCRYPTPROV_OR_NCRYPT_KEY_HANDLE, 
-    NCryptExportKey, NCryptFreeObject, CERT_KEY_SPEC, BCRYPT_RSAFULLPRIVATE_BLOB, BCRYPT_RSAFULLPRIVATE_MAGIC};
+    CryptAcquireCertificatePrivateKey, NCryptExportKey, NCryptFreeObject, BCRYPT_RSAFULLPRIVATE_BLOB,
+    BCRYPT_RSAFULLPRIVATE_MAGIC, CERT_CONTEXT, CERT_KEY_SPEC, CERT_STORE_PROV_SYSTEM_W,
+    CERT_SYSTEM_STORE_CURRENT_USER_ID, CERT_SYSTEM_STORE_LOCATION_SHIFT, CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
+    HCRYPTPROV_OR_NCRYPT_KEY_HANDLE,
+};
 
 use crate::{Error, ErrorKind, Result};
 


### PR DESCRIPTION
This replaces the remaining uses of winapi as per https://github.com/Devolutions/sspi-rs/issues/174. 

I ran the tests with the features `scard,tsssp` enabled since some of the replaced calls are behind these features.