### PR TITLE
winscard: Improve environment variables and smart card info creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,11 +2878,13 @@ dependencies = [
 name = "winscard"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bitflags 2.4.2",
  "flate2",
  "iso7816",
  "iso7816-tlv",
  "picky",
+ "picky-asn1-der",
  "picky-asn1-x509",
  "proptest",
  "rand",

--- a/crates/winscard/Cargo.toml
+++ b/crates/winscard/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Devolutions Inc. <infos@devolutions.net>"]
 description = "A Rust implementation of WinSCard"
 
 [features]
-std = ["tracing/std"]
+std = ["tracing/std", "base64", "picky-asn1-der"]
 
 [lib]
 name = "winscard"
@@ -30,6 +30,8 @@ flate2 = { version = "1.0.28", features = ["zlib", "rust_backend"], default-feat
 rsa = { version = "0.9.6", features = ["hazmat", "sha1"], default-features = false }
 rand_core = "0.6.4"
 sha1 = { version = "0.10.6", default-features = false }
+base64 = { version = "0.21" , optional = true }
+picky-asn1-der = { version = "0.4", optional = true }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/crates/winscard/src/env.rs
+++ b/crates/winscard/src/env.rs
@@ -1,18 +1,18 @@
 /// Emulated smart card PIN code.
-pub const WINSCARD_PIN_ENV: &str = "SMARTCARD_PIN";
+pub const WINSCARD_PIN_ENV: &str = "WINSCARD_SMARTCARD_PIN";
 /// Path to the user certificate to be used in emulated smart card.
-pub const WINSCARD_CERT_PATH_ENV: &str = "CERTIFICATE_FILE_PATH";
+pub const WINSCARD_CERT_PATH_ENV: &str = "WINSCARD_CERTIFICATE_FILE_PATH";
 /// Smart card certificate data.
 ///
 /// *Note.* The variable value should be one-line base64 string containing ASN1 DER certificate data.
-pub const WINSCARD_CERT_DATA_ENV: &str = "CERTIFICATE_FILE_DATA";
+pub const WINSCARD_CERT_DATA_ENV: &str = "WINSCARD_CERTIFICATE_FILE_DATA";
 /// Path to the certificate private key.
-pub const WINSCARD_PK_PATH_ENV: &str = "PRIVATE_KEY_FILE_PATH";
+pub const WINSCARD_PK_PATH_ENV: &str = "WINSCARD_PRIVATE_KEY_FILE_PATH";
 /// Smart card private key data.
 ///
 /// *Note.* The variable value should be one-line base64 string containing ASN1 DER private key.
-pub const WINSCARD_PK_DATA_ENV: &str = "PRIVATE_KEY_FILE_DATA";
+pub const WINSCARD_PK_DATA_ENV: &str = "WINSCARD_PRIVATE_KEY_FILE_DATA";
 /// Emulated smart card container name.
-pub const WINSCARD_CONTAINER_NAME_ENV: &str = "SMARTCARD_CONTAINER_NAME";
+pub const WINSCARD_CONTAINER_NAME_ENV: &str = "WINSCARD_SMARTCARD_CONTAINER_NAME";
 /// Emulated smart card reader name.
-pub const WINSCARD_READER_NAME_ENV: &str = "SMARTCARD_READER_NAME";
+pub const WINSCARD_READER_NAME_ENV: &str = "WINSCARD_SMARTCARD_READER_NAME";

--- a/crates/winscard/src/env.rs
+++ b/crates/winscard/src/env.rs
@@ -1,10 +1,18 @@
 /// Emulated smart card PIN code.
-pub const WINSCARD_PIN_ENV: &str = "WINSCARD_PIN";
+pub const WINSCARD_PIN_ENV: &str = "SMARTCARD_PIN";
 /// Path to the user certificate to be used in emulated smart card.
-pub const WINSCARD_CERT_PATH_ENV: &str = "WINSCARD_CERT_PATH";
+pub const WINSCARD_CERT_PATH_ENV: &str = "CERTIFICATE_FILE_PATH";
+/// Smart card certificate data.
+///
+/// *Note.* The variable value should be one-line base64 string containing ASN1 DER certificate data.
+pub const WINSCARD_CERT_DATA_ENV: &str = "CERTIFICATE_FILE_DATA";
 /// Path to the certificate private key.
-pub const WINSCARD_PK_PATH_ENV: &str = "WINSCARD_PK_PATH";
+pub const WINSCARD_PK_PATH_ENV: &str = "PRIVATE_KEY_FILE_PATH";
+/// Smart card private key data.
+///
+/// *Note.* The variable value should be one-line base64 string containing ASN1 DER private key.
+pub const WINSCARD_PK_DATA_ENV: &str = "PRIVATE_KEY_FILE_DATA";
 /// Emulated smart card container name.
-pub const WINSCARD_CONTAINER_NAME_ENV: &str = "WINSCARD_CONTAINER";
+pub const WINSCARD_CONTAINER_NAME_ENV: &str = "SMARTCARD_CONTAINER_NAME";
 /// Emulated smart card reader name.
-pub const WINSCARD_READER_NAME_ENV: &str = "WINSCARD_READER";
+pub const WINSCARD_READER_NAME_ENV: &str = "SMARTCARD_READER_NAME";

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -106,6 +106,20 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
+#[cfg(feature = "std")]
+impl From<picky_asn1_der::Asn1DerError> for Error {
+    fn from(value: picky_asn1_der::Asn1DerError) -> Self {
+        Self::new(ErrorKind::InvalidValue, value.to_string())
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<base64::DecodeError> for Error {
+    fn from(value: base64::DecodeError) -> Self {
+        Self::new(ErrorKind::InvalidValue, value.to_string())
+    }
+}
+
 impl From<KeyError> for Error {
     fn from(value: KeyError) -> Self {
         Error::new(

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -6,7 +6,6 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 
 use picky::key::PrivateKey;
-use picky::x509::Cert;
 use picky_asn1_x509::{PublicKey, SubjectPublicKeyInfo};
 
 use crate::scard::SmartCard;
@@ -53,22 +52,44 @@ impl<'a> SmartCardInfo<'a> {
         use std::fs;
 
         use crate::env::{
-            WINSCARD_CERT_PATH_ENV, WINSCARD_CONTAINER_NAME_ENV, WINSCARD_PIN_ENV, WINSCARD_PK_PATH_ENV,
-            WINSCARD_READER_NAME_ENV,
+            WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV, WINSCARD_CONTAINER_NAME_ENV, WINSCARD_PIN_ENV,
+            WINSCARD_PK_PATH_ENV, WINSCARD_READER_NAME_ENV,
         };
 
         let container_name = env!(WINSCARD_CONTAINER_NAME_ENV)?.into();
         let reader_name: Cow<'_, str> = env!(WINSCARD_READER_NAME_ENV)?.into();
         let pin = env!(WINSCARD_PIN_ENV)?.into();
 
-        let cert_path = env!(WINSCARD_CERT_PATH_ENV)?;
-        let raw_certificate = fs::read_to_string(cert_path).map_err(|e| {
-            Error::new(
+        let auth_cert_der = if let Ok(cert_data) = env!(WINSCARD_CERT_DATA_ENV) {
+            use base64::Engine;
+            use picky_asn1_x509::Certificate;
+
+            let cert_der = base64::engine::general_purpose::STANDARD.decode(cert_data)?;
+
+            // Deserialize the certificate to ensure the provided data is a valid ASN1 DER certificate.
+            let _: Certificate = picky_asn1_der::from_bytes(&cert_der)?;
+
+            cert_der
+        } else if let Ok(cert_path) = env!(WINSCARD_CERT_PATH_ENV) {
+            use picky::x509::Cert;
+
+            let raw_certificate = fs::read_to_string(cert_path).map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidParameter,
+                    format!("Unable to read certificate from the provided file: {}", e),
+                )
+            })?;
+            Cert::from_pem_str(&raw_certificate)?.to_der()?
+        } else {
+            return Err(Error::new(
                 ErrorKind::InvalidParameter,
-                format!("Unable to read certificate from the provided file: {}", e),
-            )
-        })?;
-        let auth_cert_der = Cert::from_pem_str(&raw_certificate)?.to_der()?;
+                format!(
+                    "Either \"{}\" or \"{}\" environment variable must be present",
+                    WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV
+                ),
+            ));
+        };
+
         let pk_path = env!(WINSCARD_PK_PATH_ENV)?;
         let raw_private_key = fs::read_to_string(pk_path).map_err(|e| {
             Error::new(


### PR DESCRIPTION
Hi,
In this pull request, I've improved the environment variables' names and `SmartCardInfo` creation.

The following variable names have been renamed:

* `WINSCARD_PIN` -> `WINSCARD_SMARTCARD_PIN`.
* `WINSCARD_CERT_PATH` -> `WINSCARD_CERTIFICATE_FILE_PATH`.
* `WINSCARD_CONTAINER` -> `WINSCARD_SMARTCARD_CONTAINER_NAME`.
* `WINSCARD_READER` -> `WINSCARD_SMARTCARD_READER_NAME`.

The following variable names have been introduced:

* `WINSCARD_CERTIFICATE_FILE_DATA`: contains the base64 ASN1 DER certificate. Note: We don't support certificate chains in the emulated smart card (yet I hope), so we expect this env var to contain exactly one certificate. [Certificate example](https://crypto.qkation.com/asn1/?asn1=308205853082046da00302010202131c0000000431084fac18de9ae3000000000004300d06092a864886f70d01010b0500304b31133011060a0992268993f22c6401191603636f6d31133011060a0992268993f22c6401191603746274311f301d060355040313167462742d57494e2d39353643514f53534a54462d4341301e170d3234303232303233353235375a170d3235303231393233353235375a300030820122300d06092a864886f70d01010105000382010f003082010a02820101009d343131ae1a19793fae0899c7c640a22cdd1fa1a83c2590db21acbaf2e0a747a01460ea534986567b4d4748ddd31febb58bd463172d539784b963e53f310480f13c22cbdbcd0966652303b04280d1809d91c881c3bec1c7ac857888baeefd0fcb6aed92c63f5d39b8f8f8e2c84fcb178cb2c1cfd8312f9d2f971de8f53277c3e80ccd43b4f0c3c6e442c79b7e83033a0f91ce6796b16b00c8436e60104465a395590dc796abfd449ad9768688804384dcbf7e39ce9847674feb7a1ef23a01fc9b139f7331695c2ac3f6b0664c464cdc76da22f7f5e7e920d945963d6d14cebb26932f85a1a8c2319e330df132176434de4c9554079b26dcdae145afe7028c9d0203010001a38202ab308202a7303d06092b06010401823715070430302e06262b060104018237150885faaf4085bfbc1684818f288295fa5486a3a77f3482b6c10f84fad25b020164020102301f0603551d2504183016060a2b06010401823714020206082b06010505070302300e0603551d0f0101ff0404030205a0302906092b060104018237150a041c301a300c060a2b060104018237140202300a06082b06010505070302301d0603551d0e04160414f13316938ce63e4fb6caa19884ec847e2ea8e80730280603551d110101ff041e301ca01a060a2b060104018237140203a00c0c0a7432407462742e636f6d301f0603551d23041830168014f8ac9b9eb8a7b69358c346277a66593470cb40ad3081d80603551d1f0481d03081cd3081caa081c7a081c48681c16c6461703a2f2f2f434e3d7462742d57494e2d39353643514f53534a54462d43412c434e3d57494e2d39353643514f53534a54462c434e3d4344502c434e3d5075626c69632532304b657925323053657276696365732c434e3d53657276696365732c434e3d436f6e66696775726174696f6e2c44433d7462742c44433d636f6d3f63657274696669636174655265766f636174696f6e4c6973743f626173653f6f626a656374436c6173733d63524c446973747269627574696f6e506f696e743081c406082b060105050701010481b73081b43081b106082b060105050730028681a46c6461703a2f2f2f434e3d7462742d57494e2d39353643514f53534a54462d43412c434e3d4149412c434e3d5075626c69632532304b657925323053657276696365732c434e3d53657276696365732c434e3d436f6e66696775726174696f6e2c44433d7462742c44433d636f6d3f634143657274696669636174653f626173653f6f626a656374436c6173733d63657274696669636174696f6e417574686f72697479300d06092a864886f70d01010b050003820101002eb6e58da9a5c820c67138dda7095ac6ea01db827d636981492e785ef2e16b4a6a4da9526c1eeb63151f4501dfc1d82c4ff7a722bd1810dc4eb9c53a5da60ca893e28c197d2313c066daf209da5fab625b48061c61664033a8a579bf7e230ccdd589203283f478f4272672d695af03c25ca905bdd12fc80fab54e087ae7b0672c323f2adc575e1ce373c17ae5eeb65ffb62653605ddaaf3522f1dff6edf4cc32edf5435e706f27349ea3ec856a9e4448c806024034b0eb79dcda71f924b453183f74b32828e676fd808299365098f8607a91e8f3381d610431b66c71c2eea7de1e5fb7b4ecb6cd2e0927387075d7f49325793a4b558ea37e217aa3d528941cf7).
* `WINSCARD_PRIVATE_KEY_FILE_DATA`: contains the base64 ASN1 DER private key. [Private key example](https://crypto.qkation.com/asn1/?asn1=308204be020100300d06092a864886f70d0101010500048204a8308204a402010002820101009d343131ae1a19793fae0899c7c640a22cdd1fa1a83c2590db21acbaf2e0a747a01460ea534986567b4d4748ddd31febb58bd463172d539784b963e53f310480f13c22cbdbcd0966652303b04280d1809d91c881c3bec1c7ac857888baeefd0fcb6aed92c63f5d39b8f8f8e2c84fcb178cb2c1cfd8312f9d2f971de8f53277c3e80ccd43b4f0c3c6e442c79b7e83033a0f91ce6796b16b00c8436e60104465a395590dc796abfd449ad9768688804384dcbf7e39ce9847674feb7a1ef23a01fc9b139f7331695c2ac3f6b0664c464cdc76da22f7f5e7e920d945963d6d14cebb26932f85a1a8c2319e330df132176434de4c9554079b26dcdae145afe7028c9d0203010001028201010098e99fc0775da3d1b103941221a4d251edd9d95ee1ca3fb03bb6f1d19756b6e090f1c1a3ad0823c81380040af8dad87deac5ecfdc619acea018c63832688839cf90a49be8a3b531d6adb384747290ea050a4f1a867c331b30c39781967dbf8045915d5a9a3751735829b8b5ced03d0c54372cddb62abd568cc55ee1e2003cb421a3be0da8b9bed84b9058327856b2224414c745199b0d4c70f8758154879fe492dcc849093153e4a44e67813bb8242cfd4a963849fe5a04520dccb3d4bd39059cf1f284fe6a9edcdfd395c184759f6b81bb85ce5b87094421fb3776fe3d9351d00abaf75cb9ed08ad3fadbf7b296423f6304ff8c895b31bf13120bee00b11af102818100c913ce406026c905c57b72d26805c03f8408fa77433ba9013167dc640c0b6bfcf57d9803a68220545618d42316512a2f358e855a4b389adf837d9a3b80c4f7d4c397eae0172da7cbbd39c3125d772e49cb5bfc576507e88d7a12f660885e0f639d9bbeec87d70e6ce0e87797d734972eb78ea74cf033b16c15319532e7c7568302818100c82490370d921747b438dd93734ac6cfee77166a93491bae112b70336eb5702f56a2587e66d8faa4365b5a03c2488cc5d32ae647a333b966f1d53166aae97723a6be526a7770df3e8ce282802c5abb9d704403f86d3075d397c83db3f378b92e4b22e80df2d8e5dcfa0d462ac7041083e3ad22259369db1463a1b7e8c766265f0281806e7e48af4d66e2be1e27d90fd003a102061f1ceb5e71b14c2b87042fa202c0c38f6f0592b3f3fba9fc69c660c589b261a0cf816dfdb9cc3918bb737e51236b806a3ed7dd6e3f335e9ccbd9eb049b523f50d56a53e7fbb189d4d408b9411656e4899e250b3b162d221d71010eda3e56f95ffaaeea73702485dd1b92fe17298ddb02818100c30645f52f671d02450e687347142578f680daba0d3d5f18962882d3cb5c47ae0938770cecc1203325b88c953f1b1cf9a3d498c253b892404b049877d7b159e3c6968c8eac46b3732b2b8948c66fbf8421a255501d6dec52bc036684d489ddc0cb7c7f2d2067d44d28e80868a4b744349085e3d143bd11bae37ef14b8609f6f702818026b1fa2aa1280fd84353e7ebba098aa3619f9731c115e65ae5596b0ee1b114c5d88db49a50da62fa4fda941644da3482f7a2a1c6f48b89a5f8c550701c6edeb8f4c08620f1ef8f960f90ad2476f2b7646ea2fd25eb78b2cdadcbea1369f2c0c7a1c6d9a6b4a1bd75638a27852602fb7eccf55af78f867eeb6d0b804305dc3ac2).

**_Note._** The base64 string must be padded and without newline characters.