### PR TITLE
Fix CredSSP credentials handling when using `ClearTextPassword` to specify the password

### DIFF
--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -944,7 +944,11 @@ impl<'a> Kerberos {
                     .ok_or_else(|| Error::new(ErrorKind::InvalidToken, "Input buffers must be specified"))?;
                 let input_token = SecurityBuffer::find_buffer(input, SecurityBufferType::Token)?;
 
-                let neg_token_targ: NegTokenTarg1 = picky_asn1_der::from_bytes(&input_token.buffer)?;
+                let neg_token_targ = {
+                    let mut d = picky_asn1_der::Deserializer::new_from_bytes(&input_token.buffer);
+                    let neg_token_targ: NegTokenTarg1 = KrbResult::deserialize(&mut d)??;
+                    neg_token_targ
+                };
 
                 let ap_rep = extract_ap_rep_from_neg_token_targ(&neg_token_targ)?;
 


### PR DESCRIPTION
Hi,
In this PR I've made two main changes:

* Fixed the credentials handling in the CredSSP module when using `ClearTextPassword` to specify the password. Now we can connect to the RDP server using only the `.rdp` file without any credentials prompts.
* Improved the error handling in the Kerberos implementation.
