### PR TITLE
Correctly implement SCardAccessStartedEvent

### DIFF
--- a/crates/ffi-types/src/common.rs
+++ b/crates/ffi-types/src/common.rs
@@ -9,7 +9,7 @@ pub type LpCByte = *const u8;
 pub type LpByte = *mut u8;
 pub type LpCVoid = *const c_void;
 pub type LpVoid = *mut c_void;
-pub type Handle = *mut c_void;
+pub type Handle = isize;
 pub type Bool = i32;
 
 /// [Guid](https://learn.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid)


### PR DESCRIPTION
Hi,
In this pull request, I've fixed the `SCardAccessStartedEvent` function implementation.

Previously, we returned hardcoded value from the `SCardAccessStartedEvent` function. Unfortunately, it causes an error sometimes when using `sspi.dll` in `mstsc.exe`. This problem was fixed by introducing one global event for the entire process. We create one signaled event using Windows API and return a handle to it from the `SCardAccessStartedEvent` function. In such a way we tell that our emulated smart card is always ready. Moreover, this is a reason why we didn't use any reference counters as the original API assumes.

closes #230 