### PR TITLE
chore(ci): disallow println std in sspi lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Compiling the ffi module is enough to lint the whole sspi workspace
       - name: Check clippy
-        run: cargo clippy --manifest-path ffi/Cargo.toml ${{ matrix.additional-args }} -- -D warnings
+        run: cargo clippy --manifest-path ffi/Cargo.toml ${{ matrix.additional-args }} -- -D warnings -D clippy::print_stdout
 
   tests:
     name: Tests [${{ matrix.os }}] [${{ matrix.crate-name }}]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::print_stdout)]
 #![allow(non_snake_case)]
 
 #[macro_use]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -261,7 +261,6 @@ struct DataBuffer {
 /// This is a temporary fix until we implement the correct behavior.
 pub fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [DecryptBuffer]) -> Result<()> {
     let buffer = DecryptBuffer::find_buffer_mut(buffers, SecurityBufferType::Stream);
-    println!("decrypted: {:?}", decrypted);
     let mut stream_buffer_inner = None;
     // If there is a stream buffer, then we will write the decrypted data into it.
     if let Ok(stream_buffer) = buffer {


### PR DESCRIPTION
waiting for #235 to be merged first, to prevent people from the same mistake.