### PR TITLE
Improve `SECBUFFER_STREAM` buffer handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dns_resolver = ["dep:trust-dns-resolver", "dep:tokio"]
 tsssp = ["dep:rustls"]
 # Turns on Kerberos smart card login (available only on Windows and users WinSCard API)
 scard = ["dep:pcsc", "dep:winscard"]
+test_data = []
 
 [dependencies]
 byteorder = "1.4"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -35,3 +35,6 @@ tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
 windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }
+
+[dev-dependencies]
+sspi = { path = "..", features = ["network_client", "dns_resolver", "test_data"] }

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -439,8 +439,8 @@ mod tests {
         // MSDN code example: https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
         let plain_message = b"some plain message";
 
-        let kerberos_client = sspi::kerberos::test_client();
-        let mut kerberos_server = sspi::kerberos::test_server();
+        let kerberos_client = sspi::kerberos::test_data::fake_client();
+        let mut kerberos_server = sspi::kerberos::test_data::fake_server();
 
         let mut message = [
             SecurityBuffer {

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -1006,7 +1006,7 @@ impl SspiEx for Kerberos {
     }
 }
 
-#[cfg(feature = "test_data")]
+#[cfg(any(feature = "test_data", test))]
 pub fn test_client() -> Kerberos {
     use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
 
@@ -1039,7 +1039,7 @@ pub fn test_client() -> Kerberos {
     }
 }
 
-#[cfg(feature = "test_data")]
+#[cfg(any(feature = "test_data", test))]
 pub fn test_server() -> Kerberos {
     use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
 

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -1006,18 +1006,77 @@ impl SspiEx for Kerberos {
     }
 }
 
+#[cfg(feature = "test_data")]
+pub fn test_client() -> Kerberos {
+    use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
+
+    Kerberos {
+        state: KerberosState::Final,
+        config: KerberosConfig {
+            kdc_url: None,
+            client_computer_name: None,
+        },
+        auth_identity: None,
+        encryption_params: EncryptionParams {
+            encryption_type: Some(CipherSuite::Aes256CtsHmacSha196),
+            session_key: Some(vec![
+                21, 56, 207, 133, 152, 47, 177, 117, 223, 235, 169, 237, 173, 202, 11, 254, 142, 185, 237, 5, 97, 79,
+                112, 46, 73, 182, 117, 0, 35, 91, 24, 66,
+            ]),
+            sub_session_key: Some(vec![
+                146, 61, 191, 46, 26, 68, 247, 94, 124, 95, 1, 190, 15, 185, 245, 64, 18, 203, 212, 49, 43, 222, 254,
+                217, 85, 222, 7, 92, 254, 153, 105, 144,
+            ]),
+            sspi_encrypt_key_usage: INITIATOR_SEAL,
+            sspi_decrypt_key_usage: ACCEPTOR_SEAL,
+        },
+        seq_number: 1234,
+        realm: None,
+        kdc_url: None,
+        channel_bindings: None,
+        #[cfg(feature = "scard")]
+        dh_parameters: None,
+    }
+}
+
+#[cfg(feature = "test_data")]
+pub fn test_server() -> Kerberos {
+    use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
+
+    Kerberos {
+        state: KerberosState::Final,
+        config: KerberosConfig {
+            kdc_url: None,
+            client_computer_name: None,
+        },
+        auth_identity: None,
+        encryption_params: EncryptionParams {
+            encryption_type: Some(CipherSuite::Aes256CtsHmacSha196),
+            session_key: Some(vec![
+                21, 56, 207, 133, 152, 47, 177, 117, 223, 235, 169, 237, 173, 202, 11, 254, 142, 185, 237, 5, 97, 79,
+                112, 46, 73, 182, 117, 0, 35, 91, 24, 66,
+            ]),
+            sub_session_key: Some(vec![
+                146, 61, 191, 46, 26, 68, 247, 94, 124, 95, 1, 190, 15, 185, 245, 64, 18, 203, 212, 49, 43, 222, 254,
+                217, 85, 222, 7, 92, 254, 153, 105, 144,
+            ]),
+            sspi_encrypt_key_usage: ACCEPTOR_SEAL,
+            sspi_decrypt_key_usage: INITIATOR_SEAL,
+        },
+        seq_number: 0,
+        realm: None,
+        kdc_url: None,
+        channel_bindings: None,
+        #[cfg(feature = "scard")]
+        dh_parameters: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
-    use picky_krb::crypto::CipherSuite;
-
-    use super::EncryptionParams;
     use crate::generator::NetworkRequest;
     use crate::network_client::NetworkClient;
-    use crate::{
-        DecryptBuffer, EncryptionFlags, Kerberos, KerberosConfig, KerberosState, SecurityBuffer, SecurityBufferType,
-        Sspi,
-    };
+    use crate::{DecryptBuffer, EncryptionFlags, SecurityBuffer, SecurityBufferType, Sspi};
 
     struct NetworkClientMock;
 
@@ -1031,58 +1090,8 @@ mod tests {
     fn stream_buffer_decryption() {
         // https://learn.microsoft.com/en-us/windows/win32/secauthn/sspi-kerberos-interoperability-with-gssapi
 
-        let session_key = vec![
-            137, 60, 120, 245, 164, 179, 76, 200, 242, 96, 57, 174, 111, 209, 90, 76, 58, 117, 55, 138, 81, 75, 110,
-            235, 80, 228, 14, 238, 76, 128, 139, 81,
-        ];
-        let sub_session_key = vec![
-            35, 147, 211, 63, 83, 48, 241, 34, 97, 95, 27, 106, 195, 18, 95, 91, 17, 45, 187, 6, 26, 195, 16, 108, 123,
-            119, 121, 155, 58, 142, 204, 74,
-        ];
-
-        let mut kerberos_server = Kerberos {
-            state: KerberosState::Final,
-            config: KerberosConfig {
-                kdc_url: None,
-                client_computer_name: None,
-            },
-            auth_identity: None,
-            encryption_params: EncryptionParams {
-                encryption_type: Some(CipherSuite::Aes256CtsHmacSha196),
-                session_key: Some(session_key.clone()),
-                sub_session_key: Some(sub_session_key.clone()),
-                sspi_encrypt_key_usage: INITIATOR_SEAL,
-                sspi_decrypt_key_usage: ACCEPTOR_SEAL,
-            },
-            seq_number: 0,
-            realm: None,
-            kdc_url: None,
-            channel_bindings: None,
-            #[cfg(feature = "scard")]
-            dh_parameters: None,
-        };
-
-        let mut kerberos_client = Kerberos {
-            state: KerberosState::Final,
-            config: KerberosConfig {
-                kdc_url: None,
-                client_computer_name: None,
-            },
-            auth_identity: None,
-            encryption_params: EncryptionParams {
-                encryption_type: Some(CipherSuite::Aes256CtsHmacSha196),
-                session_key: Some(session_key),
-                sub_session_key: Some(sub_session_key),
-                sspi_encrypt_key_usage: ACCEPTOR_SEAL,
-                sspi_decrypt_key_usage: INITIATOR_SEAL,
-            },
-            seq_number: 0,
-            realm: None,
-            kdc_url: None,
-            channel_bindings: None,
-            #[cfg(feature = "scard")]
-            dh_parameters: None,
-        };
+        let mut kerberos_server = super::test_server();
+        let mut kerberos_client = super::test_client();
 
         let plain_message = b"some plain message";
 
@@ -1103,10 +1112,11 @@ mod tests {
 
         let mut buffer = message[0].buffer.clone();
         buffer.extend_from_slice(&message[1].buffer);
-        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Token(&mut [])];
+
+        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Data(&mut [])];
 
         kerberos_client.decrypt_message(&mut message, 0).unwrap();
 
-        assert_eq!(message[0].data(), plain_message);
+        assert_eq!(message[1].data(), plain_message);
     }
 }

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -977,10 +977,11 @@ xFnLp2UBrhxA9GYrpJ5i0onRmexQnTVSl5DDq07s+3dbr9YAKjrg9IDZYqLbdwP1
 
         let mut buffer = message[0].buffer.clone();
         buffer.extend_from_slice(&message[1].buffer);
-        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Token(&mut [])];
+
+        let mut message = [DecryptBuffer::Stream(&mut buffer), DecryptBuffer::Data(&mut [])];
 
         pku2u_client.decrypt_message(&mut message, 0).unwrap();
 
-        assert_eq!(message[0].data(), plain_message);
+        assert_eq!(message[1].data(), plain_message);
     }
 }


### PR DESCRIPTION
Hi,
In this pull request, I fixed the `SECBUFFER_STREAM` buffer handling.

This is how it works: 

I've explored the `SECBUFFER_STREAM` buffer usage and discovered that it is only used to pass the data to the decrypt function. Moreover, as I understand, it never changes its size and pointer location.

The sspi takes the inner buffer from the `Stream` decrypt buffer, writes data into it, and then assigns it to the `Data` decrypt buffer. Thus, after the decryption, the `Stream` decrypt buffer will be empty, and `Data` will contain decrypted data. But during the data copying on the FFI layer, we skip the `SECBUFFER_STREAM` buffer. So, we'll have resulting buffers the same as in the Windows SSPI.

Also, I added a test in the `ffi` crate that calls the `DecryptMessage` functions and expects the same behavior as for the original Windows SSPI. 

Related discussion: #232 