### PR TITLE
System-provided smart card implementation

### DIFF
--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -115,6 +115,7 @@ pub type GetOpenCardNameWFn = extern "system" fn(LpOpenCardNameW) -> ScardStatus
 pub type GetSCardApiFunctionTableFn = extern "system" fn() -> PSCardApiFunctionTable;
 
 // https://github.com/FreeRDP/FreeRDP/blob/88f79c5748f4031cb50dfae3ebadcc6619b69f1c/winpr/include/winpr/smartcard.h#L1114
+#[derive(Debug)]
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct SCardApiFunctionTable {

--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -12,56 +12,58 @@ pub type SCardEstablishContextFn =
     unsafe extern "system" fn(u32, *const c_void, *const c_void, LpScardContext) -> ScardStatus;
 pub type SCardReleaseContextFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
 pub type SCardIsValidContextFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
-pub type SCardListReaderGroupsAFn = extern "system" fn(ScardContext, LpStr, LpDword) -> ScardStatus;
-pub type SCardListReaderGroupsWFn = extern "system" fn(ScardContext, LpWStr, LpDword) -> ScardStatus;
+pub type SCardListReaderGroupsAFn = unsafe extern "system" fn(ScardContext, LpStr, LpDword) -> ScardStatus;
+pub type SCardListReaderGroupsWFn = unsafe extern "system" fn(ScardContext, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListReadersAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListCardsAFn =
     unsafe extern "system" fn(ScardContext, LpCByte, LpCGuid, u32, *mut u8, LpDword) -> ScardStatus;
 pub type SCardListCardsWFn =
     unsafe extern "system" fn(ScardContext, LpCByte, LpCGuid, u32, *mut u16, LpDword) -> ScardStatus;
-pub type SCardListInterfacesAFn = extern "system" fn(ScardContext, LpCStr, LpGuid, LpDword) -> ScardStatus;
-pub type SCardListInterfacesWFn = extern "system" fn(ScardContext, LpCWStr, LpGuid, LpDword) -> ScardStatus;
-pub type SCardGetProviderIdAFn = extern "system" fn(ScardContext, LpCStr, LpGuid) -> ScardStatus;
-pub type SCardGetProviderIdWFn = extern "system" fn(ScardContext, LpCWStr, LpGuid) -> ScardStatus;
+pub type SCardListInterfacesAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpGuid, LpDword) -> ScardStatus;
+pub type SCardListInterfacesWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpGuid, LpDword) -> ScardStatus;
+pub type SCardGetProviderIdAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpGuid) -> ScardStatus;
+pub type SCardGetProviderIdWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpGuid) -> ScardStatus;
 pub type SCardGetCardTypeProviderNameAFn =
     unsafe extern "system" fn(ScardContext, LpCStr, u32, *mut u8, LpDword) -> ScardStatus;
 pub type SCardGetCardTypeProviderNameWFn =
     unsafe extern "system" fn(ScardContext, LpCWStr, u32, *mut u16, LpDword) -> ScardStatus;
-pub type SCardIntroduceReaderGroupAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardIntroduceReaderGroupWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardForgetReaderGroupAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetReaderGroupWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardIntroduceReaderAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardIntroduceReaderWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
-pub type SCardForgetReaderAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetReaderWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardAddReaderToGroupAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardAddReaderToGroupWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
-pub type SCardRemoveReaderFromGroupAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardRemoveReaderFromGroupWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardIntroduceReaderGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardIntroduceReaderGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardForgetReaderGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetReaderGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardIntroduceReaderAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardIntroduceReaderWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardForgetReaderAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetReaderWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardAddReaderToGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardAddReaderToGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardRemoveReaderFromGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardRemoveReaderFromGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
 pub type SCardIntroduceCardTypeAFn =
-    extern "system" fn(ScardContext, LpCStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
 pub type SCardIntroduceCardTypeWFn =
-    extern "system" fn(ScardContext, LpCWStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
-pub type SCardSetCardTypeProviderNameAFn = extern "system" fn(ScardContext, LpCStr, u32, LpCStr) -> ScardStatus;
-pub type SCardSetCardTypeProviderNameWFn = extern "system" fn(ScardContext, LpCWStr, u32, LpCWStr) -> ScardStatus;
-pub type SCardForgetCardTypeAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetCardTypeWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
+pub type SCardSetCardTypeProviderNameAFn = unsafe extern "system" fn(ScardContext, LpCStr, u32, LpCStr) -> ScardStatus;
+pub type SCardSetCardTypeProviderNameWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, u32, LpCWStr) -> ScardStatus;
+pub type SCardForgetCardTypeAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetCardTypeWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
 pub type SCardFreeMemoryFn = unsafe extern "system" fn(ScardContext, LpCVoid) -> ScardStatus;
-pub type SCardAccessStartedEventFn = extern "system" fn() -> Handle;
-pub type SCardReleaseStartedEventFn = extern "system" fn();
-pub type SCardLocateCardsAFn = extern "system" fn(ScardContext, LpCStr, LpScardReaderStateA, u32) -> ScardStatus;
-pub type SCardLocateCardsWFn = extern "system" fn(ScardContext, LpCWStr, LpScardReaderStateW, u32) -> ScardStatus;
+pub type SCardAccessStartedEventFn = unsafe extern "system" fn() -> Handle;
+pub type SCardReleaseStartedEventFn = unsafe extern "system" fn();
+pub type SCardLocateCardsAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpScardReaderStateA, u32) -> ScardStatus;
+pub type SCardLocateCardsWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpScardReaderStateW, u32) -> ScardStatus;
 pub type SCardLocateCardsByATRAFn =
-    extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateA, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateA, u32) -> ScardStatus;
 pub type SCardLocateCardsByATRWFn =
-    extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateW, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateW, u32) -> ScardStatus;
 pub type SCardGetStatusChangeAFn =
     unsafe extern "system" fn(ScardContext, u32, LpScardReaderStateA, u32) -> ScardStatus;
 pub type SCardGetStatusChangeWFn =
     unsafe extern "system" fn(ScardContext, u32, LpScardReaderStateW, u32) -> ScardStatus;
-pub type SCardCancelFn = extern "system" fn(ScardContext) -> ScardStatus;
+pub type SCardCancelFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
 pub type SCardReadCacheAFn =
     unsafe extern "system" fn(ScardContext, LpUuid, u32, LpStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardReadCacheWFn =
@@ -72,23 +74,25 @@ pub type SCardGetReaderIconAFn = unsafe extern "system" fn(ScardContext, LpCStr,
 pub type SCardGetReaderIconWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardGetDeviceTypeIdAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpDword) -> ScardStatus;
 pub type SCardGetDeviceTypeIdWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpDword) -> ScardStatus;
-pub type SCardGetReaderDeviceInstanceIdAFn = extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
-pub type SCardGetReaderDeviceInstanceIdWFn = extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
+pub type SCardGetReaderDeviceInstanceIdAFn =
+    unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
+pub type SCardGetReaderDeviceInstanceIdWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWithDeviceInstanceIdAFn =
-    extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWithDeviceInstanceIdWFn =
-    extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
-pub type SCardAuditFn = extern "system" fn(ScardContext, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
+pub type SCardAuditFn = unsafe extern "system" fn(ScardContext, u32) -> ScardStatus;
 pub type SCardConnectAFn =
     unsafe extern "system" fn(ScardContext, LpCStr, u32, u32, LpScardHandle, LpDword) -> ScardStatus;
 pub type SCardConnectWFn =
     unsafe extern "system" fn(ScardContext, LpCWStr, u32, u32, LpScardHandle, LpDword) -> ScardStatus;
-pub type SCardReconnectFn = extern "system" fn(ScardHandle, u32, u32, u32, LpDword) -> ScardStatus;
+pub type SCardReconnectFn = unsafe extern "system" fn(ScardHandle, u32, u32, u32, LpDword) -> ScardStatus;
 pub type SCardDisconnectFn = unsafe extern "system" fn(ScardHandle, u32) -> ScardStatus;
 pub type SCardBeginTransactionFn = unsafe extern "system" fn(ScardHandle) -> ScardStatus;
 pub type SCardEndTransactionFn = unsafe extern "system" fn(ScardHandle, u32) -> ScardStatus;
-pub type SCardCancelTransactionFn = extern "system" fn(ScardHandle) -> ScardStatus;
-pub type SCardStateFn = extern "system" fn(ScardHandle, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
+pub type SCardCancelTransactionFn = unsafe extern "system" fn(ScardHandle) -> ScardStatus;
+pub type SCardStateFn = unsafe extern "system" fn(ScardHandle, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
 pub type SCardStatusAFn =
     unsafe extern "system" fn(ScardHandle, LpStr, LpDword, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
 pub type SCardStatusWFn =
@@ -102,17 +106,17 @@ pub type SCardTransmitFn = unsafe extern "system" fn(
     LpByte,
     LpDword,
 ) -> ScardStatus;
-pub type SCardGetTransmitCountFn = extern "system" fn(ScardHandle, LpDword) -> ScardStatus;
+pub type SCardGetTransmitCountFn = unsafe extern "system" fn(ScardHandle, LpDword) -> ScardStatus;
 pub type SCardControlFn =
     unsafe extern "system" fn(ScardHandle, u32, LpCVoid, u32, LpVoid, u32, LpDword) -> ScardStatus;
 pub type SCardGetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpByte, LpDword) -> ScardStatus;
 pub type SCardSetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpCByte, u32) -> ScardStatus;
-pub type SCardUIDlgSelectCardAFn = extern "system" fn(LpOpenCardNameExA) -> ScardStatus;
-pub type SCardUIDlgSelectCardWFn = extern "system" fn(LpOpenCardNameExW) -> ScardStatus;
-pub type GetOpenCardNameAFn = extern "system" fn(LpOpenCardNameA) -> ScardStatus;
-pub type GetOpenCardNameWFn = extern "system" fn(LpOpenCardNameW) -> ScardStatus;
+pub type SCardUIDlgSelectCardAFn = unsafe extern "system" fn(LpOpenCardNameExA) -> ScardStatus;
+pub type SCardUIDlgSelectCardWFn = unsafe extern "system" fn(LpOpenCardNameExW) -> ScardStatus;
+pub type GetOpenCardNameAFn = unsafe extern "system" fn(LpOpenCardNameA) -> ScardStatus;
+pub type GetOpenCardNameWFn = unsafe extern "system" fn(LpOpenCardNameW) -> ScardStatus;
 // Not a part of the standard winscard.h API
-pub type GetSCardApiFunctionTableFn = extern "system" fn() -> PSCardApiFunctionTable;
+pub type GetSCardApiFunctionTableFn = unsafe extern "system" fn() -> PSCardApiFunctionTable;
 
 // https://github.com/FreeRDP/FreeRDP/blob/88f79c5748f4031cb50dfae3ebadcc6619b69f1c/winpr/include/winpr/smartcard.h#L1114
 #[derive(Debug)]

--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -105,8 +105,8 @@ pub type SCardTransmitFn = unsafe extern "system" fn(
 pub type SCardGetTransmitCountFn = extern "system" fn(ScardHandle, LpDword) -> ScardStatus;
 pub type SCardControlFn =
     unsafe extern "system" fn(ScardHandle, u32, LpCVoid, u32, LpVoid, u32, LpDword) -> ScardStatus;
-pub type SCardGetAttribFn = extern "system" fn(ScardHandle, u32, LpByte, LpDword) -> ScardStatus;
-pub type SCardSetAttribFn = extern "system" fn(ScardHandle, u32, LpCByte, u32) -> ScardStatus;
+pub type SCardGetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpByte, LpDword) -> ScardStatus;
+pub type SCardSetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpCByte, u32) -> ScardStatus;
 pub type SCardUIDlgSelectCardAFn = extern "system" fn(LpOpenCardNameExA) -> ScardStatus;
 pub type SCardUIDlgSelectCardWFn = extern "system" fn(LpOpenCardNameExW) -> ScardStatus;
 pub type GetOpenCardNameAFn = extern "system" fn(LpOpenCardNameA) -> ScardStatus;

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -178,6 +178,13 @@ impl From<core::str::Utf8Error> for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl From<std::ffi::NulError> for Error {
+    fn from(value: std::ffi::NulError) -> Self {
+        Error::new(ErrorKind::InvalidParameter, value.to_string())
+    }
+}
+
 /// [Smart Card Return Values](https://learn.microsoft.com/en-us/windows/win32/secauthn/authentication-return-values).
 #[derive(Debug, PartialEq, ToPrimitive, FromPrimitive)]
 #[repr(u32)]

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -256,6 +256,43 @@ impl From<DeviceTypeId> for u32 {
     }
 }
 
+/// [SCardEstablishContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardestablishcontext)
+///
+/// `dwScope` parameter:
+/// Scope of the resource manager context.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ScardScope {
+    /// Database operations are performed within the domain of the user.
+    User = 0,
+    /// Database operations are performed within the domain of the system.
+    /// The calling application must have appropriate access permissions for any database actions.
+    System = 2,
+}
+
+impl TryFrom<u32> for ScardScope {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::User,
+            2 => Self::System,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidParameter,
+                    format!("Invalid ScardScope value: {}", value),
+                ))
+            }
+        })
+    }
+}
+
+impl From<ScardScope> for u32 {
+    fn from(value: ScardScope) -> Self {
+        value as u32
+    }
+}
+
 /// [SCardConnectW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardconnectw)
 ///
 /// `dwShareMode` parameter:

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", 
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
-windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }
+windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader"] }
 
 [dev-dependencies]
 sspi = { path = "..", features = ["network_client", "dns_resolver", "test_data"] }

--- a/ffi/src/winscard/mod.rs
+++ b/ffi/src/winscard/mod.rs
@@ -13,6 +13,7 @@ pub mod pcsc_lite;
 pub mod scard;
 pub mod scard_context;
 mod scard_handle;
+mod system_scard;
 
 // The constants below are not documented anywhere and were discovered during debugging.
 // Related example: https://github.com/bluetech/pcsc-rust/blob/b397cc8e3834a1dc791631105f37f34d321c8696/pcsc/src/lib.rs#L605-L613

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -30,9 +30,9 @@ unsafe fn connect(
     let protocol = Protocol::from_bits(dw_preferred_protocols);
 
     let scard_context = unsafe { scard_context_to_winscard_context(context)? };
-    let ScardConnectData { scard, protocol } = scard_context.connect(reader_name, share_mode, protocol)?;
+    let ScardConnectData { handle, protocol } = scard_context.connect(reader_name, share_mode, protocol)?;
 
-    let scard = WinScardHandle::new(scard.handle, context);
+    let scard = WinScardHandle::new(handle, context);
 
     let raw_card_handle = into_raw_ptr(scard) as ScardHandle;
 

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -8,8 +8,8 @@ use ffi_types::winscard::{
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpCWStr, LpDword, LpStr, LpVoid, LpWStr};
 #[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
-use winscard::winscard::Protocol;
-use winscard::{ErrorKind, WinScardResult};
+use winscard::winscard::{AttributeId, Protocol, ScardConnectData, ShareMode};
+use winscard::{Error, ErrorKind, WinScardResult};
 
 use super::buf_alloc::{copy_buff, write_multistring_a, write_multistring_w};
 use crate::utils::{c_w_str_to_string, into_raw_ptr};
@@ -30,8 +30,7 @@ unsafe fn connect(
     let protocol = Protocol::from_bits(dw_preferred_protocols);
 
     let scard_context = unsafe { scard_context_to_winscard_context(context)? };
-    let scard = scard_context.connect(reader_name, share_mode, protocol)?;
-    let protocol = scard.handle.status()?.protocol.bits();
+    let ScardConnectData { scard, protocol } = scard_context.connect(reader_name, share_mode, protocol)?;
 
     let scard = WinScardHandle::new(scard.handle, context);
 
@@ -42,7 +41,7 @@ unsafe fn connect(
 
     unsafe {
         *ph_card = raw_card_handle;
-        *pdw_active_protocol = protocol;
+        *pdw_active_protocol = protocol.bits();
     }
 
     Ok(())

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -8,8 +8,8 @@ use ffi_types::winscard::{
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpCWStr, LpDword, LpStr, LpVoid, LpWStr};
 #[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
-use winscard::winscard::{AttributeId, Protocol, ScardConnectData, ShareMode};
-use winscard::{Error, ErrorKind, WinScardResult};
+use winscard::winscard::{Protocol, ScardConnectData};
+use winscard::{ErrorKind, WinScardResult};
 
 use super::buf_alloc::{copy_buff, write_multistring_a, write_multistring_w};
 use crate::utils::{c_w_str_to_string, into_raw_ptr};

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -3,9 +3,9 @@ use std::mem::size_of;
 use std::ptr::null_mut;
 use std::slice::from_raw_parts;
 
+use ffi_types::winscard::functions::SCardApiFunctionTable;
 use ffi_types::winscard::{ScardContext, ScardHandle, ScardIoRequest};
 use num_traits::ToPrimitive;
-use ffi_types::winscard::functions::SCardApiFunctionTable;
 use winscard::winscard::{
     AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, Status, TransmitOutData, WinScard,
 };
@@ -22,7 +22,11 @@ pub struct SystemScard {
 
 impl SystemScard {
     pub fn new(h_card: ScardHandle, h_card_context: ScardContext) -> Self {
-        Self { h_card, h_card_context, api: init_scard_api_table(), }
+        Self {
+            h_card,
+            h_card_context,
+            api: init_scard_api_table(),
+        }
     }
 }
 
@@ -41,9 +45,7 @@ impl Drop for SystemScard {
             }
             #[cfg(target_os = "windows")]
             {
-                if let Err(err) =
-                    try_execute!(unsafe { (self.api.SCardDisconnect)(self.h_card, 0) })
-                {
+                if let Err(err) = try_execute!(unsafe { (self.api.SCardDisconnect)(self.h_card, 0) }) {
                     error!(?err, "Cannot disconnect the card");
                 }
             }
@@ -115,12 +117,7 @@ impl WinScard for SystemScard {
             }
             #[cfg(target_os = "windows")]
             {
-                try_execute!(unsafe {
-                    (self.api.SCardFreeMemory)(
-                        self.h_card_context,
-                        reader_name as *const _,
-                    )
-                })?;
+                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_card_context, reader_name as *const _,) })?;
             }
 
             return Err(Error::new(
@@ -135,9 +132,7 @@ impl WinScard for SystemScard {
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                (self.api.SCardFreeMemory)(self.h_card_context, reader_name as *const _)
-            })?;
+            try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_card_context, reader_name as *const _) })?;
         }
 
         let status = Status {
@@ -296,9 +291,7 @@ impl WinScard for SystemScard {
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                (self.api.SCardEndTransaction)(self.h_card, disposition.into())
-            })
+            try_execute!(unsafe { (self.api.SCardEndTransaction)(self.h_card, disposition.into()) })
         }
     }
 
@@ -360,14 +353,7 @@ impl WinScard for SystemScard {
             // If this value is NULL, SCardGetAttrib ignores the buffer length supplied in pcbAttrLen,
             // writes the length of the buffer that would have been returned if this parameter
             // had not been NULL to pcbAttrLen, and returns a success code.
-            try_execute!(unsafe {
-                (self.api.SCardGetAttrib)(
-                    self.h_card,
-                    attr_id,
-                    null_mut(),
-                    &mut data_len,
-                )
-            })?;
+            try_execute!(unsafe { (self.api.SCardGetAttrib)(self.h_card, attr_id, null_mut(), &mut data_len,) })?;
         }
 
         let mut data = vec![0; data_len.try_into()?];
@@ -380,14 +366,7 @@ impl WinScard for SystemScard {
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                (self.api.SCardGetAttrib)(
-                    self.h_card,
-                    attr_id,
-                    data.as_mut_ptr(),
-                    &mut data_len,
-                )
-            })?;
+            try_execute!(unsafe { (self.api.SCardGetAttrib)(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len) })?;
         }
 
         Ok(Cow::Owned(data))
@@ -406,14 +385,7 @@ impl WinScard for SystemScard {
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                (self.api.SCardSetAttrib)(
-                    self.h_card,
-                    attr_id,
-                    attribute_data.as_ptr(),
-                    len,
-                )
-            })
+            try_execute!(unsafe { (self.api.SCardSetAttrib)(self.h_card, attr_id, attribute_data.as_ptr(), len,) })
         }
     }
 
@@ -424,9 +396,7 @@ impl WinScard for SystemScard {
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                (self.api.SCardDisconnect)(self.h_card, disposition.into())
-            })?;
+            try_execute!(unsafe { (self.api.SCardDisconnect)(self.h_card, disposition.into()) })?;
         }
 
         // Mark the current card handle as disconnected.

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -42,7 +42,7 @@ impl Drop for SystemScard {
             #[cfg(target_os = "windows")]
             {
                 if let Err(err) =
-                    try_execute!(unsafe { windows_sys::Win32::Security::Credentials::SCardDisconnect(self.h_card, 0) })
+                    try_execute!(unsafe { (self.api.SCardDisconnect)(self.h_card, 0) })
                 {
                     error!(?err, "Cannot disconnect the card");
                 }
@@ -425,7 +425,7 @@ impl WinScard for SystemScard {
         #[cfg(target_os = "windows")]
         {
             try_execute!(unsafe {
-                windows_sys::Win32::Security::Credentials::SCardDisconnect(self.h_card, disposition.into())
+                (self.api.SCardDisconnect)(self.h_card, disposition.into())
             })?;
         }
 

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -4,9 +4,9 @@ use std::ptr::null_mut;
 use std::slice::from_raw_parts;
 
 use ffi_types::winscard::{ScardContext, ScardHandle, ScardIoRequest};
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::ToPrimitive;
 use winscard::winscard::{
-    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, State, Status, TransmitOutData, WinScard,
+    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, Status, TransmitOutData, WinScard,
 };
 use winscard::{Error, ErrorKind, WinScardResult, CHUNK_SIZE};
 

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,10 +1,20 @@
+use ffi_types::winscard::ScardHandle;
+use num_traits::FromPrimitive;
 use winscard::winscard::{
     AttributeId, ControlCode, IoRequest, Protocol, ReconnectInitialization, ShareMode, Status, TransmitOutData,
     WinScard,
 };
-use winscard::WinScardResult;
+use winscard::{Error, ErrorKind, WinScardResult};
 
-pub struct SystemScard {}
+pub struct SystemScard {
+    h_card: ScardHandle,
+}
+
+impl SystemScard {
+    pub fn new(h_card: ScardHandle) -> Self {
+        Self { h_card }
+    }
+}
 
 impl WinScard for SystemScard {
     fn status(&self) -> WinScardResult<Status> {
@@ -20,7 +30,12 @@ impl WinScard for SystemScard {
     }
 
     fn begin_transaction(&mut self) -> WinScardResult<()> {
-        todo!()
+        #[cfg(not(target_os = "windows"))]
+        unsafe {
+            try_execute!(pcsc_lite_rs::SCardBeginTransaction(self.h_card))?;
+        }
+        // TODO(@TheBestTvarynka): implement for Windows too.
+        Ok(())
     }
 
     fn end_transaction(&mut self) -> WinScardResult<()> {

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,0 +1,46 @@
+use winscard::winscard::{
+    AttributeId, ControlCode, IoRequest, Protocol, ReconnectInitialization, ShareMode, Status, TransmitOutData,
+    WinScard,
+};
+use winscard::WinScardResult;
+
+pub struct SystemScard {}
+
+impl WinScard for SystemScard {
+    fn status(&self) -> WinScardResult<Status> {
+        todo!()
+    }
+
+    fn control(&mut self, code: ControlCode, input: &[u8]) -> WinScardResult<Vec<u8>> {
+        todo!()
+    }
+
+    fn transmit(&mut self, send_pci: IoRequest, input_apdu: &[u8]) -> WinScardResult<TransmitOutData> {
+        todo!()
+    }
+
+    fn begin_transaction(&mut self) -> WinScardResult<()> {
+        todo!()
+    }
+
+    fn end_transaction(&mut self) -> WinScardResult<()> {
+        todo!()
+    }
+
+    fn reconnect(
+        &mut self,
+        share_mode: ShareMode,
+        preferred_protocol: Option<Protocol>,
+        initialization: ReconnectInitialization,
+    ) -> WinScardResult<Protocol> {
+        todo!()
+    }
+
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<&[u8]> {
+        todo!()
+    }
+
+    fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()> {
+        todo!()
+    }
+}

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -53,14 +53,14 @@ impl SystemScard {
         if h_card == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
-                "Scard handle can not be a zero.",
+                "scard handle can not be a zero",
             ));
         }
 
         if h_card_context == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
-                "Scard context handle can not be a zero.",
+                "scard context handle can not be a zero",
             ));
         }
 
@@ -80,7 +80,7 @@ impl SystemScard {
         } else {
             Err(Error::new(
                 ErrorKind::InvalidHandle,
-                "smart card is not connected or has been disconnected.",
+                "smart card is not connected or has been disconnected",
             ))
         }
     }
@@ -178,7 +178,7 @@ impl WinScard for SystemScard {
 
             return Err(Error::new(
                 ErrorKind::InternalError,
-                "Returned reader is not valid UTF-8",
+                "returned reader is not valid UTF-8",
             ));
         };
 
@@ -354,7 +354,7 @@ impl WinScard for SystemScard {
     fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
         let attr_id = attribute_id
             .to_u32()
-            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "cannot convert AttributeId -> u32"))?;
         let mut data_len = 0;
 
         // https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602
@@ -387,7 +387,7 @@ impl WinScard for SystemScard {
     fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()> {
         let attr_id = attribute_id
             .to_u32()
-            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "cannot convert AttributeId -> u32"))?;
 
         let len = attribute_data.len().try_into()?;
 

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -11,12 +11,13 @@ use winscard::winscard::{
 };
 use winscard::{Error, ErrorKind, WinScardResult};
 
-use super::{init_scard_api_table, parse_multi_string_owned};
+use super::parse_multi_string_owned;
 use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 
 pub struct SystemScard {
     h_card: ScardHandle,
     h_card_context: ScardContext,
+    #[cfg(target_os = "windows")]
     api: SCardApiFunctionTable,
 }
 
@@ -25,7 +26,8 @@ impl SystemScard {
         Self {
             h_card,
             h_card_context,
-            api: init_scard_api_table(),
+            #[cfg(target_os = "windows")]
+            api: super::init_scard_api_table(),
         }
     }
 }

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -174,20 +174,26 @@ impl WinScard for SystemScard {
 
     fn begin_transaction(&mut self) -> WinScardResult<()> {
         #[cfg(not(target_os = "windows"))]
-        unsafe {
-            try_execute!(pcsc_lite_rs::SCardBeginTransaction(self.h_card))?;
+        {
+            try_execute!(unsafe { pcsc_lite_rs::SCardBeginTransaction(self.h_card) })
         }
-        // TODO(@TheBestTvarynka): implement for Windows too.
-        Ok(())
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(unsafe { windows_sys::Win32::Security::Credentials::SCardBeginTransaction(self.h_card) })
+        }
     }
 
     fn end_transaction(&mut self, disposition: ReaderAction) -> WinScardResult<()> {
         #[cfg(not(target_os = "windows"))]
-        unsafe {
-            try_execute!(pcsc_lite_rs::SCardEndTransaction(self.h_card, disposition.into()))?;
+        {
+            try_execute!(unsafe { pcsc_lite_rs::SCardEndTransaction(self.h_card, disposition.into()) })
         }
-        // TODO(@TheBestTvarynka): implement for Windows too.
-        Ok(())
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardEndTransaction(self.h_card, disposition.into())
+            })
+        }
     }
 
     fn reconnect(
@@ -196,11 +202,11 @@ impl WinScard for SystemScard {
         preferred_protocol: Option<Protocol>,
         initialization: ReaderAction,
     ) -> WinScardResult<Protocol> {
+        let dw_preferred_protocols = preferred_protocol.unwrap_or_default().bits();
+        let mut active_protocol = 0;
+
         #[cfg(not(target_os = "windows"))]
         {
-            let dw_preferred_protocols = preferred_protocol.unwrap_or_default().bits();
-            let mut active_protocol = 0;
-
             try_execute!(unsafe {
                 pcsc_lite_rs::SCardReconnect(
                     self.h_card,
@@ -210,43 +216,75 @@ impl WinScard for SystemScard {
                     &mut active_protocol,
                 )
             })?;
-
-            Ok(Protocol::from_bits(active_protocol).unwrap_or_default())
         }
         #[cfg(target_os = "windows")]
         {
-            // TODO(@TheBestTvarynka): implement for Windows too.
-            todo!()
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardReconnect(
+                    self.h_card,
+                    share_mode.into(),
+                    dw_preferred_protocols,
+                    initialization.into(),
+                    &mut active_protocol,
+                )
+            })?;
         }
+
+        Ok(Protocol::from_bits(active_protocol).unwrap_or_default())
     }
 
     fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
         let attr_id = attribute_id
             .to_u32()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
+        let mut data_len = 0;
 
         #[cfg(not(target_os = "windows"))]
         {
-            let mut data_len = 0;
-
-            // [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
+            // https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602
             //
             // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
             // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
             try_execute!(unsafe { pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, null_mut(), &mut data_len) })?;
-
-            let mut data = vec![0; data_len.try_into()?];
-            try_execute!(unsafe {
-                pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len)
-            })?;
-
-            Ok(Cow::Owned(data))
         }
         #[cfg(target_os = "windows")]
         {
-            // TODO(@TheBestTvarynka): implement for Windows too.
-            todo!()
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib
+            //
+            // If this value is NULL, SCardGetAttrib ignores the buffer length supplied in pcbAttrLen,
+            // writes the length of the buffer that would have been returned if this parameter
+            // had not been NULL to pcbAttrLen, and returns a success code.
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardGetAttrib(
+                    self.h_card,
+                    attr_id,
+                    null_mut(),
+                    &mut data_len,
+                )
+            })?;
         }
+
+        let mut data = vec![0; data_len.try_into()?];
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(unsafe {
+                pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len)
+            })?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardGetAttrib(
+                    self.h_card,
+                    attr_id,
+                    data.as_mut_ptr(),
+                    &mut data_len,
+                )
+            })?;
+        }
+
+        Ok(Cow::Owned(data))
     }
 
     fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()> {
@@ -254,15 +292,22 @@ impl WinScard for SystemScard {
             .to_u32()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
 
+        let len = attribute_data.len().try_into()?;
+
         #[cfg(not(target_os = "windows"))]
         {
-            let len = attribute_data.len().try_into().unwrap();
-            try_execute!(unsafe { pcsc_lite_rs::SCardSetAttrib(self.h_card, attr_id, attribute_data.as_ptr(), len) })?;
+            try_execute!(unsafe { pcsc_lite_rs::SCardSetAttrib(self.h_card, attr_id, attribute_data.as_ptr(), len) })
         }
         #[cfg(target_os = "windows")]
         {
-            // TODO(@TheBestTvarynka): implement for Windows too.
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardSetAttrib(
+                    self.h_card,
+                    attr_id,
+                    attribute_data.as_ptr(),
+                    len,
+                )
+            })
         }
-        Ok(())
     }
 }

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -41,10 +41,17 @@ pub struct SystemScard {
 
 impl SystemScard {
     pub fn new(h_card: ScardHandle, h_card_context: ScardContext) -> WinScardResult<Self> {
+        if h_card == 0 {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                "Scard handle can not be a zero.",
+            ));
+        }
+
         if h_card_context == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
-                "Scard context handle can not be zero.",
+                "Scard context handle can not be a zero.",
             ));
         }
 

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -36,7 +36,7 @@ impl SystemScard {
             h_card,
             h_card_context,
             #[cfg(target_os = "windows")]
-            api: super::init_scard_api_table(),
+            api: super::init_scard_api_table()?,
             #[cfg(not(target_os = "windows"))]
             api: initialize_pcsc_lite_api()?,
         })

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,10 +1,10 @@
-use std::borrow::Cow;
 use std::ptr::null_mut;
 
 use ffi_types::winscard::ScardHandle;
 use num_traits::{FromPrimitive, ToPrimitive};
 use winscard::winscard::{
-    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, Status, TransmitOutData, WinScard,
+    AttributeId, ControlCode, IoRequest, OutBuffer, Protocol, ReaderAction, RequestedBufferType, ShareMode, Status,
+    TransmitOutData, WinScard,
 };
 use winscard::{Error, ErrorKind, WinScardResult};
 
@@ -79,27 +79,55 @@ impl WinScard for SystemScard {
         }
     }
 
-    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
+    fn get_attribute(&self, attribute_id: AttributeId, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let attr_id = attribute_id
             .to_u32()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
 
         #[cfg(not(target_os = "windows"))]
         {
-            let mut data_len = 0;
+            Ok(match buffer_type {
+                RequestedBufferType::Length => {
+                    let mut data_len = 0;
 
-            // [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
-            //
-            // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
-            // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
-            try_execute!(unsafe { pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, null_mut(), &mut data_len) })?;
+                    // [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
+                    //
+                    // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
+                    // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
+                    try_execute!(unsafe {
+                        pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, null_mut(), &mut data_len)
+                    })?;
 
-            let mut data = vec![0; data_len.try_into().unwrap()];
-            try_execute!(unsafe {
-                pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len)
-            })?;
+                    OutBuffer::DataLen(data_len.try_into()?)
+                }
+                RequestedBufferType::Buff(buf) => {
+                    let mut data_len = buf.len().try_into()?;
 
-            Ok(Cow::Owned(data))
+                    try_execute!(unsafe {
+                        pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, buf.as_mut_ptr(), &mut data_len)
+                    })?;
+
+                    OutBuffer::Written(data_len.try_into()?)
+                }
+                RequestedBufferType::Allocate => {
+                    let mut data_len = 0;
+
+                    // [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
+                    //
+                    // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
+                    // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
+                    try_execute!(unsafe {
+                        pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, null_mut(), &mut data_len)
+                    })?;
+
+                    let mut data = vec![0; data_len.try_into().unwrap()];
+                    try_execute!(unsafe {
+                        pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len)
+                    })?;
+
+                    OutBuffer::Allocated(data)
+                }
+            })
         }
         #[cfg(target_os = "windows")]
         {

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -10,6 +10,7 @@ use winscard::winscard::{
 };
 use winscard::{Error, ErrorKind, WinScardResult, CHUNK_SIZE};
 
+use super::parse_multi_string_owned;
 use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 
 pub struct SystemScard {
@@ -55,9 +56,9 @@ impl WinScard for SystemScard {
             })?;
 
             let readers = if let Ok(readers) =
-                parse_multi_string(unsafe { from_raw_parts(reader_name, reader_name_len.try_into()?) })
+                parse_multi_string_owned(unsafe { from_raw_parts(reader_name, reader_name_len.try_into()?) })
             {
-                readers.iter().map(|&r| Cow::Owned(r.to_owned())).collect()
+                readers
             } else {
                 try_execute!(unsafe { pcsc_lite_rs::SCardFreeMemory(self.h_card_context, reader_name as *const _) })?;
 
@@ -264,14 +265,4 @@ impl WinScard for SystemScard {
         }
         Ok(())
     }
-}
-
-fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
-    let res: Result<Vec<&str>, _> = buf
-        .split(|&c| c == 0)
-        .filter(|v| v.is_empty())
-        .map(|v| std::str::from_utf8(v))
-        .collect();
-
-    Ok(res?)
 }

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,8 +1,10 @@
+use std::borrow::Cow;
+use std::ptr::null_mut;
+
 use ffi_types::winscard::ScardHandle;
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 use winscard::winscard::{
-    AttributeId, ControlCode, IoRequest, Protocol, ReconnectInitialization, ShareMode, Status, TransmitOutData,
-    WinScard,
+    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, Status, TransmitOutData, WinScard,
 };
 use winscard::{Error, ErrorKind, WinScardResult};
 
@@ -38,24 +40,88 @@ impl WinScard for SystemScard {
         Ok(())
     }
 
-    fn end_transaction(&mut self) -> WinScardResult<()> {
-        todo!()
+    fn end_transaction(&mut self, disposition: ReaderAction) -> WinScardResult<()> {
+        #[cfg(not(target_os = "windows"))]
+        unsafe {
+            try_execute!(pcsc_lite_rs::SCardEndTransaction(self.h_card, disposition.into()))?;
+        }
+        // TODO(@TheBestTvarynka): implement for Windows too.
+        Ok(())
     }
 
     fn reconnect(
         &mut self,
         share_mode: ShareMode,
         preferred_protocol: Option<Protocol>,
-        initialization: ReconnectInitialization,
+        initialization: ReaderAction,
     ) -> WinScardResult<Protocol> {
-        todo!()
+        #[cfg(not(target_os = "windows"))]
+        {
+            let dw_preferred_protocols = preferred_protocol.unwrap_or_default().bits();
+            let mut active_protocol = 0;
+
+            try_execute!(unsafe {
+                pcsc_lite_rs::SCardReconnect(
+                    self.h_card,
+                    share_mode.into(),
+                    dw_preferred_protocols,
+                    initialization.into(),
+                    &mut active_protocol,
+                )
+            })?;
+
+            Ok(Protocol::from_bits(active_protocol).unwrap_or_default())
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
-    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<&[u8]> {
-        todo!()
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
+        let attr_id = attribute_id
+            .to_u32()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let mut data_len = 0;
+
+            // [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
+            //
+            // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
+            // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
+            try_execute!(unsafe { pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, null_mut(), &mut data_len) })?;
+
+            let mut data = vec![0; data_len.try_into().unwrap()];
+            try_execute!(unsafe {
+                pcsc_lite_rs::SCardGetAttrib(self.h_card, attr_id, data.as_mut_ptr(), &mut data_len)
+            })?;
+
+            Ok(Cow::Owned(data))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
     fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()> {
-        todo!()
+        let attr_id = attribute_id
+            .to_u32()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "Cannot convert AttributeId -> u32"))?;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let len = attribute_data.len().try_into().unwrap();
+            try_execute!(unsafe { pcsc_lite_rs::SCardSetAttrib(self.h_card, attr_id, attribute_data.as_ptr(), len) })?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+        }
+        Ok(())
     }
 }

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -67,7 +67,7 @@ impl WinScard for SystemScard {
         // PCSC-lite docs do not specify that ATR buf should be 32 bytes long, but actually,
         // the ATR string can not be longer than 32 bytes.
         let mut atr = vec![0; 32];
-        let mut atr_len = 0;
+        let mut atr_len = 32;
 
         #[cfg(not(target_os = "windows"))]
         {
@@ -104,6 +104,7 @@ impl WinScard for SystemScard {
                     &mut atr_len,
                 )
             })?;
+            info!("atr after: {:?}", atr);
         }
 
         let readers = if let Ok(readers) =

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use ffi_types::winscard::ScardContext;
 use winscard::winscard::{DeviceTypeId, Icon, MemoryPtr, Protocol, ShareMode, WinScard, WinScardContext};
-use winscard::WinScardResult;
+use winscard::{Error, ErrorKind, WinScardResult};
 
 pub struct SystemScardContext {
     h_context: ScardContext,
@@ -28,16 +28,46 @@ impl WinScardContext for SystemScardContext {
         todo!()
     }
 
-    fn device_type_id(&self, reader_name: &str) -> WinScardResult<DeviceTypeId> {
-        todo!()
+    fn device_type_id(&self, _reader_name: &str) -> WinScardResult<DeviceTypeId> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetDeviceTypeId function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
-    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon> {
-        todo!()
+    fn reader_icon(&self, _reader_name: &str) -> WinScardResult<Icon> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetReaderIcon function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
     fn is_valid(&self) -> bool {
-        todo!()
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(unsafe { pcsc_lite_rs::SCardIsValidContext(self.h_context) }).is_ok()
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
     fn read_cache(&self, key: &str) -> Option<&[u8]> {
@@ -53,10 +83,6 @@ impl WinScardContext for SystemScardContext {
     }
 
     fn cancel(&mut self) -> WinScardResult<()> {
-        todo!()
-    }
-
-    fn free(&mut self, ptr: MemoryPtr) -> WinScardResult<()> {
         todo!()
     }
 }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -75,12 +75,7 @@ impl WinScardContext for SystemScardContext {
         share_mode: ShareMode,
         protocol: Option<Protocol>,
     ) -> WinScardResult<ScardConnectData> {
-        // SAFETY:
-        // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-        // > This function will return an error if the supplied bytes contain an internal 0 byte.
-        //
-        // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-        let c_string = CString::new(reader_name).expect("Rust string slice should not contain 0 bytes");
+        let c_string = CString::new(reader_name)?;
 
         let mut scard: ScardHandle = 0;
         let mut active_protocol = 0;
@@ -203,12 +198,7 @@ impl WinScardContext for SystemScardContext {
 
             let mut device_type_id = 0;
 
-            // SAFETY:
-            // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-            // > This function will return an error if the supplied bytes contain an internal 0 byte.
-            //
-            // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-            let c_reader_name = CString::new(_reader_name).expect("Rust string slice should not contain 0 bytes");
+            let c_reader_name = CString::new(_reader_name)?;
 
             try_execute!(
                 // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
@@ -242,12 +232,7 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
-            // SAFETY:
-            // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-            // > This function will return an error if the supplied bytes contain an internal 0 byte.
-            //
-            // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-            let c_reader_name = CString::new(_reader_name).expect("Rust string slice should not contain 0 bytes");
+            let c_reader_name = CString::new(_reader_name)?;
 
             let mut icon_buf_len = 0;
 
@@ -314,12 +299,7 @@ impl WinScardContext for SystemScardContext {
 
             let mut data_len = SCARD_AUTOALLOCATE;
 
-            // SAFETY:
-            // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-            // > This function will return an error if the supplied bytes contain an internal 0 byte.
-            //
-            // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-            let c_cache_key = CString::new(_key).expect("Rust string slice should not contain 0 bytes");
+            let c_cache_key = CString::new(_key)?;
             let mut card_id = uuid_to_c_guid(_card_id);
 
             let mut data: *mut u8 = null_mut();
@@ -389,12 +369,7 @@ impl WinScardContext for SystemScardContext {
         {
             use super::uuid_to_c_guid;
 
-            // SAFETY:
-            // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-            // > This function will return an error if the supplied bytes contain an internal 0 byte.
-            //
-            // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-            let c_cache_key = CString::new(_key.as_str()).expect("Rust string slice should not contain 0 bytes");
+            let c_cache_key = CString::new(_key.as_str())?;
             let mut card_id = uuid_to_c_guid(_card_id);
 
             try_execute!(
@@ -496,22 +471,16 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
+            use std::ffi::NulError;
+
             use ffi_types::winscard::ScardReaderStateA;
             use winscard::winscard::CurrentState;
 
             let mut states = Vec::with_capacity(_reader_states.len());
-            let c_readers: Vec<_> = _reader_states
+            let c_readers = _reader_states
                 .iter()
-                .map(|reader_state| {
-                    // SAFETY:
-                    // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-                    // > This function will return an error if the supplied bytes contain an internal 0 byte.
-                    //
-                    // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-                    CString::new(reader_state.reader_name.as_ref())
-                        .expect("Rust string slice should not contain 0 bytes")
-                })
-                .collect();
+                .map(|reader_state| CString::new(reader_state.reader_name.as_ref()))
+                .collect::<Result<Vec<CString>, NulError>>()?;
 
             for (reader_state, c_reader) in _reader_states.iter_mut().zip(c_readers.iter()) {
                 states.push(ScardReaderStateA {
@@ -624,12 +593,7 @@ impl WinScardContext for SystemScardContext {
             let mut data_len = SCARD_AUTOALLOCATE;
             let mut data: *mut u8 = null_mut();
 
-            // SAFETY:
-            // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
-            // > This function will return an error if the supplied bytes contain an internal 0 byte.
-            //
-            // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
-            let c_card_name = CString::new(_card_name).expect("Rust string slice should not contain 0 bytes");
+            let c_card_name = CString::new(_card_name)?;
 
             try_execute!(
                 // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -515,7 +515,7 @@ impl WinScardContext for SystemScardContext {
             use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 
             let mut data_len = SCARD_AUTOALLOCATE;
-            let mut data: *mut *mut u8 = null_mut();
+            let mut data: *mut u8 = null_mut();
 
             // SAFETY:
             // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new
@@ -529,7 +529,7 @@ impl WinScardContext for SystemScardContext {
                     self.h_context,
                     c_card_name.as_ptr() as *const _,
                     provider_id.into(),
-                    data as *mut u8,
+                    ((&mut data) as *mut *mut u8) as *mut _,
                     &mut data_len,
                 )
             })?;
@@ -542,9 +542,11 @@ impl WinScardContext for SystemScardContext {
                 return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
             };
 
+            debug!(?data);
+
             let name = if let Ok(name) = String::from_utf8(
                 unsafe {
-                    let raw_name = from_raw_parts(*data, data_len);
+                    let raw_name = from_raw_parts(data, data_len);
                     debug!(?raw_name);
                     raw_name
                 }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -197,8 +197,7 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
-            // TODO(@TheBestTvarynka): implement for Windows too.
-            todo!()
+            try_execute!(unsafe { windows_sys::Win32::Security::Credentials::SCardCancel(self.h_context) })
         }
     }
 }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -43,13 +43,17 @@ impl Drop for SystemScardContext {
     fn drop(&mut self) {
         #[cfg(not(target_os = "windows"))]
         {
-            try_execute!(unsafe { pcsc_lite_rs::SCardReleaseContext(self.h_context) })?;
+            if let Err(err) = try_execute!(unsafe { pcsc_lite_rs::SCardReleaseContext(self.h_context) }) {
+                error!(?err, "Can not release the scard context");
+            }
         }
         #[cfg(target_os = "windows")]
         {
-            try_execute!(unsafe {
-                windows_sys::Win32::Security::Credentials::SCardReleaseContext(self.h_context)
-            })?;
+            if let Err(err) =
+                try_execute!(unsafe { windows_sys::Win32::Security::Credentials::SCardReleaseContext(self.h_context) })
+            {
+                error!(?err, "Can not release the scard context");
+            }
         }
     }
 }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -48,7 +48,7 @@ impl SystemScardContext {
         if h_context == 0 {
             return Err(Error::new(
                 ErrorKind::InternalError,
-                "Can not establish context: SCardEstablishContext did not set the context handle",
+                "can not establish context: SCardEstablishContext did not set the context handle",
             ));
         }
 
@@ -541,7 +541,7 @@ impl WinScardContext for SystemScardContext {
             // We do not need to change all fields. Only event state and atr values can be changed.
             for (state, reader_state) in states.iter().zip(_reader_states.iter_mut()) {
                 reader_state.event_state = CurrentState::from_bits(state.dw_event_state)
-                    .ok_or_else(|| Error::new(ErrorKind::InternalError, "Invalid dwEventState"))?;
+                    .ok_or_else(|| Error::new(ErrorKind::InternalError, "invalid dwEventState"))?;
                 reader_state.atr_len = state.cb_atr.try_into()?;
                 reader_state.atr = state.rgb_atr;
             }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use winscard::winscard::{DeviceTypeId, Icon, MemoryPtr, Protocol, ShareMode, WinScard, WinScardContext};
+use winscard::WinScardResult;
+
+pub struct SystemScardContext {}
+
+impl WinScardContext for SystemScardContext {
+    fn connect(
+        &self,
+        reader_name: &str,
+        share_mode: ShareMode,
+        protocol: Option<Protocol>,
+    ) -> WinScardResult<Box<dyn WinScard>> {
+        todo!()
+    }
+
+    fn list_readers(&self) -> Vec<Cow<str>> {
+        todo!()
+    }
+
+    fn device_type_id(&self, reader_name: &str) -> WinScardResult<DeviceTypeId> {
+        todo!()
+    }
+
+    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon> {
+        todo!()
+    }
+
+    fn is_valid(&self) -> bool {
+        todo!()
+    }
+
+    fn read_cache(&self, key: &str) -> Option<&[u8]> {
+        todo!()
+    }
+
+    fn write_cache(&mut self, key: String, value: Vec<u8>) {
+        todo!()
+    }
+
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {
+        todo!()
+    }
+
+    fn cancel(&mut self) -> WinScardResult<()> {
+        todo!()
+    }
+
+    fn free(&mut self, ptr: MemoryPtr) -> WinScardResult<()> {
+        todo!()
+    }
+}

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -39,6 +39,21 @@ impl SystemScardContext {
     }
 }
 
+impl Drop for SystemScardContext {
+    fn drop(&mut self) {
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(unsafe { pcsc_lite_rs::SCardReleaseContext(self.h_context) })?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardReleaseContext(self.h_context)
+            })?;
+        }
+    }
+}
+
 impl WinScardContext for SystemScardContext {
     fn connect(
         &self,

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -38,9 +38,9 @@ impl SystemScardContext {
         #[cfg(not(target_os = "windows"))]
         let api = initialize_pcsc_lite_api()?;
 
-        // SAFETY: This function is safe to call because the `scope` parameter value is type checked
-        // and `*mut h_context` can't be `null`.
         try_execute!(
+            // SAFETY: This function is safe to call because the `scope` parameter value is type checked
+            // and `*mut h_context` can't be `null`.
             unsafe { (api.SCardEstablishContext)(scope.into(), null_mut(), null_mut(), &mut h_context) },
             "SCardEstablishContext failed"
         )?;
@@ -58,8 +58,8 @@ impl SystemScardContext {
 
 impl Drop for SystemScardContext {
     fn drop(&mut self) {
-        // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
         if let Err(err) = try_execute!(
+            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
             unsafe { (self.api.SCardReleaseContext)(self.h_context) },
             "SCardReleaseContext failed"
         ) {
@@ -87,9 +87,9 @@ impl WinScardContext for SystemScardContext {
 
         #[cfg(not(target_os = "windows"))]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardConnect)(
                         self.h_context,
@@ -105,9 +105,9 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardConnectA)(
                         self.h_context,
@@ -139,10 +139,9 @@ impl WinScardContext for SystemScardContext {
             //
             // If the application sends mszGroups and mszReaders as NULL then this function will return the size of the buffer needed to allocate in pcchReaders.
             // `mszGroups`: List of groups to list readers (not used).
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe { (self.api.SCardListReaders)(self.h_context, null(), null_mut(), &mut readers_buf_len) },
                 "SCardListReaders failed"
             )?;
@@ -154,10 +153,9 @@ impl WinScardContext for SystemScardContext {
             //  If this value is NULL, SCardListReaders ignores the buffer length supplied in pcchReaders,
             //  writes the length of the buffer that would have been returned if this parameter
             //  had not been NULL to pcchReaders, and returns a success code.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe { (self.api.SCardListReadersA)(self.h_context, null(), null_mut(), &mut readers_buf_len) },
                 "SCardListReadersA failed"
             )?;
@@ -167,9 +165,9 @@ impl WinScardContext for SystemScardContext {
 
         #[cfg(not(target_os = "windows"))]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListReaders)(self.h_context, null(), readers.as_mut_ptr(), &mut readers_buf_len)
                 },
@@ -178,9 +176,9 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListReadersA)(self.h_context, null(), readers.as_mut_ptr(), &mut readers_buf_len)
                 },
@@ -212,9 +210,9 @@ impl WinScardContext for SystemScardContext {
             // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
             let c_reader_name = CString::new(_reader_name).expect("Rust string slice should not contain 0 bytes");
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardGetDeviceTypeIdA)(
                         self.h_context,
@@ -258,10 +256,9 @@ impl WinScardContext for SystemScardContext {
             // If this value is NULL, the function ignores the buffer length supplied in the pcbIcon parameter,
             // writes the length of the buffer that would have been returned to pcbIcon if this parameter
             // had not been NULL, and returns a success code.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardGetReaderIconA)(
                         self.h_context,
@@ -275,9 +272,9 @@ impl WinScardContext for SystemScardContext {
 
             let mut icon_buf = vec![0; icon_buf_len.try_into()?];
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardGetReaderIconA)(
                         self.h_context,
@@ -294,8 +291,8 @@ impl WinScardContext for SystemScardContext {
     }
 
     fn is_valid(&self) -> bool {
-        // SAFETY: This function is safe to call because we are allowed to pass any value.
         try_execute!(
+            // SAFETY: This function is safe to call because we are allowed to pass any value.
             unsafe { (self.api.SCardIsValidContext)(self.h_context) },
             "SCardIsValidContext failed"
         )
@@ -329,10 +326,9 @@ impl WinScardContext for SystemScardContext {
 
             // It's not specified in the `SCardReadCacheA` function documentation, but after some
             // `msclmd.dll` reversing, we found out that this function supports the `SCARD_AUTOALLOCATE`.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardReadCacheA)(
                         self.h_context,
@@ -349,8 +345,8 @@ impl WinScardContext for SystemScardContext {
             let data_len: usize = if let Ok(len) = data_len.try_into() {
                 len
             } else {
-                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                 try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                     unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
                     "SCardFreeMemory failed"
                 )?;
@@ -359,10 +355,14 @@ impl WinScardContext for SystemScardContext {
             };
 
             let mut cache_item = vec![0; data_len];
-            cache_item.copy_from_slice(unsafe { from_raw_parts(data, data_len) });
+            cache_item.copy_from_slice(
+                // SAFETY: A slice creation is safe here because the `data` pointer is a local pointer and
+                // was initialized by `SCardReadCacheA` function.
+                unsafe { from_raw_parts(data, data_len) },
+            );
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                 unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
                 "SCardFreeMemory failed"
             )?;
@@ -397,9 +397,9 @@ impl WinScardContext for SystemScardContext {
             let c_cache_key = CString::new(_key.as_str()).expect("Rust string slice should not contain 0 bytes");
             let mut card_id = uuid_to_c_guid(_card_id);
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardWriteCacheA)(
                         self.h_context,
@@ -423,10 +423,9 @@ impl WinScardContext for SystemScardContext {
             // https://pcsclite.apdu.fr/api/group__API.html#ga9d970d086d5218e080d0079d63f9d496
             //
             // If the application sends mszGroups as NULL then this function will return the size of the buffer needed to allocate in pcchGroups.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe { (self.api.SCardListReaderGroups)(self.h_context, null_mut(), &mut reader_groups_buf_len) },
                 "SCardListReaderGroups failed"
             )?;
@@ -438,10 +437,9 @@ impl WinScardContext for SystemScardContext {
             // If this value is NULL, SCardListReaderGroups ignores the buffer length supplied in pcchGroups,
             // writes the length of the buffer that would have been returned if this parameter had not been
             // NULL to pcchGroups, and returns a success code.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe { (self.api.SCardListReaderGroupsA)(self.h_context, null_mut(), &mut reader_groups_buf_len) },
                 "SCardListReaderGroupsA failed"
             )?;
@@ -451,9 +449,9 @@ impl WinScardContext for SystemScardContext {
 
         #[cfg(not(target_os = "windows"))]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListReaderGroups)(
                         self.h_context,
@@ -466,9 +464,9 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListReaderGroupsA)(
                         self.h_context,
@@ -526,9 +524,9 @@ impl WinScardContext for SystemScardContext {
                 });
             }
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardGetStatusChangeA)(
                         self.h_context,
@@ -580,10 +578,9 @@ impl WinScardContext for SystemScardContext {
             // mszCards: If this value is NULL, SCardListCards ignores the buffer length supplied in
             // pcchCards, returning the length of the buffer that would have been returned if this
             // parameter had not been NULL to pcchCards and a success code.
-            //
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListCardsA)(self.h_context, atr, c_uuids, uuids_len, null_mut(), &mut cards_buf_len)
                 },
@@ -592,9 +589,9 @@ impl WinScardContext for SystemScardContext {
 
             let mut cards = vec![0; cards_buf_len.try_into()?];
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardListCardsA)(
                         self.h_context,
@@ -634,9 +631,9 @@ impl WinScardContext for SystemScardContext {
             // The Rust string slice cannot contain 0 bytes. So, it's safe to unwrap it.
             let c_card_name = CString::new(_card_name).expect("Rust string slice should not contain 0 bytes");
 
-            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
-            // and other parameters are type checked.
             try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
                 unsafe {
                     (self.api.SCardGetCardTypeProviderNameA)(
                         self.h_context,
@@ -652,8 +649,8 @@ impl WinScardContext for SystemScardContext {
             let data_len: usize = if let Ok(len) = data_len.try_into() {
                 len
             } else {
-                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                 try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                     unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
                     "SCardFreeMemory failed"
                 )?;
@@ -661,11 +658,15 @@ impl WinScardContext for SystemScardContext {
                 return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
             };
 
-            let name = if let Ok(name) = String::from_utf8(unsafe { from_raw_parts(data, data_len) }.to_vec()) {
+            let name = if let Ok(name) = String::from_utf8(
+                // SAFETY: A slice create is safe because the `data` pointer is a local pointer and
+                // was initialized by `SCardGetCardTypeProviderNameA` function.
+                unsafe { from_raw_parts(data, data_len) }.to_vec(),
+            ) {
                 name
             } else {
-                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                 try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
                     unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
                     "SCardFreeMemory failed"
                 )?;

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -7,7 +7,7 @@ use ffi_types::winscard::{ScardContext, ScardHandle};
 use winscard::winscard::{DeviceTypeId, Icon, Protocol, ScardConnectData, ShareMode, Uuid, WinScardContext};
 use winscard::{Error, ErrorKind, WinScardResult};
 
-use super::{parse_multi_string_owned, uuid_to_c_guid, SystemScard};
+use super::{parse_multi_string_owned, SystemScard};
 
 pub struct SystemScardContext {
     h_context: ScardContext,
@@ -229,6 +229,7 @@ impl WinScardContext for SystemScardContext {
         }
         #[cfg(target_os = "windows")]
         {
+            use super::uuid_to_c_guid;
             use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 
             let mut data_len = SCARD_AUTOALLOCATE;

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -14,8 +14,26 @@ pub struct SystemScardContext {
 }
 
 impl SystemScardContext {
-    pub fn new(h_context: ScardContext) -> Self {
-        Self { h_context }
+    pub fn establish(dw_scope: u32) -> WinScardResult<Self> {
+        let mut h_context = 0;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(unsafe { pcsc_lite_rs::SCardEstablishContext(dw_scope, null(), null(), &mut h_context,) })?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(unsafe {
+                windows_sys::Win32::Security::Credentials::SCardEstablishContext(
+                    dw_scope,
+                    null(),
+                    null(),
+                    &mut h_context,
+                )
+            })?;
+        }
+
+        Ok(Self { h_context })
     }
 }
 

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -1,9 +1,18 @@
 use std::borrow::Cow;
 
+use ffi_types::winscard::ScardContext;
 use winscard::winscard::{DeviceTypeId, Icon, MemoryPtr, Protocol, ShareMode, WinScard, WinScardContext};
 use winscard::WinScardResult;
 
-pub struct SystemScardContext {}
+pub struct SystemScardContext {
+    h_context: ScardContext,
+}
+
+impl SystemScardContext {
+    pub fn new(h_context: ScardContext) -> Self {
+        Self { h_context }
+    }
+}
 
 impl WinScardContext for SystemScardContext {
     fn connect(

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -284,7 +284,7 @@ impl WinScardContext for SystemScardContext {
             let data_len: usize = if let Ok(len) = data_len.try_into() {
                 len
             } else {
-                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, *data as *const _) })?;
+                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) })?;
 
                 return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
             };
@@ -292,7 +292,7 @@ impl WinScardContext for SystemScardContext {
             let mut cache_item = vec![0; data_len];
             cache_item.copy_from_slice(unsafe { from_raw_parts(data, data_len) });
 
-            try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, *data as *const _) })?;
+            try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) })?;
 
             Ok(Cow::Owned(cache_item))
         }
@@ -537,7 +537,7 @@ impl WinScardContext for SystemScardContext {
             let data_len: usize = if let Ok(len) = data_len.try_into() {
                 len
             } else {
-                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, *data as *const _) })?;
+                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) })?;
 
                 return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
             };
@@ -554,7 +554,7 @@ impl WinScardContext for SystemScardContext {
             ) {
                 name
             } else {
-                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, *data as *const _) })?;
+                try_execute!(unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) })?;
 
                 return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
             };

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ffi_types::winscard::ScardContext;
-use winscard::winscard::{DeviceTypeId, Icon, MemoryPtr, Protocol, ShareMode, WinScard, WinScardContext};
+use winscard::winscard::{DeviceTypeId, Icon, Protocol, ShareMode, WinScard, WinScardContext};
 use winscard::{Error, ErrorKind, WinScardResult};
 
 pub struct SystemScardContext {
@@ -70,12 +70,31 @@ impl WinScardContext for SystemScardContext {
         }
     }
 
-    fn read_cache(&self, key: &str) -> Option<&[u8]> {
-        todo!()
+    fn read_cache(&self, _key: &str) -> Option<Cow<[u8]>> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            None
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
-    fn write_cache(&mut self, key: String, value: Vec<u8>) {
-        todo!()
+    fn write_cache(&mut self, _key: String, _value: Vec<u8>) -> WinScardResult<()> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardWriteCache function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // TODO(@TheBestTvarynka): implement for Windows too.
+            todo!()
+        }
     }
 
     fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -260,7 +260,7 @@ impl WinScardContext for SystemScardContext {
             let c_cache_key = CString::new(_key).expect("Rust string slice should not contain 0 bytes");
             let card_id = uuid_to_c_guid(_card_id);
 
-            let mut data: *mut *mut u8 = null_mut();
+            let mut data: *mut u8 = null_mut();
 
             // It's not specified in the `SCardReadCacheA` function documentation, but after some
             // `msclmd.dll` reversing, we found out that this function supports the `SCARD_AUTOALLOCATE`.
@@ -270,7 +270,7 @@ impl WinScardContext for SystemScardContext {
                     &card_id,
                     _freshness_counter,
                     c_cache_key.as_ptr() as *const _,
-                    ((&mut data) as *mut *mut *mut u8) as *mut _,
+                    ((&mut data) as *mut *mut u8) as *mut _,
                     &mut data_len,
                 )
             })?;
@@ -286,7 +286,7 @@ impl WinScardContext for SystemScardContext {
             };
 
             let mut cache_item = vec![0; data_len];
-            cache_item.copy_from_slice(unsafe { from_raw_parts(*data, data_len) });
+            cache_item.copy_from_slice(unsafe { from_raw_parts(data, data_len) });
 
             try_execute!(unsafe {
                 windows_sys::Win32::Security::Credentials::SCardFreeMemory(self.h_context, *data as *const _)

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -34,7 +34,7 @@ impl SystemScardContext {
         let mut h_context = 0;
 
         #[cfg(target_os = "windows")]
-        let api = super::init_scard_api_table();
+        let api = super::init_scard_api_table()?;
         #[cfg(not(target_os = "windows"))]
         let api = initialize_pcsc_lite_api()?;
 
@@ -96,10 +96,10 @@ impl WinScardContext for SystemScardContext {
             })?;
         }
 
-        let scard = Box::new(SystemScard::new(scard, self.h_context)?);
+        let handle = Box::new(SystemScard::new(scard, self.h_context)?);
 
         Ok(ScardConnectData {
-            scard,
+            handle,
             protocol: Protocol::from_bits(active_protocol).unwrap_or_default(),
         })
     }

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -3,9 +3,7 @@ macro_rules! try_execute {
         use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
-        // Note. WinSCard API functions from `windows-sys` crate return `i32` as status code.
-        // So, we cast the `i32` status code into `u32`.
-        let error_kind = ErrorKind::from_u32($x as u32).unwrap_or(ErrorKind::InternalError);
+        let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);
         if error_kind == ErrorKind::Success {
             Ok(())
         } else {

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -1,5 +1,5 @@
 macro_rules! try_execute {
-    ($x:expr) => {{
+    ($x:expr, $msg:expr) => {{
         use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
@@ -7,7 +7,10 @@ macro_rules! try_execute {
         if error_kind == ErrorKind::Success {
             Ok(())
         } else {
-            Err(Error::new(error_kind, ""))
+            Err(Error::new(error_kind, $msg))
         }
     }};
+    ($x:expr) => {
+        try_execute!($x, "")
+    };
 }

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -1,5 +1,6 @@
 macro_rules! try_execute {
     ($x:expr) => {{
+        use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
         let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -3,7 +3,9 @@ macro_rules! try_execute {
         use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
-        let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);
+        // Note. WinSCard API functions from `windows-sys` crate return `i32` as status code.
+        // So, we cast the `i32` status code into `u32`.
+        let error_kind = ErrorKind::from_u32($x as u32).unwrap_or(ErrorKind::InternalError);
         if error_kind == ErrorKind::Success {
             Ok(())
         } else {

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -1,0 +1,12 @@
+macro_rules! try_execute {
+    ($x:expr) => {{
+        use winscard::{Error, ErrorKind};
+
+        let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);
+        if error_kind == ErrorKind::Success {
+            Ok(())
+        } else {
+            Err(Error::new(error_kind, ""))
+        }
+    }};
+}

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -7,9 +7,12 @@ mod card;
 mod context;
 
 use std::borrow::Cow;
+use num_traits::Zero;
+use windows_sys::s;
 
 pub use card::SystemScard;
 pub use context::SystemScardContext;
+use ffi_types::winscard::functions::SCardApiFunctionTable;
 use winscard::WinScardResult;
 
 fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
@@ -30,11 +33,124 @@ fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>
 }
 
 #[cfg(target_os = "windows")]
-fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> windows_sys::core::GUID {
-    windows_sys::core::GUID {
+fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> ffi_types::Uuid {
+    // windows_sys::core::GUID {
+    //     data1: id.data1,
+    //     data2: id.data2,
+    //     data3: id.data3,
+    //     data4: id.data4,
+    // }
+    ffi_types::Uuid {
         data1: id.data1,
         data2: id.data2,
         data3: id.data3,
         data4: id.data4,
     }
+}
+
+pub fn init_scard_api_table() -> SCardApiFunctionTable {
+    use std::mem::transmute;
+
+    use windows_sys::Win32::System::LibraryLoader::GetProcAddress;
+    use windows_sys::Win32::System::LibraryLoader::LoadLibraryA;
+
+    let winscard_module = unsafe {
+        LoadLibraryA(s!("C:\\Windows\\System32\\WinSCard.dll"))
+    };
+
+    if winscard_module.is_zero() {
+        error!("Can not load the original winscard module.");
+    }
+
+    // let f1: SCardEstablishContextFn = unsafe {
+    //     transmute(GetProcAddress(winscard_module, s!("SCardEstablishContext")))
+    // };
+
+    macro_rules! load_fn {
+        ($module:expr, $func_name:literal) => {{
+            unsafe {
+                transmute(GetProcAddress($module, s!($func_name)))
+            }
+        }};
+    }
+
+    let api_table = SCardApiFunctionTable {
+        dw_version: 0,
+        dw_flags: 0,
+        SCardEstablishContext: load_fn!(winscard_module, "SCardEstablishContext"),
+        SCardReleaseContext: load_fn!(winscard_module, "SCardReleaseContext"),
+        SCardIsValidContext: load_fn!(winscard_module, "SCardIsValidContext"),
+        SCardListReaderGroupsA: load_fn!(winscard_module, "SCardListReaderGroupsA"),
+        SCardListReaderGroupsW: load_fn!(winscard_module, "SCardListReaderGroupsW"),
+        SCardListReadersA: load_fn!(winscard_module, "SCardListReadersA"),
+        SCardListReadersW: load_fn!(winscard_module, "SCardListReadersW"),
+        SCardListCardsA: load_fn!(winscard_module, "SCardListCardsA"),
+        SCardListCardsW: load_fn!(winscard_module, "SCardListCardsW"),
+        SCardListInterfacesA: load_fn!(winscard_module, "SCardListInterfacesA"),
+        SCardListInterfacesW: load_fn!(winscard_module, "SCardListInterfacesW"),
+        SCardGetProviderIdA: load_fn!(winscard_module, "SCardGetProviderIdA"),
+        SCardGetProviderIdW: load_fn!(winscard_module, "SCardGetProviderIdW"),
+        SCardGetCardTypeProviderNameA: load_fn!(winscard_module, "SCardGetCardTypeProviderNameA"),
+        SCardGetCardTypeProviderNameW: load_fn!(winscard_module, "SCardGetCardTypeProviderNameW"),
+        SCardIntroduceReaderGroupA: load_fn!(winscard_module, "SCardIntroduceReaderGroupA"),
+        SCardIntroduceReaderGroupW: load_fn!(winscard_module, "SCardIntroduceReaderGroupW"),
+        SCardForgetReaderGroupA: load_fn!(winscard_module, "SCardForgetReaderGroupA"),
+        SCardForgetReaderGroupW: load_fn!(winscard_module, "SCardForgetReaderGroupW"),
+        SCardIntroduceReaderA: load_fn!(winscard_module, "SCardIntroduceReaderA"),
+        SCardIntroduceReaderW: load_fn!(winscard_module, "SCardIntroduceReaderW"),
+        SCardForgetReaderA: load_fn!(winscard_module, "SCardForgetReaderA"),
+        SCardForgetReaderW: load_fn!(winscard_module, "SCardForgetReaderW"),
+        SCardAddReaderToGroupA: load_fn!(winscard_module, "SCardAddReaderToGroupA"),
+        SCardAddReaderToGroupW: load_fn!(winscard_module, "SCardAddReaderToGroupW"),
+        SCardRemoveReaderFromGroupA: load_fn!(winscard_module, "SCardRemoveReaderFromGroupA"),
+        SCardRemoveReaderFromGroupW: load_fn!(winscard_module, "SCardRemoveReaderFromGroupW"),
+        SCardIntroduceCardTypeA: load_fn!(winscard_module, "SCardIntroduceCardTypeA"),
+        SCardIntroduceCardTypeW: load_fn!(winscard_module, "SCardIntroduceCardTypeW"),
+        SCardSetCardTypeProviderNameA: load_fn!(winscard_module, "SCardSetCardTypeProviderNameA"),
+        SCardSetCardTypeProviderNameW: load_fn!(winscard_module, "SCardSetCardTypeProviderNameW"),
+        SCardFreeMemory: load_fn!(winscard_module, "SCardFreeMemory"),
+        SCardAccessStartedEvent: load_fn!(winscard_module, "SCardAccessStartedEvent"),
+        SCardReleaseStartedEvent: load_fn!(winscard_module, "SCardReleaseStartedEvent"),
+        SCardLocateCardsA: load_fn!(winscard_module, "SCardLocateCardsA"),
+        SCardLocateCardsW: load_fn!(winscard_module, "SCardLocateCardsW"),
+        SCardLocateCardsByATRA: load_fn!(winscard_module, "SCardLocateCardsByATRA"),
+        SCardLocateCardsByATRW: load_fn!(winscard_module, "SCardLocateCardsByATRW"),
+        SCardGetStatusChangeA: load_fn!(winscard_module, "SCardGetStatusChangeA"),
+        SCardGetStatusChangeW: load_fn!(winscard_module, "SCardGetStatusChangeW"),
+        SCardCancel: load_fn!(winscard_module, "SCardCancel"),
+        SCardConnectA: load_fn!(winscard_module, "SCardConnectA"),
+        SCardConnectW: load_fn!(winscard_module, "SCardConnectW"),
+        SCardReconnect: load_fn!(winscard_module, "SCardReconnect"),
+        SCardDisconnect: load_fn!(winscard_module, "SCardDisconnect"),
+        SCardBeginTransaction: load_fn!(winscard_module, "SCardBeginTransaction"),
+        SCardEndTransaction: load_fn!(winscard_module, "SCardEndTransaction"),
+        SCardCancelTransaction: load_fn!(winscard_module, "SCardCancelTransaction"),
+        SCardState: load_fn!(winscard_module, "SCardState"),
+        SCardStatusA: load_fn!(winscard_module, "SCardStatusA"),
+        SCardStatusW: load_fn!(winscard_module, "SCardStatusW"),
+        SCardTransmit: load_fn!(winscard_module, "SCardTransmit"),
+        SCardGetTransmitCount: load_fn!(winscard_module, "SCardGetTransmitCount"),
+        SCardControl: load_fn!(winscard_module, "SCardControl"),
+        SCardGetAttrib: load_fn!(winscard_module, "SCardGetAttrib"),
+        SCardSetAttrib: load_fn!(winscard_module, "SCardSetAttrib"),
+        SCardUIDlgSelectCardA: load_fn!(winscard_module, "SCardUIDlgSelectCardA"),
+        SCardUIDlgSelectCardW: load_fn!(winscard_module, "SCardUIDlgSelectCardW"),
+        GetOpenCardNameA: load_fn!(winscard_module, "GetOpenCardNameA"),
+        GetOpenCardNameW: load_fn!(winscard_module, "GetOpenCardNameW"),
+        SCardReadCacheA: load_fn!(winscard_module, "SCardReadCacheA"),
+        SCardReadCacheW: load_fn!(winscard_module, "SCardReadCacheW"),
+        SCardWriteCacheA: load_fn!(winscard_module, "SCardWriteCacheA"),
+        SCardWriteCacheW: load_fn!(winscard_module, "SCardWriteCacheW"),
+        SCardGetReaderIconA: load_fn!(winscard_module, "SCardGetReaderIconA"),
+        SCardGetReaderIconW: load_fn!(winscard_module, "SCardGetReaderIconW"),
+        SCardGetDeviceTypeIdA: load_fn!(winscard_module, "SCardGetDeviceTypeIdA"),
+        SCardGetDeviceTypeIdW: load_fn!(winscard_module, "SCardGetDeviceTypeIdW"),
+        SCardGetReaderDeviceInstanceIdA: load_fn!(winscard_module, "SCardGetReaderDeviceInstanceIdA"),
+        SCardGetReaderDeviceInstanceIdW: load_fn!(winscard_module, "SCardGetReaderDeviceInstanceIdW"),
+        SCardListReadersWithDeviceInstanceIdA: load_fn!(winscard_module, "SCardListReadersWithDeviceInstanceIdA"),
+        SCardListReadersWithDeviceInstanceIdW: load_fn!(winscard_module, "SCardListReadersWithDeviceInstanceIdW"),
+        SCardAudit: load_fn!(winscard_module, "SCardAudit"),
+    };
+    debug!(?api_table);
+    api_table
 }

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -15,7 +15,7 @@ use winscard::WinScardResult;
 fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
     let res: Result<Vec<&str>, _> = buf
         .split(|&c| c == 0)
-        .filter(|v| v.is_empty())
+        .filter(|v| !v.is_empty())
         .map(|v| std::str::from_utf8(v))
         .collect();
 
@@ -24,8 +24,8 @@ fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
 
 fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>> {
     Ok(parse_multi_string(buf)?
-        .iter()
-        .map(|&r| Cow::Owned(r.to_owned()))
+        .into_iter()
+        .map(|r| Cow::Owned(r.to_owned()))
         .collect())
 }
 

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -55,11 +55,13 @@ pub fn init_scard_api_table() -> SCardApiFunctionTable {
     use windows_sys::Win32::System::LibraryLoader::LoadLibraryA;
 
     let winscard_module = unsafe {
-        LoadLibraryA(s!("C:\\Windows\\System32\\WinSCard.dll"))
+        LoadLibraryA(s!("C:\\Windows\\System32\\WinSCardOriginal.dll"))
     };
 
     if winscard_module.is_zero() {
         error!("Can not load the original winscard module.");
+    } else {
+        info!("Original winscard.dll has been loaded!");
     }
 
     // let f1: SCardEstablishContextFn = unsafe {

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -10,14 +10,13 @@ use std::borrow::Cow;
 
 pub use card::SystemScard;
 pub use context::SystemScardContext;
-use num_traits::Zero;
 use winscard::WinScardResult;
 
 fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
     let res: Result<Vec<&str>, _> = buf
         .split(|&c| c == 0)
         .filter(|v| !v.is_empty())
-        .map(|v| std::str::from_utf8(v))
+        .map(std::str::from_utf8)
         .collect();
 
     Ok(res?)
@@ -55,10 +54,6 @@ pub fn init_scard_api_table() -> SCardApiFunctionTable {
     } else {
         info!("Original winscard.dll has been loaded!");
     }
-
-    // let f1: SCardEstablishContextFn = unsafe {
-    //     transmute(GetProcAddress(winscard_module, s!("SCardEstablishContext")))
-    // };
 
     macro_rules! load_fn {
         ($module:expr, $func_name:literal) => {{
@@ -143,6 +138,6 @@ pub fn init_scard_api_table() -> SCardApiFunctionTable {
         SCardListReadersWithDeviceInstanceIdW: load_fn!(winscard_module, "SCardListReadersWithDeviceInstanceIdW"),
         SCardAudit: load_fn!(winscard_module, "SCardAudit"),
     };
-    debug!(?api_table);
+
     api_table
 }

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "scard")]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 mod macros;

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -10,9 +10,7 @@ use std::borrow::Cow;
 
 pub use card::SystemScard;
 pub use context::SystemScardContext;
-use ffi_types::winscard::functions::SCardApiFunctionTable;
 use num_traits::Zero;
-use windows_sys::s;
 use winscard::WinScardResult;
 
 fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
@@ -34,12 +32,6 @@ fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>
 
 #[cfg(target_os = "windows")]
 fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> ffi_types::Uuid {
-    // windows_sys::core::GUID {
-    //     data1: id.data1,
-    //     data2: id.data2,
-    //     data3: id.data3,
-    //     data4: id.data4,
-    // }
     ffi_types::Uuid {
         data1: id.data1,
         data2: id.data2,
@@ -48,9 +40,12 @@ fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> ffi_types::Uuid {
     }
 }
 
+#[cfg(target_os = "windows")]
 pub fn init_scard_api_table() -> SCardApiFunctionTable {
     use std::mem::transmute;
 
+    use ffi_types::winscard::functions::SCardApiFunctionTable;
+    use windows_sys::s;
     use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
     let winscard_module = unsafe { LoadLibraryA(s!("C:\\Windows\\System32\\WinSCardOriginal.dll")) };

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -7,12 +7,12 @@ mod card;
 mod context;
 
 use std::borrow::Cow;
-use num_traits::Zero;
-use windows_sys::s;
 
 pub use card::SystemScard;
 pub use context::SystemScardContext;
 use ffi_types::winscard::functions::SCardApiFunctionTable;
+use num_traits::Zero;
+use windows_sys::s;
 use winscard::WinScardResult;
 
 fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
@@ -51,12 +51,9 @@ fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> ffi_types::Uuid {
 pub fn init_scard_api_table() -> SCardApiFunctionTable {
     use std::mem::transmute;
 
-    use windows_sys::Win32::System::LibraryLoader::GetProcAddress;
-    use windows_sys::Win32::System::LibraryLoader::LoadLibraryA;
+    use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
-    let winscard_module = unsafe {
-        LoadLibraryA(s!("C:\\Windows\\System32\\WinSCardOriginal.dll"))
-    };
+    let winscard_module = unsafe { LoadLibraryA(s!("C:\\Windows\\System32\\WinSCardOriginal.dll")) };
 
     if winscard_module.is_zero() {
         error!("Can not load the original winscard module.");
@@ -70,9 +67,7 @@ pub fn init_scard_api_table() -> SCardApiFunctionTable {
 
     macro_rules! load_fn {
         ($module:expr, $func_name:literal) => {{
-            unsafe {
-                transmute(GetProcAddress($module, s!($func_name)))
-            }
+            unsafe { transmute(GetProcAddress($module, s!($func_name))) }
         }};
     }
 

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -44,101 +44,115 @@ fn uuid_to_c_guid(id: uuid::Uuid) -> ffi_types::Uuid {
 }
 
 #[cfg(target_os = "windows")]
-pub fn init_scard_api_table() -> SCardApiFunctionTable {
+pub fn init_scard_api_table() -> WinScardResult<SCardApiFunctionTable> {
+    use std::env;
+    use std::ffi::CString;
     use std::mem::transmute;
 
     use windows_sys::s;
     use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
-    let winscard_module = unsafe { LoadLibraryA(s!("C:\\Windows\\System32\\WinSCardOriginal.dll")) };
+    /// Path to the `winscard` module.
+    ///
+    /// The user can use this environment variable to customize the `winscard` library loading.
+    const WINSCARD_LIB_PATH_ENV: &str = "WINSCARD_LIB_PATH";
+
+    let file_name = CString::new(if let Ok(lib_path) = env::var(WINSCARD_LIB_PATH_ENV) {
+        lib_path.into_bytes()
+    } else {
+        "WinSCard.dll".as_bytes().to_vec()
+    })
+    .expect("Rust string should not contain zero bytes");
+
+    let winscard_module = unsafe { LoadLibraryA(file_name.as_ptr() as *const _) };
 
     if winscard_module == 0 {
-        error!("Can not load the original winscard module.");
+        error!("Can not load the winscard module.");
     } else {
-        info!("Original winscard.dll has been loaded!");
+        info!("The winscard module has been loaded!");
     }
 
     macro_rules! load_fn {
-        ($module:expr, $func_name:literal) => {{
-            unsafe { transmute(GetProcAddress($module, s!($func_name))) }
+        ($func_name:literal) => {{
+            unsafe { transmute(GetProcAddress(winscard_module, s!($func_name))) }
         }};
     }
 
-    SCardApiFunctionTable {
+    Ok(SCardApiFunctionTable {
         dw_version: 0,
         dw_flags: 0,
-        SCardEstablishContext: load_fn!(winscard_module, "SCardEstablishContext"),
-        SCardReleaseContext: load_fn!(winscard_module, "SCardReleaseContext"),
-        SCardIsValidContext: load_fn!(winscard_module, "SCardIsValidContext"),
-        SCardListReaderGroupsA: load_fn!(winscard_module, "SCardListReaderGroupsA"),
-        SCardListReaderGroupsW: load_fn!(winscard_module, "SCardListReaderGroupsW"),
-        SCardListReadersA: load_fn!(winscard_module, "SCardListReadersA"),
-        SCardListReadersW: load_fn!(winscard_module, "SCardListReadersW"),
-        SCardListCardsA: load_fn!(winscard_module, "SCardListCardsA"),
-        SCardListCardsW: load_fn!(winscard_module, "SCardListCardsW"),
-        SCardListInterfacesA: load_fn!(winscard_module, "SCardListInterfacesA"),
-        SCardListInterfacesW: load_fn!(winscard_module, "SCardListInterfacesW"),
-        SCardGetProviderIdA: load_fn!(winscard_module, "SCardGetProviderIdA"),
-        SCardGetProviderIdW: load_fn!(winscard_module, "SCardGetProviderIdW"),
-        SCardGetCardTypeProviderNameA: load_fn!(winscard_module, "SCardGetCardTypeProviderNameA"),
-        SCardGetCardTypeProviderNameW: load_fn!(winscard_module, "SCardGetCardTypeProviderNameW"),
-        SCardIntroduceReaderGroupA: load_fn!(winscard_module, "SCardIntroduceReaderGroupA"),
-        SCardIntroduceReaderGroupW: load_fn!(winscard_module, "SCardIntroduceReaderGroupW"),
-        SCardForgetReaderGroupA: load_fn!(winscard_module, "SCardForgetReaderGroupA"),
-        SCardForgetReaderGroupW: load_fn!(winscard_module, "SCardForgetReaderGroupW"),
-        SCardIntroduceReaderA: load_fn!(winscard_module, "SCardIntroduceReaderA"),
-        SCardIntroduceReaderW: load_fn!(winscard_module, "SCardIntroduceReaderW"),
-        SCardForgetReaderA: load_fn!(winscard_module, "SCardForgetReaderA"),
-        SCardForgetReaderW: load_fn!(winscard_module, "SCardForgetReaderW"),
-        SCardAddReaderToGroupA: load_fn!(winscard_module, "SCardAddReaderToGroupA"),
-        SCardAddReaderToGroupW: load_fn!(winscard_module, "SCardAddReaderToGroupW"),
-        SCardRemoveReaderFromGroupA: load_fn!(winscard_module, "SCardRemoveReaderFromGroupA"),
-        SCardRemoveReaderFromGroupW: load_fn!(winscard_module, "SCardRemoveReaderFromGroupW"),
-        SCardIntroduceCardTypeA: load_fn!(winscard_module, "SCardIntroduceCardTypeA"),
-        SCardIntroduceCardTypeW: load_fn!(winscard_module, "SCardIntroduceCardTypeW"),
-        SCardSetCardTypeProviderNameA: load_fn!(winscard_module, "SCardSetCardTypeProviderNameA"),
-        SCardSetCardTypeProviderNameW: load_fn!(winscard_module, "SCardSetCardTypeProviderNameW"),
-        SCardFreeMemory: load_fn!(winscard_module, "SCardFreeMemory"),
-        SCardAccessStartedEvent: load_fn!(winscard_module, "SCardAccessStartedEvent"),
-        SCardReleaseStartedEvent: load_fn!(winscard_module, "SCardReleaseStartedEvent"),
-        SCardLocateCardsA: load_fn!(winscard_module, "SCardLocateCardsA"),
-        SCardLocateCardsW: load_fn!(winscard_module, "SCardLocateCardsW"),
-        SCardLocateCardsByATRA: load_fn!(winscard_module, "SCardLocateCardsByATRA"),
-        SCardLocateCardsByATRW: load_fn!(winscard_module, "SCardLocateCardsByATRW"),
-        SCardGetStatusChangeA: load_fn!(winscard_module, "SCardGetStatusChangeA"),
-        SCardGetStatusChangeW: load_fn!(winscard_module, "SCardGetStatusChangeW"),
-        SCardCancel: load_fn!(winscard_module, "SCardCancel"),
-        SCardConnectA: load_fn!(winscard_module, "SCardConnectA"),
-        SCardConnectW: load_fn!(winscard_module, "SCardConnectW"),
-        SCardReconnect: load_fn!(winscard_module, "SCardReconnect"),
-        SCardDisconnect: load_fn!(winscard_module, "SCardDisconnect"),
-        SCardBeginTransaction: load_fn!(winscard_module, "SCardBeginTransaction"),
-        SCardEndTransaction: load_fn!(winscard_module, "SCardEndTransaction"),
-        SCardCancelTransaction: load_fn!(winscard_module, "SCardCancelTransaction"),
-        SCardState: load_fn!(winscard_module, "SCardState"),
-        SCardStatusA: load_fn!(winscard_module, "SCardStatusA"),
-        SCardStatusW: load_fn!(winscard_module, "SCardStatusW"),
-        SCardTransmit: load_fn!(winscard_module, "SCardTransmit"),
-        SCardGetTransmitCount: load_fn!(winscard_module, "SCardGetTransmitCount"),
-        SCardControl: load_fn!(winscard_module, "SCardControl"),
-        SCardGetAttrib: load_fn!(winscard_module, "SCardGetAttrib"),
-        SCardSetAttrib: load_fn!(winscard_module, "SCardSetAttrib"),
-        SCardUIDlgSelectCardA: load_fn!(winscard_module, "SCardUIDlgSelectCardA"),
-        SCardUIDlgSelectCardW: load_fn!(winscard_module, "SCardUIDlgSelectCardW"),
-        GetOpenCardNameA: load_fn!(winscard_module, "GetOpenCardNameA"),
-        GetOpenCardNameW: load_fn!(winscard_module, "GetOpenCardNameW"),
-        SCardReadCacheA: load_fn!(winscard_module, "SCardReadCacheA"),
-        SCardReadCacheW: load_fn!(winscard_module, "SCardReadCacheW"),
-        SCardWriteCacheA: load_fn!(winscard_module, "SCardWriteCacheA"),
-        SCardWriteCacheW: load_fn!(winscard_module, "SCardWriteCacheW"),
-        SCardGetReaderIconA: load_fn!(winscard_module, "SCardGetReaderIconA"),
-        SCardGetReaderIconW: load_fn!(winscard_module, "SCardGetReaderIconW"),
-        SCardGetDeviceTypeIdA: load_fn!(winscard_module, "SCardGetDeviceTypeIdA"),
-        SCardGetDeviceTypeIdW: load_fn!(winscard_module, "SCardGetDeviceTypeIdW"),
-        SCardGetReaderDeviceInstanceIdA: load_fn!(winscard_module, "SCardGetReaderDeviceInstanceIdA"),
-        SCardGetReaderDeviceInstanceIdW: load_fn!(winscard_module, "SCardGetReaderDeviceInstanceIdW"),
-        SCardListReadersWithDeviceInstanceIdA: load_fn!(winscard_module, "SCardListReadersWithDeviceInstanceIdA"),
-        SCardListReadersWithDeviceInstanceIdW: load_fn!(winscard_module, "SCardListReadersWithDeviceInstanceIdW"),
-        SCardAudit: load_fn!(winscard_module, "SCardAudit"),
-    }
+        SCardEstablishContext: load_fn!("SCardEstablishContext"),
+        SCardReleaseContext: load_fn!("SCardReleaseContext"),
+        SCardIsValidContext: load_fn!("SCardIsValidContext"),
+        SCardListReaderGroupsA: load_fn!("SCardListReaderGroupsA"),
+        SCardListReaderGroupsW: load_fn!("SCardListReaderGroupsW"),
+        SCardListReadersA: load_fn!("SCardListReadersA"),
+        SCardListReadersW: load_fn!("SCardListReadersW"),
+        SCardListCardsA: load_fn!("SCardListCardsA"),
+        SCardListCardsW: load_fn!("SCardListCardsW"),
+        SCardListInterfacesA: load_fn!("SCardListInterfacesA"),
+        SCardListInterfacesW: load_fn!("SCardListInterfacesW"),
+        SCardGetProviderIdA: load_fn!("SCardGetProviderIdA"),
+        SCardGetProviderIdW: load_fn!("SCardGetProviderIdW"),
+        SCardGetCardTypeProviderNameA: load_fn!("SCardGetCardTypeProviderNameA"),
+        SCardGetCardTypeProviderNameW: load_fn!("SCardGetCardTypeProviderNameW"),
+        SCardIntroduceReaderGroupA: load_fn!("SCardIntroduceReaderGroupA"),
+        SCardIntroduceReaderGroupW: load_fn!("SCardIntroduceReaderGroupW"),
+        SCardForgetReaderGroupA: load_fn!("SCardForgetReaderGroupA"),
+        SCardForgetReaderGroupW: load_fn!("SCardForgetReaderGroupW"),
+        SCardIntroduceReaderA: load_fn!("SCardIntroduceReaderA"),
+        SCardIntroduceReaderW: load_fn!("SCardIntroduceReaderW"),
+        SCardForgetReaderA: load_fn!("SCardForgetReaderA"),
+        SCardForgetReaderW: load_fn!("SCardForgetReaderW"),
+        SCardAddReaderToGroupA: load_fn!("SCardAddReaderToGroupA"),
+        SCardAddReaderToGroupW: load_fn!("SCardAddReaderToGroupW"),
+        SCardRemoveReaderFromGroupA: load_fn!("SCardRemoveReaderFromGroupA"),
+        SCardRemoveReaderFromGroupW: load_fn!("SCardRemoveReaderFromGroupW"),
+        SCardIntroduceCardTypeA: load_fn!("SCardIntroduceCardTypeA"),
+        SCardIntroduceCardTypeW: load_fn!("SCardIntroduceCardTypeW"),
+        SCardSetCardTypeProviderNameA: load_fn!("SCardSetCardTypeProviderNameA"),
+        SCardSetCardTypeProviderNameW: load_fn!("SCardSetCardTypeProviderNameW"),
+        SCardFreeMemory: load_fn!("SCardFreeMemory"),
+        SCardAccessStartedEvent: load_fn!("SCardAccessStartedEvent"),
+        SCardReleaseStartedEvent: load_fn!("SCardReleaseStartedEvent"),
+        SCardLocateCardsA: load_fn!("SCardLocateCardsA"),
+        SCardLocateCardsW: load_fn!("SCardLocateCardsW"),
+        SCardLocateCardsByATRA: load_fn!("SCardLocateCardsByATRA"),
+        SCardLocateCardsByATRW: load_fn!("SCardLocateCardsByATRW"),
+        SCardGetStatusChangeA: load_fn!("SCardGetStatusChangeA"),
+        SCardGetStatusChangeW: load_fn!("SCardGetStatusChangeW"),
+        SCardCancel: load_fn!("SCardCancel"),
+        SCardConnectA: load_fn!("SCardConnectA"),
+        SCardConnectW: load_fn!("SCardConnectW"),
+        SCardReconnect: load_fn!("SCardReconnect"),
+        SCardDisconnect: load_fn!("SCardDisconnect"),
+        SCardBeginTransaction: load_fn!("SCardBeginTransaction"),
+        SCardEndTransaction: load_fn!("SCardEndTransaction"),
+        SCardCancelTransaction: load_fn!("SCardCancelTransaction"),
+        SCardState: load_fn!("SCardState"),
+        SCardStatusA: load_fn!("SCardStatusA"),
+        SCardStatusW: load_fn!("SCardStatusW"),
+        SCardTransmit: load_fn!("SCardTransmit"),
+        SCardGetTransmitCount: load_fn!("SCardGetTransmitCount"),
+        SCardControl: load_fn!("SCardControl"),
+        SCardGetAttrib: load_fn!("SCardGetAttrib"),
+        SCardSetAttrib: load_fn!("SCardSetAttrib"),
+        SCardUIDlgSelectCardA: load_fn!("SCardUIDlgSelectCardA"),
+        SCardUIDlgSelectCardW: load_fn!("SCardUIDlgSelectCardW"),
+        GetOpenCardNameA: load_fn!("GetOpenCardNameA"),
+        GetOpenCardNameW: load_fn!("GetOpenCardNameW"),
+        SCardReadCacheA: load_fn!("SCardReadCacheA"),
+        SCardReadCacheW: load_fn!("SCardReadCacheW"),
+        SCardWriteCacheA: load_fn!("SCardWriteCacheA"),
+        SCardWriteCacheW: load_fn!("SCardWriteCacheW"),
+        SCardGetReaderIconA: load_fn!("SCardGetReaderIconA"),
+        SCardGetReaderIconW: load_fn!("SCardGetReaderIconW"),
+        SCardGetDeviceTypeIdA: load_fn!("SCardGetDeviceTypeIdA"),
+        SCardGetDeviceTypeIdW: load_fn!("SCardGetDeviceTypeIdW"),
+        SCardGetReaderDeviceInstanceIdA: load_fn!("SCardGetReaderDeviceInstanceIdA"),
+        SCardGetReaderDeviceInstanceIdW: load_fn!("SCardGetReaderDeviceInstanceIdW"),
+        SCardListReadersWithDeviceInstanceIdA: load_fn!("SCardListReadersWithDeviceInstanceIdA"),
+        SCardListReadersWithDeviceInstanceIdW: load_fn!("SCardListReadersWithDeviceInstanceIdW"),
+        SCardAudit: load_fn!("SCardAudit"),
+    })
 }

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -6,5 +6,25 @@ mod macros;
 mod card;
 mod context;
 
+use std::borrow::Cow;
+
 pub use card::SystemScard;
 pub use context::SystemScardContext;
+use winscard::WinScardResult;
+
+fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
+    let res: Result<Vec<&str>, _> = buf
+        .split(|&c| c == 0)
+        .filter(|v| v.is_empty())
+        .map(|v| std::str::from_utf8(v))
+        .collect();
+
+    Ok(res?)
+}
+
+fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>> {
+    Ok(parse_multi_string(buf)?
+        .iter()
+        .map(|&r| Cow::Owned(r.to_owned()))
+        .collect())
+}

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,0 +1,5 @@
+mod card;
+mod context;
+
+pub use card::SystemScard;
+pub use context::SystemScardContext;

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -63,8 +63,7 @@ pub fn init_scard_api_table() -> WinScardResult<SCardApiFunctionTable> {
         lib_path.into_bytes()
     } else {
         "WinSCard.dll".as_bytes().to_vec()
-    })
-    .expect("Rust string should not contain zero bytes");
+    })?;
 
     // SAFETY: This function is safe to call because the `file_name.as_ptr()` is guaranteed to be
     // the null-terminated C string by `CString` type.

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -73,10 +73,10 @@ pub fn init_scard_api_table() -> WinScardResult<SCardApiFunctionTable> {
     if winscard_module == 0 {
         return Err(Error::new(
             ErrorKind::InternalError,
-            "Can not load the winscard module: LoadLibrary function has returned NULL",
+            "can not load the winscard module: LoadLibrary function has returned NULL",
         ));
     } else {
-        info!("The winscard module has been loaded!");
+        info!("The winscard module has been loaded");
     }
 
     macro_rules! load_fn {

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,3 +1,8 @@
+#![cfg(feature = "scard")]
+
+#[macro_use]
+mod macros;
+
 mod card;
 mod context;
 

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -28,3 +28,13 @@ fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>
         .map(|&r| Cow::Owned(r.to_owned()))
         .collect())
 }
+
+#[cfg(target_os = "windows")]
+fn uuid_to_c_guid(id: winscard::winscard::Uuid) -> windows_sys::core::GUID {
+    windows_sys::core::GUID {
+        data1: id.data1,
+        data2: id.data2,
+        data3: id.data3,
+        data4: id.data4,
+    }
+}


### PR DESCRIPTION
Hi,
In this pull request, I've implemented the system-provided smart card support. Now we can call system API to access system-provided smart cards.
I've also implemented dynamic `winscard.dll` loading. We can't always use the `winscard-sys` crate, because if the `winscard.dll` is hooked (in the case of [MsRdpEx](https://github.com/Devolutions/MsRdpEx)), then the `winscard-sys` will just redirect calls to our library and we'll get a stack overflow.