### PR TITLE
Winscard FFI improvements

### DIFF
--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -38,7 +38,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use picky::key::KeyError;
 use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
-pub use scard_context::{Reader, ScardContext, SmartCardInfo};
+pub use scard_context::{Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
 /// The [WinScardResult] type.
 pub type WinScardResult<T> = result::Result<T, Error>;

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -20,10 +20,10 @@ use crate::{Error, ErrorKind, WinScardResult};
 // set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
 const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
 
-// Default name of the emulated smart card.
-const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
-
-const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
+/// Default name of the emulated smart card.
+pub const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
+/// Default CSP name.
+pub const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
 const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
 const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "msclmd.dll";
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -10,4 +10,5 @@ pub mod sspi;
 mod utils;
 #[cfg(feature = "scard")]
 #[deny(unsafe_op_in_unsafe_fn)]
+#[warn(clippy::undocumented_unsafe_blocks)]
 pub mod winscard;

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -358,11 +358,10 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 fn collect_smart_card_creds(username: &[u8], password: &[u8]) -> Result<SmartCardIdentityBuffers> {
     if username.contains(&b'@') {
         info!("Trying to collect smart card creds...");
-        use winscard::SmartCardInfo;
+        use winscard::{SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
         use crate::sspi::utils::raw_wide_str_trim_nulls;
         use crate::utils::str_encode_utf16;
-        use crate::winscard::scard_context::{DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
         match SmartCardInfo::try_from_env() {
             Ok(smart_card_info) => {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -17,17 +17,14 @@ pub unsafe fn c_w_str_to_string(s: *const u16) -> String {
 }
 
 pub unsafe fn raw_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
-    unsafe { from_raw_parts(raw_buffer, len) }
-        .iter()
-        .map(|c| *c as u8)
-        .collect()
+    unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
 }
 
 pub fn str_to_w_buff(data: &str) -> Vec<u16> {
     data.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
-#[cfg(all(feature = "scard", target_os = "windows"))]
+#[cfg(any(feature = "scard", feature = "tsssp"))]
 pub fn str_encode_utf16(data: &str) -> Vec<u8> {
     data.encode_utf16().flat_map(|c| c.to_le_bytes()).collect()
 }

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -9,7 +9,7 @@ pub const SCARD_AUTOALLOCATE: u32 = 0xffffffff;
 
 /// This function decides how to treat the provided buffer by the user and how to return the requested data.
 ///
-/// When the user requests some data from the smart card using the WinSCard API, we have three causes
+/// When the user requests some data from the smart card using the WinSCard API, we have three ways
 /// how to handle it:
 /// * write data in the provided buffer.
 /// * write data length of the requested data in the provided length pointer.
@@ -19,7 +19,7 @@ pub unsafe fn build_buf_request_type<'data>(
     pcb_buf: LpDword,
 ) -> WinScardResult<RequestedBufferType<'data>> {
     if pcb_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
 
     Ok(if p_buf.is_null() {
@@ -27,7 +27,7 @@ pub unsafe fn build_buf_request_type<'data>(
         // would have been returned if this parameter had not been NULL, and returns a success code.
         RequestedBufferType::Length
     } else if
-    // SAFETY: The `pcb_buf` parameter cannot be a null. We've checked for it above.
+    // SAFETY: The `pcb_buf` parameter cannot be null. We've checked for it above.
     unsafe { *pcb_buf } == SCARD_AUTOALLOCATE {
         // If the buffer length is specified as SCARD_AUTOALLOCATE, then data pointer is
         // converted to a pointer to a byte pointer, and receives the address of a block of memory
@@ -46,7 +46,7 @@ pub unsafe fn build_buf_request_type_wide<'data>(
     pcb_buf: LpDword,
 ) -> WinScardResult<RequestedBufferType<'data>> {
     if pcb_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
 
     Ok(if p_buf.is_null() {
@@ -55,7 +55,7 @@ pub unsafe fn build_buf_request_type_wide<'data>(
         // to pcbAttrLen, and returns a success code.
         RequestedBufferType::Length
     } else if
-    // SAFETY: The `pcb_buf` parameter cannot be a null. We've checked for it above.
+    // SAFETY: The `pcb_buf` parameter cannot be null. We've checked for it above.
     unsafe { *pcb_buf } == SCARD_AUTOALLOCATE {
         // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib
         //
@@ -71,11 +71,11 @@ pub unsafe fn build_buf_request_type_wide<'data>(
 /// Saves the resulting data after the [RequestedBufferType] processing.
 pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
     if p_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
     }
 
     if pcb_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
 
     match out_buf {
@@ -104,11 +104,11 @@ pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) 
 /// to the `u16` buffer instead of `u8`. So, the buffer length is divided by two.
 pub unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
     if p_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
     }
 
     if pcb_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be a null"));
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
 
     match out_buf {

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -7,27 +7,33 @@ use super::scard_handle::{OutBuffer, RequestedBufferType};
 
 pub const SCARD_AUTOALLOCATE: u32 = 0xffffffff;
 
-// TODO: write proper comments.
+/// This function decides how to treat the provided buffer by the user and how to return the requested data.
+///
+/// When the user requests some data from the smart card using the WinSCard API, we have three causes
+/// how to handle it:
+/// * write data in the provided buffer.
+/// * write data length of the requested data in the provided length pointer.
+/// * allocate data by ourselves and write data pointer in the provided buffer.
 pub unsafe fn build_buf_request_type<'data>(
     p_buf: LpByte,
     pcb_buf: LpDword,
 ) -> WinScardResult<RequestedBufferType<'data>> {
     Ok(if p_buf.is_null() {
-        // If this value is NULL, SCardGetAttrib ignores the buffer length supplied in pcbAttrLen,
-        // writes the length of the buffer that would have been returned if this parameter had not been NULL
-        // to pcbAttrLen, and returns a success code.
+        // If this value is NULL, we ignore the buffer length, writes the length of the buffer that
+        // would have been returned if this parameter had not been NULL, and returns a success code.
         RequestedBufferType::Length
     } else if unsafe { *pcb_buf } == SCARD_AUTOALLOCATE {
-        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib
-        //
-        // If the buffer length is specified as SCARD_AUTOALLOCATE, then pbAttr is converted to a pointer
-        // to a byte pointer, and receives the address of a block of memory containing the attribute.
+        // If the buffer length is specified as SCARD_AUTOALLOCATE, then data pointer is
+        // converted to a pointer to a byte pointer, and receives the address of a block of memory
+        // containing the attribute.
         RequestedBufferType::Allocate
     } else {
         RequestedBufferType::Buff(unsafe { from_raw_parts_mut(p_buf, (*pcb_buf).try_into()?) })
     })
 }
 
+/// This function behaves as the [build_buf_request_type] but here it expects a pointer
+/// to the `u16` buffer instead of `u8`. So, the buffer length is multiplied by two.
 pub unsafe fn build_buf_request_type_wide<'data>(
     p_buf: LpWStr,
     pcb_buf: LpDword,
@@ -48,12 +54,19 @@ pub unsafe fn build_buf_request_type_wide<'data>(
     })
 }
 
-// TODO: write proper comments.
+/// Saves the resulting data after the [RequestedBufferType] processing.
 pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
     match out_buf {
-        OutBuffer::Written(len) => unsafe { *pcb_buf = len.try_into()? },
-        OutBuffer::DataLen(len) => unsafe { *pcb_buf = len.try_into()? },
+        OutBuffer::Written(len) => unsafe {
+            // We already wrote the requested data in the provided buffer, so we only need to write the data length.
+            *pcb_buf = len.try_into()?
+        },
+        OutBuffer::DataLen(len) => unsafe {
+            // The user requested only the requested data length, so we just return it.
+            *pcb_buf = len.try_into()?
+        },
         OutBuffer::Allocated(data) => unsafe {
+            // We allocated a new memory for the requested data, so we need to save the buffer and buffer length.
             *(p_buf as *mut *mut u8) = data.as_mut_ptr();
             *pcb_buf = data.len().try_into()?;
         },
@@ -62,6 +75,8 @@ pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) 
     Ok(())
 }
 
+/// This function behaves as the [save_out_buf] but here it expects a pointer
+/// to the `u16` buffer instead of `u8`. So, the buffer length is divided by two.
 pub unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
     match out_buf {
         OutBuffer::Written(len) => unsafe { *pcb_buf = u32::try_from(len)? / 2 },

--- a/ffi/src/winscard/macros.rs
+++ b/ffi/src/winscard/macros.rs
@@ -4,6 +4,13 @@ macro_rules! check_handle {
             return u32::from(winscard::ErrorKind::InvalidHandle);
         }
     }};
+    ($x:expr, $name:expr) => {{
+        use winscard::{Error, ErrorKind};
+
+        if $x == 0 {
+            return Err(Error::new(ErrorKind::InvalidHandle, $name));
+        }
+    }};
 }
 
 macro_rules! try_execute {
@@ -31,6 +38,13 @@ macro_rules! check_null {
     ($x:expr) => {{
         if $x.is_null() {
             return u32::from(winscard::ErrorKind::InvalidParameter);
+        }
+    }};
+    ($x:expr, $name:expr) => {{
+        use winscard::{Error, ErrorKind};
+
+        if $x.is_null() {
+            return Err(Error::new(ErrorKind::InvalidParameter, $name));
         }
     }};
 }

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -38,9 +38,9 @@ pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
     } else {
         Cow::Borrowed("libpcsclite")
     };
-    // SAFE: Rust string cannot contain `0` bytes.
-    let pcsc_lite_path = CString::new(pcsc_lite_path.as_ref()).expect("CString creation should not fail");
+    let pcsc_lite_path = CString::new(pcsc_lite_path.as_ref())?;
 
+    // SAFETY: The library path is type checked.
     let handle = unsafe { dlopen(pcsc_lite_path.as_ptr(), 0) };
     if handle.is_null() {
         return Err(Error::new(ErrorKind::InternalError, "Can not load pcsc-lite library"));
@@ -49,6 +49,8 @@ pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
     macro_rules! load_fn {
         ($func_name:literal) => {{
             let fn_name = CString::new($func_name).expect("CString creation should not fail");
+            // SAFETY: The `handle` is initialized and checked above. The function name should be correct
+            // because it's hardcoded in the code.
             unsafe { std::mem::transmute(dlsym(handle, fn_name.as_ptr())) }
         }};
     }

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -482,7 +482,7 @@ pub unsafe extern "system" fn SCardGetAttrib(
         format!("invalid attribute id: {}", dw_attr_id)
     )));
 
-    // SAFETY: The `handle` is not null. All other guarantees should be provided by the user.
+    // SAFETY: The `handle` is not zero. All other guarantees should be provided by the user.
     let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
     // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
     // and the `pcb_atr_len` parameter cannot be null (checked above).
@@ -509,11 +509,13 @@ pub unsafe extern "system" fn SCardSetAttrib(
     check_handle!(handle);
     check_null!(pb_attr);
 
+    // SAFETY: The `pb_attr` parameter is not null (checked above).
     let attr_data = unsafe { from_raw_parts(pb_attr, cb_attr_len.try_into().unwrap()) };
     let attr_id = try_execute!(AttributeId::from_u32(dw_attr_id).ok_or_else(|| Error::new(
         ErrorKind::InvalidParameter,
         format!("Invalid attribute id: {}", dw_attr_id)
     )));
+    // SAFETY: The `handle` is not zero (checked above). All other guarantees should be provided by the user.
     let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
 
     try_execute!(scard.set_attribute(attr_id, attr_data));

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -274,8 +274,10 @@ pub unsafe extern "system" fn SCardStatusW(
     let scard = unsafe { (handle as *mut WinScardHandle).as_mut() }.unwrap();
     let readers_buf_type = try_execute!(unsafe { build_buf_request_type_wide(msz_reader_names, pcch_reader_len) });
     let atr_buf_type = try_execute!(unsafe { build_buf_request_type(pb_atr, pcb_atr_len) });
+    debug!(?atr_buf_type);
 
     let status = try_execute!(scard.status_wide(readers_buf_type, atr_buf_type));
+    debug!(?status);
 
     unsafe {
         *pdw_state = status.state.into();
@@ -284,9 +286,8 @@ pub unsafe extern "system" fn SCardStatusW(
 
     try_execute!(unsafe { save_out_buf_wide(status.readers, msz_reader_names, pcch_reader_len) });
 
-    if !pb_atr.is_null() {
-        try_execute!(unsafe { save_out_buf(status.atr, pb_atr, pcb_atr_len) });
-    }
+    debug!("pb_atr: {:?} {} {}", pb_atr, !pb_atr.is_null(), unsafe { *pcb_atr_len });
+    try_execute!(unsafe { save_out_buf(status.atr, pb_atr, pcb_atr_len) });
 
     ErrorKind::Success.into()
 }

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -15,7 +15,7 @@ use winscard::{Error, ErrorKind, WinScardResult};
 use super::buf_alloc::{build_buf_request_type, build_buf_request_type_wide, save_out_buf, save_out_buf_wide};
 use crate::utils::{c_w_str_to_string, into_raw_ptr};
 use crate::winscard::scard_handle::{
-    copy_io_request_to_scard_io_request, scard_context_handle_to_scard_context, scard_context_to_winscard_context,
+    copy_io_request_to_scard_io_request, raw_scard_handle_to_scard_handle, scard_context_to_winscard_context,
     scard_handle_to_winscard, scard_io_request_to_io_request, WinScardContextHandle, WinScardHandle,
 };
 
@@ -262,7 +262,7 @@ pub unsafe extern "system" fn SCardStatusA(
     check_null!(pcb_atr_len);
 
     // SAFETY: The `handle` is not null. All other guarantees should be provided by the user.
-    let scard = try_execute!(unsafe { scard_context_handle_to_scard_context(handle) });
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
     // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
     let readers_buf_type = try_execute!(unsafe { build_buf_request_type(msz_reader_names, pcch_reader_len) });
     // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
@@ -308,7 +308,7 @@ pub unsafe extern "system" fn SCardStatusW(
     check_null!(pcb_atr_len);
 
     // SAFETY: The `handle` is not null. All other guarantees should be provided by the user.
-    let scard = try_execute!(unsafe { scard_context_handle_to_scard_context(handle) });
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
     // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
     let readers_buf_type = try_execute!(unsafe { build_buf_request_type_wide(msz_reader_names, pcch_reader_len) });
     // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
@@ -482,7 +482,7 @@ pub unsafe extern "system" fn SCardGetAttrib(
     )));
 
     // SAFETY: The `handle` is not null. All other guarantees should be provided by the user.
-    let scard = try_execute!(unsafe { scard_context_handle_to_scard_context(handle) });
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
     // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
     // and the `pcb_atr_len` parameter cannot be null (checked above).
     let buffer_type = try_execute!(unsafe { build_buf_request_type(pb_attr, pcb_attr_len) });

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -156,9 +156,9 @@ pub unsafe extern "system" fn SCardDisconnect(handle: ScardHandle, dw_dispositio
 
     if let Some(context) = scard.context() {
         if context.remove_scard(handle) {
-            info!(?handle, "Successfully disconnected!");
+            info!(?handle, "Successfully disconnected");
         } else {
-            warn!("ScardHandle does not belong to the specified context.")
+            warn!("ScardHandle does not belong to the specified context")
         }
     }
 
@@ -274,10 +274,8 @@ pub unsafe extern "system" fn SCardStatusW(
     let scard = unsafe { (handle as *mut WinScardHandle).as_mut() }.unwrap();
     let readers_buf_type = try_execute!(unsafe { build_buf_request_type_wide(msz_reader_names, pcch_reader_len) });
     let atr_buf_type = try_execute!(unsafe { build_buf_request_type(pb_atr, pcb_atr_len) });
-    debug!(?atr_buf_type);
 
     let status = try_execute!(scard.status_wide(readers_buf_type, atr_buf_type));
-    debug!(?status);
 
     unsafe {
         *pdw_state = status.state.into();
@@ -286,7 +284,6 @@ pub unsafe extern "system" fn SCardStatusW(
 
     try_execute!(unsafe { save_out_buf_wide(status.readers, msz_reader_names, pcch_reader_len) });
 
-    debug!("pb_atr: {:?} {} {}", pb_atr, !pb_atr.is_null(), unsafe { *pcb_atr_len });
     try_execute!(unsafe { save_out_buf(status.atr, pb_atr, pcb_atr_len) });
 
     ErrorKind::Success.into()
@@ -410,7 +407,7 @@ pub unsafe extern "system" fn SCardGetAttrib(
 
     let attr_id = try_execute!(AttributeId::from_u32(dw_attr_id).ok_or_else(|| Error::new(
         ErrorKind::InvalidParameter,
-        format!("Invalid attribute id: {}", dw_attr_id)
+        format!("invalid attribute id: {}", dw_attr_id)
     )));
 
     let scard = unsafe { (handle as *mut WinScardHandle).as_ref().unwrap() };

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -1,12 +1,12 @@
 use std::ffi::CStr;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
-use num_traits::FromPrimitive;
 
 use ffi_types::winscard::{
     LpOpenCardNameA, LpOpenCardNameExA, LpOpenCardNameExW, LpOpenCardNameW, LpScardHandle, LpScardIoRequest,
     ScardContext, ScardHandle, ScardStatus,
 };
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpCWStr, LpDword, LpStr, LpVoid, LpWStr};
+use num_traits::FromPrimitive;
 #[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
 use winscard::winscard::{AttributeId, Protocol, ScardConnectData, ShareMode};
@@ -118,7 +118,7 @@ pub unsafe extern "system" fn SCardConnectW(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardReconnect"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardReconnect(
+pub unsafe extern "system" fn SCardReconnect(
     handle: ScardHandle,
     dw_share_mode: u32,
     dw_preferred_protocols: u32,
@@ -399,7 +399,7 @@ pub unsafe extern "system" fn SCardControl(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardGetAttrib"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardGetAttrib(
+pub unsafe extern "system" fn SCardGetAttrib(
     handle: ScardHandle,
     dw_attr_id: u32,
     pb_attr: LpByte,

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -120,8 +120,14 @@ pub unsafe extern "system" fn SCardReleaseContext(context: ScardContext) -> Scar
     debug!(?context, thread_id = ?std::thread::current().id(), "ctxwinscar");
     check_handle!(context);
 
-    let _ = unsafe { Box::from_raw(context as *mut WinScardContextHandle) };
-    release_context(context);
+    if is_present(context) {
+        let _ = unsafe { Box::from_raw(context as *mut WinScardContextHandle) };
+        release_context(context);
+
+        info!("Scard context has been successfully released.");
+    } else {
+        warn!("Scard context is invalid or has been released.");
+    }
 
     ErrorKind::Success.into()
 }

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -753,11 +753,10 @@ pub unsafe extern "system" fn SCardGetStatusChangeW(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardCancel"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardCancel(_context: ScardContext) -> ScardStatus {
-    // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcancel
-    // The SCardCancel function terminates all outstanding actions within a specific resource manager context.
-    //
-    // We do not have such actions in an emulated scard context
+pub extern "system" fn SCardCancel(context: ScardContext) -> ScardStatus {
+    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
+    try_execute!(context.cancel());
+
     ErrorKind::Success.into()
 }
 

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::ffi::CStr;
-use std::num::TryFromIntError;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::{Mutex, OnceLock};
 
@@ -842,17 +841,21 @@ pub unsafe extern "system" fn SCardGetStatusChangeA(
     };
     let mut reader_states = try_execute!(c_reader_states
         .iter()
-        .map(|c_reader| Ok(ReaderState {
-            // SAFETY: The reader name should not be null. All other guarantees should be provided by the user.
-            reader_name: unsafe { CStr::from_ptr(c_reader.sz_reader as *const _) }.to_string_lossy(),
-            user_data: c_reader.pv_user_data as usize,
-            current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
-            event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
-            atr_len: c_reader.cb_atr.try_into()?,
-            atr: c_reader.rgb_atr,
-        }))
-        .collect::<Result<Vec<_>, TryFromIntError>>()
-        .map_err(|err| winscard::Error::from(err)));
+        .map(|c_reader| {
+            check_null!(c_reader.sz_reader, "reader name in reader state");
+
+            Ok(ReaderState {
+                // SAFETY: The reader name should not be null (checked above). All other guarantees
+                // should be provided by the user.
+                reader_name: unsafe { CStr::from_ptr(c_reader.sz_reader as *const _) }.to_string_lossy(),
+                user_data: c_reader.pv_user_data as usize,
+                current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
+                event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
+                atr_len: c_reader.cb_atr.try_into()?,
+                atr: c_reader.rgb_atr,
+            })
+        })
+        .collect::<Result<Vec<_>, winscard::Error>>());
     try_execute!(context.get_status_change(dw_timeout, &mut reader_states));
 
     for (reader_state, c_reader_state) in reader_states.iter().zip(c_reader_states.iter_mut()) {
@@ -879,26 +882,30 @@ pub unsafe extern "system" fn SCardGetStatusChangeW(
     // SAFETY: The `context` value is not zero (checked above).
     let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
 
+    // SAFETY: The `rg_reader_states` parameter is not null (checked above).
     let c_reader_states = unsafe {
         from_raw_parts_mut(
-            // SAFETY: The `rg_reader_states` parameter is not null (checked above).
             rg_reader_states,
             try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer),
         )
     };
     let mut reader_states = try_execute!(c_reader_states
         .iter()
-        .map(|c_reader| Ok(ReaderState {
-            // SAFETY: The reader name should not be null. All other guarantees should be provided by the user.
-            reader_name: Cow::Owned(unsafe { c_w_str_to_string(c_reader.sz_reader) }),
-            user_data: c_reader.pv_user_data as usize,
-            current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
-            event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
-            atr_len: c_reader.cb_atr.try_into()?,
-            atr: c_reader.rgb_atr,
-        }))
-        .collect::<Result<Vec<_>, TryFromIntError>>()
-        .map_err(|err| winscard::Error::from(err)));
+        .map(|c_reader| {
+            check_null!(c_reader.sz_reader, "reader name in reader state");
+
+            Ok(ReaderState {
+                // SAFETY: The reader name should not be null (checked above). All other guarantees
+                // should be provided by the user.
+                reader_name: Cow::Owned(unsafe { c_w_str_to_string(c_reader.sz_reader) }),
+                user_data: c_reader.pv_user_data as usize,
+                current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
+                event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
+                atr_len: c_reader.cb_atr.try_into()?,
+                atr: c_reader.rgb_atr,
+            })
+        })
+        .collect::<Result<Vec<_>, winscard::Error>>());
     try_execute!(context.get_status_change(dw_timeout, &mut reader_states));
 
     for (reader_state, c_reader_state) in reader_states.iter().zip(c_reader_states.iter_mut()) {

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -422,10 +422,25 @@ pub unsafe fn scard_handle_to_winscard<'a>(handle: ScardHandle) -> WinScardResul
     }
 }
 
-/// Tries to convert the raw scard context handle to the [&mut WinScardHandle].
-pub unsafe fn scard_context_handle_to_scard_context<'a>(
+/// Tries to convert the raw scard handle to the [&mut WinScardHandle].
+pub unsafe fn raw_scard_handle_to_scard_handle<'a>(h_card: ScardHandle) -> WinScardResult<&'a mut WinScardHandle> {
+    if h_card == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidHandle,
+            "scard context handle cannot be zero",
+        ));
+    }
+
+    // SAFETY: It should be safe to cast the value. The `h_card` is not null (checked above).
+    // All other guarantees should be provided by the user.
+    unsafe { (h_card as *mut WinScardHandle).as_mut() }
+        .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
+}
+
+/// Tries to convert the raw scard context handle to the [&mut WinScardContextHandle].
+pub unsafe fn raw_scard_context_handle_to_scard_context_handle<'a>(
     h_context: ScardContext,
-) -> WinScardResult<&'a mut WinScardHandle> {
+) -> WinScardResult<&'a mut WinScardContextHandle> {
     if h_context == 0 {
         return Err(Error::new(
             ErrorKind::InvalidHandle,
@@ -435,7 +450,7 @@ pub unsafe fn scard_context_handle_to_scard_context<'a>(
 
     // SAFETY: It should be safe to cast the value. The `h_context` is not null (checked above).
     // All other guarantees should be provided by the user.
-    unsafe { (h_context as *mut WinScardHandle).as_mut() }
+    unsafe { (h_context as *mut WinScardContextHandle).as_mut() }
         .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
 }
 

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -292,6 +292,11 @@ impl WinScardHandle {
         self.scard.as_ref()
     }
 
+    /// Returns the mutable [WinScard] handle.
+    pub fn scard_mut(&mut self) -> &mut dyn WinScard {
+        self.scard.as_mut()
+    }
+
     /// Returns the parent [ScardContext] it belongs.
     pub fn raw_context(&self) -> ScardContext {
         self.context

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -162,13 +162,14 @@ impl WinScardContextHandle {
             .iter()
             .flat_map(|reader| {
                 reader
-                    .as_bytes()
-                    .iter()
-                    .chain(once(&0))
+                    .encode_utf16()
+                    .chain(std::iter::once(0))
                     .flat_map(|i| i.to_le_bytes().to_vec())
             })
             .chain([0, 0].into_iter())
             .collect();
+
+        debug!(?data);
 
         self.write_to_out_buf(&data, buffer_type)
     }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -89,12 +89,14 @@ impl WinScardContextHandle {
         }
     }
 
+    /// Returns the icon of the specified reader.
     pub fn get_reader_icon(&mut self, reader: &str, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
         self.write_to_out_buf(&reader_icon, buffer_type)
     }
 
+    /// Lists readers.
     pub fn list_readers(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let readers: Vec<_> = self
             .scard_context()
@@ -106,6 +108,7 @@ impl WinScardContextHandle {
         self.write_multi_string(&readers, buffer_type)
     }
 
+    /// Lists readers but the resulting buffers contain wide strings.
     pub fn list_readers_wide(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let readers: Vec<_> = self
             .scard_context()
@@ -117,6 +120,7 @@ impl WinScardContextHandle {
         self.write_multi_string_wide(&readers, buffer_type)
     }
 
+    /// Reads smart card cache.
     pub fn read_cache(
         &mut self,
         card_id: Uuid,
@@ -132,6 +136,7 @@ impl WinScardContextHandle {
         self.write_to_out_buf(cached_value.as_ref(), buffer_type)
     }
 
+    /// Converts provided strings to the C-multi-string and saves it.
     pub fn write_multi_string(
         &mut self,
         values: &[String],
@@ -146,6 +151,8 @@ impl WinScardContextHandle {
         self.write_to_out_buf(&data, buffer_type)
     }
 
+    /// Converts provided strings to the C-multi-string and saves it but the resulting buffers contain
+    /// wide strings.
     pub fn write_multi_string_wide(
         &mut self,
         values: &[String],
@@ -166,6 +173,7 @@ impl WinScardContextHandle {
         self.write_to_out_buf(&data, buffer_type)
     }
 
+    /// Saves the provided data in the [OutBuffer] based on the [RequestedBufferType].
     pub fn write_to_out_buf(
         &mut self,
         data: &[u8],
@@ -246,10 +254,19 @@ pub enum OutBuffer<'data> {
     Allocated(&'data mut [u8]),
 }
 
+/// Represents the smart card status.
+///
+/// This structure is aimed to represent smart card status data on the FFI layer.
 pub struct FfiScardStatus<'data> {
+    /// List of display names (multi-string) by which the currently connected reader is known.
     pub readers: OutBuffer<'data>,
+    /// Buffer that receives the ATR string from the currently inserted card, if available.
+    ///
+    /// [ATR string](https://learn.microsoft.com/en-us/windows/win32/secgloss/a-gly).
     pub atr: OutBuffer<'data>,
+    /// Current state of the smart card in the reader.
     pub state: State,
+    /// Current protocol, if any. The returned value is meaningful only if the returned value of pdwState is SCARD_SPECIFICMODE.
     pub protocol: Protocol,
 }
 
@@ -284,6 +301,7 @@ impl WinScardHandle {
         unsafe { (self.raw_context() as *mut WinScardContextHandle).as_mut() }
     }
 
+    /// Returns the requested smart card attribute.
     pub fn get_attribute(
         &self,
         attribute_id: AttributeId,
@@ -294,6 +312,7 @@ impl WinScardHandle {
         self.context().unwrap().write_to_out_buf(data.as_ref(), buffer_type)
     }
 
+    /// Returns smart card status.
     pub fn status(
         &mut self,
         readers_buf_type: RequestedBufferType,
@@ -314,6 +333,7 @@ impl WinScardHandle {
         })
     }
 
+    /// Returns smart card status but all strings are wide.
     pub fn status_wide(
         &mut self,
         readers_buf_type: RequestedBufferType,

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -231,6 +231,7 @@ impl WinScardContextHandle {
                 }
 
                 buf[0..data.len()].copy_from_slice(&data);
+                info!("data has been copied... {:?}", data);
 
                 OutBuffer::Written(data.len())
             }
@@ -267,6 +268,7 @@ impl Drop for WinScardContextHandle {
 }
 
 /// Represents how and what data the user want to extract.
+#[derive(Debug)]
 pub enum RequestedBufferType<'data> {
     /// This means the user wants the data filled in the provided buffer.
     Buff(&'data mut [u8]),
@@ -281,6 +283,7 @@ pub enum RequestedBufferType<'data> {
 /// The user can request some data from the smart card. For example, `SCardReadCache` or `SCardGetAttrib` functions.
 /// However, buffer handling can be tricky in such situations. The user may want to allocate the memory
 /// or ask us to do it. This enum aimed to solve this complexity.
+#[derive(Debug)]
 pub enum OutBuffer<'data> {
     /// The data has been written into provided buffer by [RequestedBufferType::Buff].
     Written(usize),
@@ -295,6 +298,7 @@ pub enum OutBuffer<'data> {
 /// Represents the smart card status.
 ///
 /// This structure is aimed to represent smart card status data on the FFI layer.
+#[derive(Debug)]
 pub struct FfiScardStatus<'data> {
     /// List of display names (multi-string) by which the currently connected reader is known.
     pub readers: OutBuffer<'data>,
@@ -383,6 +387,7 @@ impl WinScardHandle {
         atr_but_type: RequestedBufferType,
     ) -> WinScardResult<FfiScardStatus> {
         let status = self.scard().status()?;
+        debug!(?status);
         let readers: Vec<_> = status.readers.into_iter().map(|r| r.to_string()).collect();
         let context = self.context().unwrap();
 

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -122,6 +122,40 @@ impl WinScardContextHandle {
         self.write_multi_string_wide(&readers, buffer_type)
     }
 
+    /// Lists cards.
+    pub fn list_cards(
+        &mut self,
+        atr: Option<&[u8]>,
+        required_interfaces: Option<&[Uuid]>,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cards: Vec<_> = self
+            .scard_context()
+            .list_cards(atr, required_interfaces)?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string(&cards, buffer_type)
+    }
+
+    /// Lists readers but the resulting buffers contain wide strings.
+    pub fn list_cards_wide(
+        &mut self,
+        atr: Option<&[u8]>,
+        required_interfaces: Option<&[Uuid]>,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cards: Vec<_> = self
+            .scard_context()
+            .list_cards(atr, required_interfaces)?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string_wide(&cards, buffer_type)
+    }
+
     /// Reads smart card cache.
     pub fn read_cache(
         &mut self,

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -4,7 +4,8 @@ use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use ffi_types::winscard::{LpScardIoRequest, ScardContext, ScardHandle, ScardIoRequest};
 use ffi_types::LpCVoid;
-use winscard::winscard::{AttributeId, IoRequest, Protocol, State, Uuid, WinScard, WinScardContext};
+use uuid::Uuid;
+use winscard::winscard::{AttributeId, IoRequest, Protocol, State, WinScard, WinScardContext};
 use winscard::{Error, ErrorKind, WinScardResult};
 
 /// Scard context handle representation.
@@ -202,7 +203,7 @@ impl WinScardContextHandle {
                     .chain(std::iter::once(0))
                     .flat_map(|i| i.to_le_bytes().to_vec())
             })
-            .chain([0, 0].into_iter())
+            .chain([0, 0])
             .collect();
 
         debug!(?data);
@@ -230,7 +231,7 @@ impl WinScardContextHandle {
                     );
                 }
 
-                buf[0..data.len()].copy_from_slice(&data);
+                buf[0..data.len()].copy_from_slice(data);
                 info!("data has been copied... {:?}", data);
 
                 OutBuffer::Written(data.len())
@@ -240,7 +241,7 @@ impl WinScardContextHandle {
                 let allocated = self.allocate_buffer(data.len())?;
                 let buf = unsafe { from_raw_parts_mut(allocated, data.len()) };
 
-                buf.copy_from_slice(&data);
+                buf.copy_from_slice(data);
 
                 OutBuffer::Allocated(buf)
             }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -42,6 +42,8 @@ impl WinScardContextHandle {
             return Err(Error::new(ErrorKind::InvalidHandle, "ScardHandle can not be NULL"));
         }
 
+        info!("Add new scard context: {}", scard);
+
         self.scards.push(scard);
 
         Ok(())
@@ -215,6 +217,7 @@ impl Drop for WinScardContextHandle {
     fn drop(&mut self) {
         // [SCardReleaseContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreleasecontext)
         // ...freeing any resources allocated under that context, including SCARDHANDLE objects
+        trace!("scards to disconnect: {:?}", self.scards);
         unsafe {
             for scard in &self.scards {
                 let _ = Box::from_raw(*scard as *mut WinScardHandle);

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -198,12 +198,7 @@ impl WinScardContextHandle {
     ) -> WinScardResult<OutBuffer<'static>> {
         let data: Vec<_> = values
             .iter()
-            .flat_map(|reader| {
-                reader
-                    .encode_utf16()
-                    .chain(std::iter::once(0))
-                    .flat_map(|i| i.to_le_bytes().to_vec())
-            })
+            .flat_map(|reader| reader.encode_utf16().chain(once(0)).flat_map(|i| i.to_le_bytes()))
             .chain([0, 0])
             .collect();
 

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -212,7 +212,7 @@ impl WinScardContextHandle {
         buffer_type: RequestedBufferType,
     ) -> WinScardResult<OutBuffer<'static>> {
         Ok(match buffer_type {
-            RequestedBufferType::Buff(buf) => {
+            RequestedBufferType::Buf(buf) => {
                 if buf.len() < data.len() {
                     return Err(
                         Error::new(
@@ -268,7 +268,7 @@ impl Drop for WinScardContextHandle {
 #[derive(Debug)]
 pub enum RequestedBufferType<'data> {
     /// This means the user wants the data filled in the provided buffer.
-    Buff(&'data mut [u8]),
+    Buf(&'data mut [u8]),
     /// The user want to query only the data length.
     Length,
     /// The user wants the data to be allocated by the library and returned from the function.
@@ -282,7 +282,7 @@ pub enum RequestedBufferType<'data> {
 /// or ask us to do it. This enum aimed to solve this complexity.
 #[derive(Debug)]
 pub enum OutBuffer<'data> {
-    /// The data has been written into provided buffer by [RequestedBufferType::Buff].
+    /// The data has been written into provided buffer by [RequestedBufferType::Buf].
     Written(usize),
     /// The user wants to know the requested data length to allocate the corresponding buffer in the future.
     DataLen(usize),

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -43,8 +43,6 @@ impl WinScardContextHandle {
             return Err(Error::new(ErrorKind::InvalidHandle, "ScardHandle can not be NULL"));
         }
 
-        info!("Add new scard context: {}", scard);
-
         self.scards.push(scard);
 
         Ok(())
@@ -67,7 +65,7 @@ impl WinScardContextHandle {
         if buff.is_null() {
             return Err(Error::new(
                 ErrorKind::NoMemory,
-                format!("Can not allocate {} bytes", size),
+                format!("cannot allocate {} bytes", size),
             ));
         }
         self.allocations.push(buff as usize);
@@ -206,8 +204,6 @@ impl WinScardContextHandle {
             .chain([0, 0])
             .collect();
 
-        debug!(?data);
-
         self.write_to_out_buf(&data, buffer_type)
     }
 
@@ -223,7 +219,7 @@ impl WinScardContextHandle {
                     return Err(
                         Error::new(
                             ErrorKind::InsufficientBuffer, format!(
-                                "Provided buffer is too small to fill the requested attribute into. Buffer len: {}. Attribute data len: {}.",
+                                "provided buffer is too small to fill the requested attribute into: buffer len: {}, attribute data len: {}.",
                                 buf.len(),
                                 data.len()
                             )
@@ -232,7 +228,6 @@ impl WinScardContextHandle {
                 }
 
                 buf[0..data.len()].copy_from_slice(data);
-                info!("data has been copied... {:?}", data);
 
                 OutBuffer::Written(data.len())
             }
@@ -253,7 +248,6 @@ impl Drop for WinScardContextHandle {
     fn drop(&mut self) {
         // [SCardReleaseContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreleasecontext)
         // ...freeing any resources allocated under that context, including SCARDHANDLE objects
-        trace!("scards to disconnect: {:?}", self.scards);
         unsafe {
             for scard in &self.scards {
                 let _ = Box::from_raw(*scard as *mut WinScardHandle);
@@ -410,7 +404,7 @@ pub unsafe fn scard_handle_to_winscard<'a>(handle: ScardHandle) -> WinScardResul
     } else {
         Err(Error::new(
             ErrorKind::InvalidHandle,
-            "Invalid smart card context handle.",
+            "invalid smart card context handle",
         ))
     }
 }
@@ -423,7 +417,7 @@ pub unsafe fn scard_context_to_winscard_context<'a>(
     } else {
         Err(Error::new(
             ErrorKind::InvalidHandle,
-            "Invalid smart card context handle.",
+            "invalid smart card context handle",
         ))
     }
 }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -3,7 +3,7 @@ use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use ffi_types::winscard::{LpScardIoRequest, ScardContext, ScardHandle, ScardIoRequest};
 use ffi_types::LpCVoid;
-use winscard::winscard::{AttributeId, IoRequest, Protocol, WinScard, WinScardContext};
+use winscard::winscard::{AttributeId, IoRequest, Protocol, Uuid, WinScard, WinScardContext};
 use winscard::{Error, ErrorKind, WinScardResult};
 
 /// Scard context handle representation.
@@ -92,6 +92,21 @@ impl WinScardContextHandle {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
         self.write_to_out_buf(&reader_icon, buffer_type)
+    }
+
+    pub fn read_cache(
+        &mut self,
+        card_id: Uuid,
+        freshness_counter: u32,
+        key: &str,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cached_value = self
+            .scard_context()
+            .read_cache(card_id, freshness_counter, key)?
+            .to_vec();
+
+        self.write_to_out_buf(cached_value.as_ref(), buffer_type)
     }
 
     pub fn write_to_out_buf(&mut self, data: &[u8], buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -180,7 +180,6 @@ impl WinScardContext for SystemScardContext {
                 "SCardListReadersA failed"
             )?;
         }
-        debug!(?readers, "Raw readers buffer");
 
         parse_multi_string_owned(&readers)
     }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -180,6 +180,7 @@ impl WinScardContext for SystemScardContext {
                 "SCardListReadersA failed"
             )?;
         }
+        debug!(?readers, "Raw readers buffer");
 
         parse_multi_string_owned(&readers)
     }

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "scard")]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 mod macros;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
             ErrorKind::TooManyPrincipals,
             "Multiple principal entries database".into(),
         ),
-        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "The client or server has a null key".into()),
+        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "The client or server has null key".into()),
         KDC_ERR_CANNOT_POSTDATE => (
             ErrorKind::KdcInvalidRequest,
             "Ticket not eligible for postdating".into(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,44 +56,44 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
         KDC_ERR_NONE => (ErrorKind::Unknown, "No error".into()),
         KDC_ERR_NAME_EXP => (
             ErrorKind::InvalidParameter,
-            "Client's entry in database has expired".into(),
+            "client's entry in database has expired".into(),
         ),
         KDC_ERR_SERVICE_EXP => (
             ErrorKind::InvalidParameter,
-            "Server's entry in database has expired".into(),
+            "server's entry in database has expired".into(),
         ),
         KDC_ERR_BAD_PVNO => (
             ErrorKind::KdcInvalidRequest,
-            "Requested protocol version number not supported".into(),
+            "requested protocol version number not supported".into(),
         ),
         KDC_ERR_C_OLD_MAST_KVNO => (
             ErrorKind::EncryptFailure,
-            "Client's key encrypted in old master key".into(),
+            "client's key encrypted in old master key".into(),
         ),
         KDC_ERR_S_OLD_MAST_KVNO => (
             ErrorKind::EncryptFailure,
-            "Server's key encrypted in old master key".into(),
+            "server's key encrypted in old master key".into(),
         ),
         KDC_ERR_C_PRINCIPAL_UNKNOWN => (
             ErrorKind::UnknownCredentials,
-            "Client not found in Kerberos database".into(),
+            "client not found in Kerberos database".into(),
         ),
         KDC_ERR_S_PRINCIPAL_UNKNOWN => (
             ErrorKind::UnknownCredentials,
-            "Server not found in Kerberos database".into(),
+            "server not found in Kerberos database".into(),
         ),
         KDC_ERR_PRINCIPAL_NOT_UNIQUE => (
             ErrorKind::TooManyPrincipals,
-            "Multiple principal entries database".into(),
+            "multiple principal entries database".into(),
         ),
-        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "The client or server has null key".into()),
+        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "the client or server has null key".into()),
         KDC_ERR_CANNOT_POSTDATE => (
             ErrorKind::KdcInvalidRequest,
-            "Ticket not eligible for postdating".into(),
+            "ticket not eligible for postdating".into(),
         ),
         KDC_ERR_NEVER_VALID => (
             ErrorKind::KdcInvalidRequest,
-            "Requested starttime is later than end time".into(),
+            "requested starttime is later than end time".into(),
         ),
         KDC_ERR_POLICY => (ErrorKind::KdcInvalidRequest, "KDC policy rejects request".into()),
         KDC_ERR_BADOPTION => (
@@ -118,109 +118,109 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
         ),
         KDC_ERR_CLIENT_REVOKED => (
             ErrorKind::UnknownCredentials,
-            "Clients credentials have been revoked".into(),
+            "clients credentials have been revoked".into(),
         ),
         KDC_ERR_SERVICE_REVOKED => (
             ErrorKind::UnknownCredentials,
-            "Credentials for server have been revoked".into(),
+            "credentials for server have been revoked".into(),
         ),
         KDC_ERR_TGT_REVOKED => (ErrorKind::UnknownCredentials, "TGT has been revoked".into()),
         KDC_ERR_CLIENT_NOTYET => (
             ErrorKind::UnknownCredentials,
-            "Client not yet valid; try again later".into(),
+            "client not yet valid; try again later".into(),
         ),
         KDC_ERR_SERVICE_NOTYET => (
             ErrorKind::UnknownCredentials,
-            "Server not yet valid; try again later".into(),
+            "server not yet valid; try again later".into(),
         ),
         KDC_ERR_KEY_EXPIRED => (
             ErrorKind::InvalidParameter,
-            "Password has expired; change password to reset".into(),
+            "password has expired; change password to reset".into(),
         ),
         KDC_ERR_PREAUTH_FAILED => (
             ErrorKind::KdcInvalidRequest,
-            "Pre-authentication information was invalid".into(),
+            "pre-authentication information was invalid".into(),
         ),
         KDC_ERR_PREAUTH_REQUIRED => (
             ErrorKind::KdcInvalidRequest,
-            "Additional preauthentication required".into(),
+            "additional preauthentication required".into(),
         ),
         KDC_ERR_SERVER_NOMATCH => (
             ErrorKind::KdcInvalidRequest,
-            "Requested server and ticket don't match".into(),
+            "requested server and ticket don't match".into(),
         ),
         KDC_ERR_MUST_USE_USER2USER => (
             ErrorKind::KdcInvalidRequest,
-            "Server principal valid for user2user only".into(),
+            "server principal valid for user2user only".into(),
         ),
         KDC_ERR_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "KDC Policy rejects transited path".into()),
-        KDC_ERR_SVC_UNAVAILABLE => (ErrorKind::KdcInvalidRequest, "A service is not available".into()),
+        KDC_ERR_SVC_UNAVAILABLE => (ErrorKind::KdcInvalidRequest, "a service is not available".into()),
         KRB_AP_ERR_BAD_INTEGRITY => (
             ErrorKind::MessageAltered,
-            "Integrity check on decrypted field failed".into(),
+            "integrity check on decrypted field failed".into(),
         ),
-        KRB_AP_ERR_TKT_EXPIRED => (ErrorKind::ContextExpired, "Ticket expired".into()),
-        KRB_AP_ERR_TKT_NYV => (ErrorKind::InvalidToken, "Ticket not yet valid".into()),
-        KRB_AP_ERR_REPEAT => (ErrorKind::KdcInvalidRequest, "Request is a replay".into()),
-        KRB_AP_ERR_NOT_US => (ErrorKind::InvalidToken, "The ticket isn't for us".into()),
+        KRB_AP_ERR_TKT_EXPIRED => (ErrorKind::ContextExpired, "ticket expired".into()),
+        KRB_AP_ERR_TKT_NYV => (ErrorKind::InvalidToken, "ticket not yet valid".into()),
+        KRB_AP_ERR_REPEAT => (ErrorKind::KdcInvalidRequest, "request is a replay".into()),
+        KRB_AP_ERR_NOT_US => (ErrorKind::InvalidToken, "the ticket isn't for us".into()),
         KRB_AP_ERR_BADMATCH => (
             ErrorKind::KdcInvalidRequest,
-            "Ticket and authenticator don't match".into(),
+            "ticket and authenticator don't match".into(),
         ),
-        KRB_AP_ERR_SKEW => (ErrorKind::TimeSkew, "Clock skew too great".into()),
-        KRB_AP_ERR_BADADDR => (ErrorKind::InvalidParameter, "Incorrect net address".into()),
-        KRB_AP_ERR_BADVERSION => (ErrorKind::KdcInvalidRequest, "Protocol version mismatch".into()),
-        KRB_AP_ERR_MSG_TYPE => (ErrorKind::InvalidToken, "Invalid msg type".into()),
-        KRB_AP_ERR_MODIFIED => (ErrorKind::MessageAltered, "Message stream modified".into()),
-        KRB_AP_ERR_BADORDER => (ErrorKind::OutOfSequence, "Message out of order".into()),
+        KRB_AP_ERR_SKEW => (ErrorKind::TimeSkew, "clock skew too great".into()),
+        KRB_AP_ERR_BADADDR => (ErrorKind::InvalidParameter, "incorrect net address".into()),
+        KRB_AP_ERR_BADVERSION => (ErrorKind::KdcInvalidRequest, "protocol version mismatch".into()),
+        KRB_AP_ERR_MSG_TYPE => (ErrorKind::InvalidToken, "invalid msg type".into()),
+        KRB_AP_ERR_MODIFIED => (ErrorKind::MessageAltered, "message stream modified".into()),
+        KRB_AP_ERR_BADORDER => (ErrorKind::OutOfSequence, "message out of order".into()),
         KRB_AP_ERR_BADKEYVER => (
             ErrorKind::KdcInvalidRequest,
-            "Specified version of key is not available".into(),
+            "specified version of key is not available".into(),
         ),
-        KRB_AP_ERR_NOKEY => (ErrorKind::NoKerbKey, "Service key not available".into()),
-        KRB_AP_ERR_MUT_FAIL => (ErrorKind::MutualAuthFailed, "Mutual authentication failed".into()),
-        KRB_AP_ERR_BADDIRECTION => (ErrorKind::OutOfSequence, "Incorrect message direction".into()),
+        KRB_AP_ERR_NOKEY => (ErrorKind::NoKerbKey, "service key not available".into()),
+        KRB_AP_ERR_MUT_FAIL => (ErrorKind::MutualAuthFailed, "mutual authentication failed".into()),
+        KRB_AP_ERR_BADDIRECTION => (ErrorKind::OutOfSequence, "incorrect message direction".into()),
         KRB_AP_ERR_METHOD => (
             ErrorKind::InvalidToken,
-            "Alternative authentication method required".into(),
+            "alternative authentication method required".into(),
         ),
-        KRB_AP_ERR_BADSEQ => (ErrorKind::OutOfSequence, "Incorrect sequence number in message".into()),
+        KRB_AP_ERR_BADSEQ => (ErrorKind::OutOfSequence, "incorrect sequence number in message".into()),
         KRB_AP_ERR_INAPP_CKSUM => (
             ErrorKind::InvalidToken,
-            "Inappropriate type of checksum in message".into(),
+            "inappropriate type of checksum in message".into(),
         ),
-        KRB_AP_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "Policy rejects transited path".into()),
+        KRB_AP_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "policy rejects transited path".into()),
         KRB_ERR_RESPONSE_TOO_BIG => (
             ErrorKind::InvalidParameter,
-            "Response too big for UDP; retry with TC".into(),
+            "response too big for UDP; retry with TC".into(),
         ),
-        KRB_ERR_GENERIC => (ErrorKind::InternalError, "Generic error (description in e-text)".into()),
+        KRB_ERR_GENERIC => (ErrorKind::InternalError, "generic error (description in e-text)".into()),
         KRB_ERR_FIELD_TOOLONG => (
             ErrorKind::KdcInvalidRequest,
-            "Field is too long for this implementation".into(),
+            "field is too long for this implementation".into(),
         ),
-        KDC_ERROR_CLIENT_NOT_TRUSTED => (ErrorKind::InvalidParameter, "Client is not trusted".into()),
+        KDC_ERROR_CLIENT_NOT_TRUSTED => (ErrorKind::InvalidParameter, "client is not trusted".into()),
         KDC_ERROR_KDC_NOT_TRUSTED => (ErrorKind::InvalidParameter, "KDC is not trusted".into()),
-        KDC_ERROR_INVALID_SIG => (ErrorKind::MessageAltered, "Invalid signature".into()),
-        KDC_ERR_KEY_TOO_WEAK => (ErrorKind::EncryptFailure, "Key is too weak".into()),
-        KDC_ERR_CERTIFICATE_MISMATCH => (ErrorKind::InvalidParameter, "Certificated mismatch".into()),
+        KDC_ERROR_INVALID_SIG => (ErrorKind::MessageAltered, "invalid signature".into()),
+        KDC_ERR_KEY_TOO_WEAK => (ErrorKind::EncryptFailure, "key is too weak".into()),
+        KDC_ERR_CERTIFICATE_MISMATCH => (ErrorKind::InvalidParameter, "certificated mismatch".into()),
         KRB_AP_ERR_NO_TGT => (
             ErrorKind::NoTgtReply,
-            "No TGT available to validate USER-TO-USER".into(),
+            "no TGT available to validate USER-TO-USER".into(),
         ),
-        KDC_ERR_WRONG_REALM => (ErrorKind::InvalidParameter, "Wrong Realm".into()),
-        KRB_AP_ERR_USER_TO_USER_REQUIRED => (ErrorKind::KdcInvalidRequest, "Ticket must be for USER-TO-USER".into()),
+        KDC_ERR_WRONG_REALM => (ErrorKind::InvalidParameter, "wrong Realm".into()),
+        KRB_AP_ERR_USER_TO_USER_REQUIRED => (ErrorKind::KdcInvalidRequest, "ticket must be for USER-TO-USER".into()),
         KDC_ERR_CANT_VERIFY_CERTIFICATE => (
             ErrorKind::KdcInvalidRequest,
             "KDC can not verify the certificate".into(),
         ),
-        KDC_ERR_INVALID_CERTIFICATE => (ErrorKind::InvalidParameter, "Invalid certificate".into()),
-        KDC_ERR_REVOKED_CERTIFICATE => (ErrorKind::KdcCertRevoked, "Revoked certificate".into()),
-        KDC_ERR_REVOCATION_STATUS_UNKNOWN => (ErrorKind::InternalError, "Revoked status unknown".into()),
-        KDC_ERR_REVOCATION_STATUS_UNAVAILABLE => (ErrorKind::InternalError, "Revoked status unavailable".into()),
-        KDC_ERR_CLIENT_NAME_MISMATCH => (ErrorKind::InvalidParameter, "Client name mismatch".into()),
+        KDC_ERR_INVALID_CERTIFICATE => (ErrorKind::InvalidParameter, "invalid certificate".into()),
+        KDC_ERR_REVOKED_CERTIFICATE => (ErrorKind::KdcCertRevoked, "revoked certificate".into()),
+        KDC_ERR_REVOCATION_STATUS_UNKNOWN => (ErrorKind::InternalError, "revoked status unknown".into()),
+        KDC_ERR_REVOCATION_STATUS_UNAVAILABLE => (ErrorKind::InternalError, "revoked status unavailable".into()),
+        KDC_ERR_CLIENT_NAME_MISMATCH => (ErrorKind::InvalidParameter, "client name mismatch".into()),
         KDC_ERR_KDC_NAME_MISMATCH => (ErrorKind::InvalidParameter, "KDC name mismatch".into()),
-        code => (ErrorKind::Unknown, format!("Unknown Kerberos error: {}", code)),
+        code => (ErrorKind::Unknown, format!("unknown Kerberos error: {}", code)),
     }
 }
 
@@ -258,7 +258,7 @@ pub fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [DecryptBuf
             return Err(Error::new(
                 ErrorKind::DecryptFailure,
                 format!(
-                    "Decrypted data length ({}) does not match the stream buffer length ({})",
+                    "decrypted data length ({}) does not match the stream buffer length ({})",
                     decrypted_len, stream_buffer_len,
                 ),
             ));
@@ -278,7 +278,7 @@ pub fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [DecryptBuf
             return Err(Error::new(
                 ErrorKind::DecryptFailure,
                 format!(
-                    "Decrypted data length ({}) does not match the data buffer length ({})",
+                    "decrypted data length ({}) does not match the data buffer length ({})",
                     decrypted.len(),
                     data.len(),
                 ),
@@ -315,14 +315,14 @@ pub fn parse_target_name(target_name: &str) -> Result<(&str, &str)> {
     let divider = target_name.find('/').ok_or_else(|| {
         Error::new(
             ErrorKind::InvalidParameter,
-            "Invalid service principal name: missing '/'",
+            "invalid service principal name: missing '/'",
         )
     })?;
 
     if divider == 0 || divider == target_name.len() - 1 {
         return Err(Error::new(
             ErrorKind::InvalidParameter,
-            "Invalid service principal name",
+            "invalid service principal name",
         ));
     }
 


### PR DESCRIPTION
Hi,
In this PR, I've improved the WinSCard FFI layer. According to my plan, this iteration's last intermediate PR. I'll perform some additional dev testing when the PR is merged.

## Implementation notes

* I moved the `clippy::undocumented_unsafe_blocks` lint to the `ffi/winscard` module lever instead of `ffi/winscard/system_scard`. Now all winscard-related code is checked.
* Refactored the code and removed all panics.
* Improved the memory management. A detailed explanation is below.

## Memory management improvements

Many winscard functions can treat the resulting data differently based on the input parameters.

* When the input data pointer is `NULL`, we should write out data len in the input data len pointer.
* When the input data length pointer value is `SCARD_AUTOALLOCATE`, we should allocate memory by ourselves, cast the output data pointer to pointer to pointer to memory, and write the memory address.
* Otherwise, we copy the data and data length into corresponding pointers.

And there are a lot of functions with such behavior. To simplify this process and reduce many `if`s/`match`s, I've introduced the `RequestBufferType` and `OutBuff` types. They are well documented, so you can read its description in the code.

Moreover, I put my effort into keeping all memory management inside the `WinScardContexthandle` structure implementation. Now it's easier to manage the memory and search for problems if there are any.

---

_Sorry for the huge PR again :disappointed: If I split those changes they will be confusing_