### PR TITLE
System provided scards support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -2155,6 +2155,7 @@ dependencies = [
  "symbol-rename-macro",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "whoami",
  "windows-sys 0.48.0",
  "winscard",
@@ -2883,6 +2884,8 @@ dependencies = [
  "flate2",
  "iso7816",
  "iso7816-tlv",
+ "num-derive",
+ "num-traits",
  "picky",
  "picky-asn1-der",
  "picky-asn1-x509",

--- a/crates/ffi-types/src/common.rs
+++ b/crates/ffi-types/src/common.rs
@@ -2,6 +2,7 @@ use std::ffi::c_void;
 
 pub type LpStr = *mut u8;
 pub type LpCStr = *const u8;
+pub type Dword = u32;
 pub type LpDword = *mut u32;
 pub type LpWStr = *mut u16;
 pub type LpCWStr = *const u16;

--- a/crates/ffi-types/src/common.rs
+++ b/crates/ffi-types/src/common.rs
@@ -26,11 +26,12 @@ pub type Bool = i32;
 #[repr(C)]
 pub struct Guid {
     pub data1: u32,
-    pub data2: u32,
-    pub data3: u32,
+    pub data2: u16,
+    pub data3: u16,
     pub data4: [u8; 8],
 }
 pub type LpCGuid = *const Guid;
 pub type LpGuid = *mut Guid;
 pub type Uuid = Guid;
 pub type LpUuid = *mut Uuid;
+pub type LpCUuid = *const Uuid;

--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -12,56 +12,58 @@ pub type SCardEstablishContextFn =
     unsafe extern "system" fn(u32, *const c_void, *const c_void, LpScardContext) -> ScardStatus;
 pub type SCardReleaseContextFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
 pub type SCardIsValidContextFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
-pub type SCardListReaderGroupsAFn = extern "system" fn(ScardContext, LpStr, LpDword) -> ScardStatus;
-pub type SCardListReaderGroupsWFn = extern "system" fn(ScardContext, LpWStr, LpDword) -> ScardStatus;
+pub type SCardListReaderGroupsAFn = unsafe extern "system" fn(ScardContext, LpStr, LpDword) -> ScardStatus;
+pub type SCardListReaderGroupsWFn = unsafe extern "system" fn(ScardContext, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListReadersAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListCardsAFn =
     unsafe extern "system" fn(ScardContext, LpCByte, LpCGuid, u32, *mut u8, LpDword) -> ScardStatus;
 pub type SCardListCardsWFn =
     unsafe extern "system" fn(ScardContext, LpCByte, LpCGuid, u32, *mut u16, LpDword) -> ScardStatus;
-pub type SCardListInterfacesAFn = extern "system" fn(ScardContext, LpCStr, LpGuid, LpDword) -> ScardStatus;
-pub type SCardListInterfacesWFn = extern "system" fn(ScardContext, LpCWStr, LpGuid, LpDword) -> ScardStatus;
-pub type SCardGetProviderIdAFn = extern "system" fn(ScardContext, LpCStr, LpGuid) -> ScardStatus;
-pub type SCardGetProviderIdWFn = extern "system" fn(ScardContext, LpCWStr, LpGuid) -> ScardStatus;
+pub type SCardListInterfacesAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpGuid, LpDword) -> ScardStatus;
+pub type SCardListInterfacesWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpGuid, LpDword) -> ScardStatus;
+pub type SCardGetProviderIdAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpGuid) -> ScardStatus;
+pub type SCardGetProviderIdWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpGuid) -> ScardStatus;
 pub type SCardGetCardTypeProviderNameAFn =
     unsafe extern "system" fn(ScardContext, LpCStr, u32, *mut u8, LpDword) -> ScardStatus;
 pub type SCardGetCardTypeProviderNameWFn =
     unsafe extern "system" fn(ScardContext, LpCWStr, u32, *mut u16, LpDword) -> ScardStatus;
-pub type SCardIntroduceReaderGroupAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardIntroduceReaderGroupWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardForgetReaderGroupAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetReaderGroupWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardIntroduceReaderAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardIntroduceReaderWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
-pub type SCardForgetReaderAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetReaderWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
-pub type SCardAddReaderToGroupAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardAddReaderToGroupWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
-pub type SCardRemoveReaderFromGroupAFn = extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
-pub type SCardRemoveReaderFromGroupWFn = extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardIntroduceReaderGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardIntroduceReaderGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardForgetReaderGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetReaderGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardIntroduceReaderAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardIntroduceReaderWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardForgetReaderAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetReaderWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+pub type SCardAddReaderToGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardAddReaderToGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
+pub type SCardRemoveReaderFromGroupAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpCStr) -> ScardStatus;
+pub type SCardRemoveReaderFromGroupWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpCWStr) -> ScardStatus;
 pub type SCardIntroduceCardTypeAFn =
-    extern "system" fn(ScardContext, LpCStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
 pub type SCardIntroduceCardTypeWFn =
-    extern "system" fn(ScardContext, LpCWStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
-pub type SCardSetCardTypeProviderNameAFn = extern "system" fn(ScardContext, LpCStr, u32, LpCStr) -> ScardStatus;
-pub type SCardSetCardTypeProviderNameWFn = extern "system" fn(ScardContext, LpCWStr, u32, LpCWStr) -> ScardStatus;
-pub type SCardForgetCardTypeAFn = extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
-pub type SCardForgetCardTypeWFn = extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpCGuid, LpCGuid, u32, LpCByte, LpCByte, u32) -> ScardStatus;
+pub type SCardSetCardTypeProviderNameAFn = unsafe extern "system" fn(ScardContext, LpCStr, u32, LpCStr) -> ScardStatus;
+pub type SCardSetCardTypeProviderNameWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, u32, LpCWStr) -> ScardStatus;
+pub type SCardForgetCardTypeAFn = unsafe extern "system" fn(ScardContext, LpCStr) -> ScardStatus;
+pub type SCardForgetCardTypeWFn = unsafe extern "system" fn(ScardContext, LpCWStr) -> ScardStatus;
 pub type SCardFreeMemoryFn = unsafe extern "system" fn(ScardContext, LpCVoid) -> ScardStatus;
-pub type SCardAccessStartedEventFn = extern "system" fn() -> Handle;
-pub type SCardReleaseStartedEventFn = extern "system" fn();
-pub type SCardLocateCardsAFn = extern "system" fn(ScardContext, LpCStr, LpScardReaderStateA, u32) -> ScardStatus;
-pub type SCardLocateCardsWFn = extern "system" fn(ScardContext, LpCWStr, LpScardReaderStateW, u32) -> ScardStatus;
+pub type SCardAccessStartedEventFn = unsafe extern "system" fn() -> Handle;
+pub type SCardReleaseStartedEventFn = unsafe extern "system" fn();
+pub type SCardLocateCardsAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpScardReaderStateA, u32) -> ScardStatus;
+pub type SCardLocateCardsWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpScardReaderStateW, u32) -> ScardStatus;
 pub type SCardLocateCardsByATRAFn =
-    extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateA, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateA, u32) -> ScardStatus;
 pub type SCardLocateCardsByATRWFn =
-    extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateW, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpScardAtrMask, u32, LpScardReaderStateW, u32) -> ScardStatus;
 pub type SCardGetStatusChangeAFn =
     unsafe extern "system" fn(ScardContext, u32, LpScardReaderStateA, u32) -> ScardStatus;
 pub type SCardGetStatusChangeWFn =
     unsafe extern "system" fn(ScardContext, u32, LpScardReaderStateW, u32) -> ScardStatus;
-pub type SCardCancelFn = extern "system" fn(ScardContext) -> ScardStatus;
+pub type SCardCancelFn = unsafe extern "system" fn(ScardContext) -> ScardStatus;
 pub type SCardReadCacheAFn =
     unsafe extern "system" fn(ScardContext, LpUuid, u32, LpStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardReadCacheWFn =
@@ -72,23 +74,25 @@ pub type SCardGetReaderIconAFn = unsafe extern "system" fn(ScardContext, LpCStr,
 pub type SCardGetReaderIconWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardGetDeviceTypeIdAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpDword) -> ScardStatus;
 pub type SCardGetDeviceTypeIdWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpDword) -> ScardStatus;
-pub type SCardGetReaderDeviceInstanceIdAFn = extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
-pub type SCardGetReaderDeviceInstanceIdWFn = extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
+pub type SCardGetReaderDeviceInstanceIdAFn =
+    unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
+pub type SCardGetReaderDeviceInstanceIdWFn =
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWithDeviceInstanceIdAFn =
-    extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCStr, LpStr, LpDword) -> ScardStatus;
 pub type SCardListReadersWithDeviceInstanceIdWFn =
-    extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
-pub type SCardAuditFn = extern "system" fn(ScardContext, u32) -> ScardStatus;
+    unsafe extern "system" fn(ScardContext, LpCWStr, LpWStr, LpDword) -> ScardStatus;
+pub type SCardAuditFn = unsafe extern "system" fn(ScardContext, u32) -> ScardStatus;
 pub type SCardConnectAFn =
     unsafe extern "system" fn(ScardContext, LpCStr, u32, u32, LpScardHandle, LpDword) -> ScardStatus;
 pub type SCardConnectWFn =
     unsafe extern "system" fn(ScardContext, LpCWStr, u32, u32, LpScardHandle, LpDword) -> ScardStatus;
-pub type SCardReconnectFn = extern "system" fn(ScardHandle, u32, u32, u32, LpDword) -> ScardStatus;
+pub type SCardReconnectFn = unsafe extern "system" fn(ScardHandle, u32, u32, u32, LpDword) -> ScardStatus;
 pub type SCardDisconnectFn = unsafe extern "system" fn(ScardHandle, u32) -> ScardStatus;
 pub type SCardBeginTransactionFn = unsafe extern "system" fn(ScardHandle) -> ScardStatus;
 pub type SCardEndTransactionFn = unsafe extern "system" fn(ScardHandle, u32) -> ScardStatus;
-pub type SCardCancelTransactionFn = extern "system" fn(ScardHandle) -> ScardStatus;
-pub type SCardStateFn = extern "system" fn(ScardHandle, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
+pub type SCardCancelTransactionFn = unsafe extern "system" fn(ScardHandle) -> ScardStatus;
+pub type SCardStateFn = unsafe extern "system" fn(ScardHandle, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
 pub type SCardStatusAFn =
     unsafe extern "system" fn(ScardHandle, LpStr, LpDword, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
 pub type SCardStatusWFn =
@@ -102,19 +106,20 @@ pub type SCardTransmitFn = unsafe extern "system" fn(
     LpByte,
     LpDword,
 ) -> ScardStatus;
-pub type SCardGetTransmitCountFn = extern "system" fn(ScardHandle, LpDword) -> ScardStatus;
+pub type SCardGetTransmitCountFn = unsafe extern "system" fn(ScardHandle, LpDword) -> ScardStatus;
 pub type SCardControlFn =
     unsafe extern "system" fn(ScardHandle, u32, LpCVoid, u32, LpVoid, u32, LpDword) -> ScardStatus;
-pub type SCardGetAttribFn = extern "system" fn(ScardHandle, u32, LpByte, LpDword) -> ScardStatus;
-pub type SCardSetAttribFn = extern "system" fn(ScardHandle, u32, LpCByte, u32) -> ScardStatus;
-pub type SCardUIDlgSelectCardAFn = extern "system" fn(LpOpenCardNameExA) -> ScardStatus;
-pub type SCardUIDlgSelectCardWFn = extern "system" fn(LpOpenCardNameExW) -> ScardStatus;
-pub type GetOpenCardNameAFn = extern "system" fn(LpOpenCardNameA) -> ScardStatus;
-pub type GetOpenCardNameWFn = extern "system" fn(LpOpenCardNameW) -> ScardStatus;
+pub type SCardGetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpByte, LpDword) -> ScardStatus;
+pub type SCardSetAttribFn = unsafe extern "system" fn(ScardHandle, u32, LpCByte, u32) -> ScardStatus;
+pub type SCardUIDlgSelectCardAFn = unsafe extern "system" fn(LpOpenCardNameExA) -> ScardStatus;
+pub type SCardUIDlgSelectCardWFn = unsafe extern "system" fn(LpOpenCardNameExW) -> ScardStatus;
+pub type GetOpenCardNameAFn = unsafe extern "system" fn(LpOpenCardNameA) -> ScardStatus;
+pub type GetOpenCardNameWFn = unsafe extern "system" fn(LpOpenCardNameW) -> ScardStatus;
 // Not a part of the standard winscard.h API
-pub type GetSCardApiFunctionTableFn = extern "system" fn() -> PSCardApiFunctionTable;
+pub type GetSCardApiFunctionTableFn = unsafe extern "system" fn() -> PSCardApiFunctionTable;
 
 // https://github.com/FreeRDP/FreeRDP/blob/88f79c5748f4031cb50dfae3ebadcc6619b69f1c/winpr/include/winpr/smartcard.h#L1114
+#[derive(Debug)]
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct SCardApiFunctionTable {

--- a/crates/winscard/Cargo.toml
+++ b/crates/winscard/Cargo.toml
@@ -32,6 +32,8 @@ rand_core = "0.6.4"
 sha1 = { version = "0.10.6", default-features = false }
 base64 = { version = "0.21" , optional = true }
 picky-asn1-der = { version = "0.4", optional = true }
+num-derive = "0.4"
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -34,9 +34,10 @@ use core::{fmt, result};
 
 pub use ber_tlv::ber_tlv_length_encoding;
 use iso7816_tlv::TlvError;
+use num_derive::{FromPrimitive, ToPrimitive};
 use picky::key::KeyError;
 use picky::x509::certificate::CertError;
-pub use scard::{SmartCard, ATR, PIV_AID};
+pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
 pub use scard_context::{Reader, ScardContext, SmartCardInfo};
 
 /// The [WinScardResult] type.
@@ -162,8 +163,23 @@ impl From<CertError> for Error {
     }
 }
 
+impl From<core::convert::Infallible> for Error {
+    fn from(_: core::convert::Infallible) -> Self {
+        Error::new(ErrorKind::InternalError, "Infallible")
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(value: core::str::Utf8Error) -> Self {
+        #[cfg(not(feature = "std"))]
+        use alloc::string::ToString;
+
+        Error::new(ErrorKind::InternalError, value.to_string())
+    }
+}
+
 /// [Smart Card Return Values](https://learn.microsoft.com/en-us/windows/win32/secauthn/authentication-return-values).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, ToPrimitive, FromPrimitive)]
 #[repr(u32)]
 pub enum ErrorKind {
     /// The client attempted a smart card operation in a remote session, such as a client session running on a terminal server,

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -178,6 +178,13 @@ impl From<core::str::Utf8Error> for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl From<std::ffi::NulError> for Error {
+    fn from(value: std::ffi::NulError) -> Self {
+        Error::new(ErrorKind::InvalidParameter, value.to_string())
+    }
+}
+
 /// [Smart Card Return Values](https://learn.microsoft.com/en-us/windows/win32/secauthn/authentication-return-values).
 #[derive(Debug, PartialEq, ToPrimitive, FromPrimitive)]
 #[repr(u32)]

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -38,7 +38,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use picky::key::KeyError;
 use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
-pub use scard_context::{Reader, ScardContext, SmartCardInfo};
+pub use scard_context::{Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
 /// The [WinScardResult] type.
 pub type WinScardResult<T> = result::Result<T, Error>;

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -7,10 +7,25 @@ use alloc::{format, vec};
 
 use picky::key::PrivateKey;
 use picky_asn1_x509::{PublicKey, SubjectPublicKeyInfo};
+use uuid::Uuid;
 
-use crate::scard::SmartCard;
-use crate::winscard::{DeviceTypeId, Icon, Protocol, ShareMode, WinScard, WinScardContext};
+use crate::scard::{SmartCard, SUPPORTED_CONNECTION_PROTOCOL};
+use crate::winscard::{
+    CurrentState, DeviceTypeId, Icon, Protocol, ProviderId, ReaderState, ScardConnectData, ShareMode, WinScardContext,
+};
 use crate::{Error, ErrorKind, WinScardResult};
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew
+// To be notified of the arrival of a new smart card reader,
+// set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
+const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
+
+// Default name of the emulated smart card.
+const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
+
+const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
+const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
+const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "msclmd.dll";
 
 /// Describes a smart card reader.
 #[derive(Debug, Clone)]
@@ -51,6 +66,8 @@ impl<'a> SmartCardInfo<'a> {
     pub fn try_from_env() -> WinScardResult<Self> {
         use std::fs;
 
+        use picky::x509::Cert;
+
         use crate::env::{
             WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV, WINSCARD_CONTAINER_NAME_ENV, WINSCARD_PIN_ENV,
             WINSCARD_PK_DATA_ENV, WINSCARD_PK_PATH_ENV, WINSCARD_READER_NAME_ENV,
@@ -71,8 +88,6 @@ impl<'a> SmartCardInfo<'a> {
 
             cert_der
         } else if let Ok(cert_path) = env!(WINSCARD_CERT_PATH_ENV) {
-            use picky::x509::Cert;
-
             let raw_certificate = fs::read_to_string(cert_path).map_err(|e| {
                 Error::new(
                     ErrorKind::InvalidParameter,
@@ -448,7 +463,7 @@ impl<'a> WinScardContext for ScardContext<'a> {
         reader_name: &str,
         _share_mode: ShareMode,
         _protocol: Option<Protocol>,
-    ) -> WinScardResult<Box<dyn WinScard>> {
+    ) -> WinScardResult<ScardConnectData> {
         if self.smart_card_info.reader.name != reader_name {
             return Err(Error::new(
                 ErrorKind::UnknownReader,
@@ -456,16 +471,19 @@ impl<'a> WinScardContext for ScardContext<'a> {
             ));
         }
 
-        Ok(Box::new(SmartCard::new(
-            Cow::Owned(reader_name.to_owned()),
-            self.smart_card_info.pin.clone(),
-            self.smart_card_info.auth_cert_der.clone(),
-            self.smart_card_info.auth_pk.clone(),
-        )?))
+        Ok(ScardConnectData {
+            handle: Box::new(SmartCard::new(
+                Cow::Owned(reader_name.to_owned()),
+                self.smart_card_info.pin.clone(),
+                self.smart_card_info.auth_cert_der.clone(),
+                self.smart_card_info.auth_pk.clone(),
+            )?),
+            protocol: SUPPORTED_CONNECTION_PROTOCOL,
+        })
     }
 
-    fn list_readers(&self) -> Vec<Cow<str>> {
-        vec![self.smart_card_info.reader.name.clone()]
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>> {
+        Ok(vec![self.smart_card_info.reader.name.clone()])
     }
 
     fn device_type_id(&self, reader_name: &str) -> WinScardResult<DeviceTypeId> {
@@ -494,11 +512,75 @@ impl<'a> WinScardContext for ScardContext<'a> {
         true
     }
 
-    fn read_cache(&self, key: &str) -> Option<&[u8]> {
-        self.cache.get(key).map(|item| item.as_slice())
+    fn read_cache(&self, _: Uuid, _: u32, key: &str) -> WinScardResult<Cow<[u8]>> {
+        self.cache
+            .get(key)
+            .map(|item| Cow::Borrowed(item.as_slice()))
+            .ok_or_else(|| Error::new(ErrorKind::CacheItemNotFound, format!("Cache item '{}' not found", key)))
     }
 
-    fn write_cache(&mut self, key: String, value: Vec<u8>) {
+    fn write_cache(&mut self, _: Uuid, _: u32, key: String, value: Vec<u8>) -> WinScardResult<()> {
         self.cache.insert(key, value);
+
+        Ok(())
+    }
+
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {
+        // We don't support configuring or introducing reader groups. So, we just return hardcoded values.
+        //
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadergroupsw
+        // SCARD_DEFAULT_READERS: TEXT("SCard$DefaultReaders\000")
+        // Default group to which all readers are added when introduced into the system.
+        Ok(vec![Cow::Borrowed("SCard$DefaultReaders\u{0}00")])
+    }
+
+    fn cancel(&mut self) -> WinScardResult<()> {
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcancel
+        // The only requests that you can cancel are those that require waiting for external action by the smart card or user.
+        //
+        // We don't have any external actions, so we just return success.
+        Ok(())
+    }
+
+    fn get_status_change(&self, _timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()> {
+        use crate::ATR;
+
+        let supported_readers = self.list_readers()?;
+
+        for reader_state in reader_states {
+            if supported_readers.contains(&reader_state.reader_name) {
+                reader_state.event_state = CurrentState::SCARD_STATE_UNNAMED_CONSTANT
+                    | CurrentState::SCARD_STATE_INUSE
+                    | CurrentState::SCARD_STATE_PRESENT
+                    | CurrentState::SCARD_STATE_CHANGED;
+                reader_state.atr[0..ATR.len()].copy_from_slice(&ATR);
+                reader_state.atr_len = ATR.len();
+            } else if reader_state.reader_name.as_ref() == NEW_READER_NOTIFICATION {
+                reader_state.event_state = CurrentState::SCARD_STATE_UNNAMED_CONSTANT;
+            } else {
+                error!(?reader_state.reader_name, "Unsupported reader");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn list_cards(&self, _atr: Option<&[u8]>, _required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>> {
+        // we have only one smart card with only one default name
+        Ok(vec![DEFAULT_CARD_NAME.into()])
+    }
+
+    fn get_card_type_provider_name(&self, _card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<str>> {
+        Ok(match provider_id {
+            ProviderId::Primary => {
+                return Err(Error::new(
+                    ErrorKind::UnsupportedFeature,
+                    "ProviderId::Primary is not supported for emulated smart card",
+                ))
+            }
+            ProviderId::Csp => MICROSOFT_DEFAULT_CSP.into(),
+            ProviderId::Ksp => MICROSOFT_DEFAULT_KSP.into(),
+            ProviderId::CardModule => MICROSOFT_SCARD_DRIVER_LOCATION.into(),
+        })
     }
 }

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -20,10 +20,10 @@ use crate::{Error, ErrorKind, WinScardResult};
 // set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
 const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
 
-// Default name of the emulated smart card.
-const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
-
-const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
+/// Default name of the emulated smart card.
+pub const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
+/// Default CSP name.
+pub const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
 const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
 const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "msclmd.dll";
 

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -256,6 +256,43 @@ impl From<DeviceTypeId> for u32 {
     }
 }
 
+/// [SCardEstablishContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardestablishcontext)
+///
+/// `dwScope` parameter:
+/// Scope of the resource manager context.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ScardScope {
+    /// Database operations are performed within the domain of the user.
+    User = 0,
+    /// Database operations are performed within the domain of the system.
+    /// The calling application must have appropriate access permissions for any database actions.
+    System = 2,
+}
+
+impl TryFrom<u32> for ScardScope {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::User,
+            2 => Self::System,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidParameter,
+                    format!("Invalid ScardScope value: {}", value),
+                ))
+            }
+        })
+    }
+}
+
+impl From<ScardScope> for u32 {
+    fn from(value: ScardScope) -> Self {
+        value as u32
+    }
+}
+
 /// [SCardConnectW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardconnectw)
 ///
 /// `dwShareMode` parameter:

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -5,8 +5,168 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use bitflags::bitflags;
+use num_derive::{FromPrimitive, ToPrimitive};
+use uuid::Uuid;
 
 use crate::{Error, ErrorKind, WinScardResult};
+
+/// Control code for the `SCardControl` operation.
+///
+/// This value identifies the specific operation to be performed. More info:
+/// * [WinSCard SCardControl](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcontrol).
+/// * [pcsc-lite SCardControl](https://pcsclite.apdu.fr/api/group__API.html#gac3454d4657110fd7f753b2d3d8f4e32f).
+pub type ControlCode = u32;
+
+/// Action to be taken on the reader.
+///
+/// More info:
+/// * [SCardEndTransaction](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardendtransaction).
+/// * [SCardReconnect](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreconnect).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ReaderAction {
+    /// Do not do anything special.
+    LeaveCard = 0,
+    /// Reset the card.
+    ResetCard = 1,
+    /// Power down the card.
+    UnpowerCard = 2,
+    /// Eject the card.
+    EjectCard = 3,
+}
+
+impl TryFrom<u32> for ReaderAction {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => ReaderAction::LeaveCard,
+            1 => ReaderAction::ResetCard,
+            2 => ReaderAction::UnpowerCard,
+            3 => ReaderAction::EjectCard,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidParameter,
+                    format!("Gow invalid disposition value: {}", value),
+                ))
+            }
+        })
+    }
+}
+
+impl From<ReaderAction> for u32 {
+    fn from(value: ReaderAction) -> Self {
+        value as u32
+    }
+}
+
+/// A smart card attribute id.
+///
+/// This enum represents a scard attribute id. A set of variants is formed by merging `WinSCard` attr ids and `pscsc-lite` attr ids.
+/// More info:
+/// * [WinSCard SCardGetAttrib](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib).
+/// * [pcsc-lite SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602).
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, FromPrimitive, ToPrimitive)]
+#[repr(u32)]
+pub enum AttributeId {
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a2e87e6925548b9fcca3fa0026b82500d
+    AsyncProtocolTypes = 0x0120,
+    /// Answer to reset (ATR) string.
+    AtrString = 0x0303,
+    /// Channel id.
+    ///
+    /// See [SCardGetAttrib](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib) for more details.
+    ChannelId = 0x0110,
+    /// DWORD indicating which mechanical characteristics are supported. If zero, no special characteristics are supported.
+    Characteristics = 0x0150,
+    /// Current block waiting time.
+    CurrentBwt = 0x0209,
+    /// Current clock rate, in kHz.
+    CurrentClk = 0x0202,
+    /// Current character waiting time.
+    CurrentCwt = 0x020a,
+    /// Bit rate conversion factor.
+    CurrentD = 0x0204,
+    /// Current error block control encoding.
+    CurrentEbcEncoding = 0x020b,
+    /// Clock conversion factor.
+    CurrentF = 0x0203,
+    /// Current byte size for information field size card.
+    CurrentIfsc = 0x0207,
+    /// Current byte size for information field size device.
+    CurrentIfsd = 0x0208,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a9c6ee3dccc23e924907e3dc2e29a50f6
+    CurrentIoState = 0x0302,
+    /// Current guard time.
+    CurrentN = 0x0205,
+    /// DWORD encoded as 0x0rrrpppp where rrr is RFU and should be 0x000. pppp encodes the current protocol type.
+    /// Whichever bit has been set indicates which ISO protocol is currently in use. (For example, if bit zero is set,
+    /// T=0 protocol is in effect.)
+    CurrentProtocolType = 0x0201,
+    /// Current work waiting time.
+    CurrentW = 0x0206,
+    /// Default clock rate, in kHz.
+    DefaultClk = 0x0121,
+    /// Default data rate, in bps.
+    DefaultDataRate = 0x0123,
+    /// Reader's display name.
+    DeviceFriendlyName = 0x0003,
+    /// Reader's display name but encoded in Wide string.
+    DeviceFriendlyNameW = 0x0005,
+    /// Reserved for future use.
+    DeviceInUse = 0x0002,
+    /// Reader's system name.
+    DeviceSystemName = 0x0004,
+    /// Reader's system name.
+    DeviceSystemNameW = 0x0006,
+    /// Instance of this vendor's reader attached to the computer. The first instance will be device unit 0,
+    /// the next will be unit 1 (if it is the same brand of reader) and so on. Two different brands of readers
+    /// will both have zero for this value.
+    DeviceUnit = 0x0001,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a1a1d31628ec9f49f79d2dda6651658d6
+    EscAuhRequest = 0xA005,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a69d8dd84f5f433efbfa6e0fce2a95528
+    EscCancel = 0xA003,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a55df7896fb65a2a942780d383d815071
+    EscReset = 0xA000,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a5fcd5c979018130c164a64c728f0716d
+    ExtendedBt = 0x020c,
+    /// Single byte. Zero if smart card electrical contact is not active; nonzero if contact is active.
+    IccInterfaceStatus = 0x0301,
+    /// Single byte indicating smart card presence.
+    IccPresence = 0x0300,
+    /// Single byte indicating smart card type.
+    IccTypePerAtr = 0x0304,
+    /// Maximum clock rate, in kHz.
+    MaxClk = 0x0122,
+    /// Maximum data rate, in bps.
+    MaxDataRate = 0x0124,
+    /// Maximum bytes for information file size device.
+    MaxIfsd = 0x0125,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a42ea634deb1ec51e10722b661aa73d01
+    MaxInput = 0xA007,
+    /// Zero if device does not support power down while smart card is inserted. Nonzero otherwise.
+    PowerMgmtSupport = 0x0131,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a62d09db2a45663ea726239aeafaac747
+    SupresT1IfsRequest = 0x0007,
+    /// DWORD encoded as 0x0rrrpppp where rrr is RFU and should be 0x000. pppp encodes the supported
+    /// protocol types. A '1' in a given bit position indicates support for the associated ISO protocol,
+    /// so if bits zero and one are set, both T=0 and T=1 protocols are supported.
+    SyncProtocolTypes = 0x0126,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a86eb3bba6a8a463aa0eac4ada7704785
+    UserAuthInputDevice = 0x0142,
+    /// https://pcsclite.apdu.fr/api/reader_8h.html#a60bf2dbb950d448099314aa86c14b2aa
+    UserToCardAuthDevice = 0x0140,
+    /// Vendor-supplied interface device serial number.
+    VendorIfdSerialNo = 0x0103,
+    /// Vendor-supplied interface device type (model designation of reader).
+    VendorIfdType = 0x0101,
+    /// Vendor-supplied interface device version (DWORD in the form 0xMMmmbbbb where MM = major version,
+    /// mm = minor version, and bbbb = build number).
+    VendorIfdVersion = 0x0102,
+    /// Vendor name.
+    VendorName = 0x0100,
+}
 
 /// ATR string.
 ///
@@ -68,7 +228,7 @@ impl From<Vec<u8>> for Icon<'_> {
 /// `ReaderType` parameter:
 /// This member contains the reader type and is required. This member can have one of the values in the following table.
 #[repr(u32)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive)]
 pub enum DeviceTypeId {
     /// Serial reader
     Serial = 0x01,
@@ -112,6 +272,12 @@ pub enum ShareMode {
     Direct = 3,
 }
 
+impl From<ShareMode> for u32 {
+    fn from(value: ShareMode) -> Self {
+        value as u32
+    }
+}
+
 impl TryFrom<u32> for ShareMode {
     type Error = Error;
 
@@ -134,7 +300,7 @@ bitflags! {
     /// `dwPreferredProtocols` and `pdwActiveProtocol` parameters:
     /// A bitmask of acceptable protocols for the connection.
     /// Possible values may be combined with the OR operation.
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
     pub struct Protocol: u32 {
         /// This parameter may be zero only if dwShareMode is set to SCARD_SHARE_DIRECT.
         /// In this case, no protocol negotiation will be performed by the drivers
@@ -175,6 +341,28 @@ pub enum State {
     Specific = 6,
 }
 
+impl TryFrom<u32> for State {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => State::Unknown,
+            1 => State::Absent,
+            2 => State::Present,
+            3 => State::Swallowed,
+            4 => State::Powered,
+            5 => State::Negotiable,
+            6 => State::Specific,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InternalError,
+                    format!("Invalid State value: {}", value),
+                ))
+            }
+        })
+    }
+}
+
 impl From<State> for u32 {
     fn from(value: State) -> Self {
         value as u32
@@ -186,39 +374,14 @@ impl From<State> for u32 {
 pub struct Status<'a> {
     /// List of display names (multiple string) by which the currently connected reader is known.
     pub readers: Vec<Cow<'a, str>>,
-    /// Current state of the smart card in the reader
+    /// Current state of the smart card in the reader.
     pub state: State,
-    /// Current protocol, if any. The returned value is meaningful only if the returned value of pdwState is SCARD_SPECIFICMODE.
+    /// Current protocol, if any. The returned value is meaningful only if the returned value of pdwState is `SCARD_SPECIFICMODE`.
     pub protocol: Protocol,
     /// Buffer that receives the ATR string from the currently inserted card, if available.
-    /// [ATR string](https://learn.microsoft.com/en-us/windows/win32/secgloss/a-gly)
+    ///
+    /// [ATR string](https://learn.microsoft.com/en-us/windows/win32/secgloss/a-gly).
     pub atr: Atr,
-}
-
-/// [SCardControl](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcontrol)
-///
-/// `dwControlCode` parameter:
-/// Control code for the operation. This value identifies the specific operation to be performed.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[repr(u32)]
-pub enum ControlCode {
-    /// `#define CM_IOCTL_GET_FEATURE_REQUEST SCARD_CTL_CODE(3400)`
-    /// Request features described in the *PC/SC 2.0 Specification Part 10*
-    IoCtl = 0x00313520,
-}
-
-impl TryFrom<u32> for ControlCode {
-    type Error = Error;
-
-    fn try_from(value: u32) -> WinScardResult<Self> {
-        match value {
-            0x00313520 => Ok(ControlCode::IoCtl),
-            _ => Err(Error::new(
-                ErrorKind::InvalidParameter,
-                format!("Unsupported control code: {:x?}", value),
-            )),
-        }
-    }
 }
 
 /// [SCARD_IO_REQUEST](https://learn.microsoft.com/en-us/windows/win32/secauthn/scard-io-request)
@@ -250,6 +413,118 @@ pub struct TransmitOutData {
     pub receive_pci: Option<IoRequest>,
 }
 
+/// This structure represents the result of the `SCardConnect` function.
+pub struct ScardConnectData {
+    /// Established smart card handle.
+    pub handle: Box<dyn WinScard>,
+    /// Established protocol to this connection.
+    pub protocol: Protocol,
+}
+
+bitflags! {
+    /// [SCardGetStatusChangeW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew)
+    ///
+    /// Current state of the reader, as seen by the application. This field can take on any of the following values,
+    /// in combination, as a bitmask.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+    pub struct CurrentState: u32 {
+        /// The application is unaware of the current state, and would like to know.
+        const SCARD_STATE_UNAWARE = 0;
+        /// The application is not interested in this reader, and it should not be considered during monitoring operations.
+        /// If this bit value is set, all other bits are ignored.
+        const SCARD_STATE_IGNORE = 1;
+        /// There is a difference between the state believed by the application, and the state known by the resource manager.
+        /// When this bit is set, the application may assume a significant state change has occurred on this reader.
+        const SCARD_STATE_CHANGED = 2;
+        /// The given reader name is not recognized by the resource manager. If this bit is set, then SCARD_STATE_CHANGED
+        /// and SCARD_STATE_IGNORE will also be set.
+        const SCARD_STATE_UNKNOWN = 4;
+        /// The application expects that this reader is not available for use. If this bit is set,
+        /// then all the following bits are ignored.
+        const SCARD_STATE_UNAVAILABLE = 8;
+        /// The application expects that there is no card in the reader. If this bit is set, all the following bits are ignored.
+        const SCARD_STATE_EMPTY = 16;
+        /// The application expects that there is a card in the reader.
+        const SCARD_STATE_PRESENT = 32;
+        /// The application expects that there is a card in the reader with an ATR that matches one of the target cards.
+        /// If this bit is set, SCARD_STATE_PRESENT is assumed. This bit has no meaning to SCardGetStatusChange beyond
+        /// SCARD_STATE_PRESENT.
+        const SCARD_STATE_ATRMATCH = 64;
+        /// The application expects that the card in the reader is allocated for exclusive use by another application.
+        /// If this bit is set, SCARD_STATE_PRESENT is assumed.
+        const SCARD_STATE_EXCLUSIVE = 128;
+        /// The application expects that the card in the reader is in use by one or more other applications,
+        /// but may be connected to in shared mode. If this bit is set, SCARD_STATE_PRESENT is assumed.
+        const SCARD_STATE_INUSE = 256;
+        /// The application expects that there is an unresponsive card in the reader.
+        const SCARD_STATE_MUTE = 512;
+        /// This implies that the card in the reader has not been powered up.
+        const SCARD_STATE_UNPOWERED = 1024;
+        /// Undocumented constant that appears in all API captures.
+        const SCARD_STATE_UNNAMED_CONSTANT = 0x00010000;
+    }
+}
+
+/// The `SCARD_READERSTATEW` structure is used by functions for tracking smart cards within readers.
+///
+/// [SCARD_READERSTATEW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/ns-winscard-scard_readerstatew).
+pub struct ReaderState<'data> {
+    /// The name of the reader being monitored.
+    pub reader_name: Cow<'data, str>,
+    /// Not used by the smart card subsystem. This member is used by the application.
+    pub user_data: usize,
+    /// Current state of the reader, as seen by the application.
+    pub current_state: CurrentState,
+    /// Current state of the reader, as known by the smart card resource manager.
+    pub event_state: CurrentState,
+    /// Number of bytes in the returned ATR.
+    pub atr_len: usize,
+    /// ATR of the inserted card, with extra alignment bytes.
+    pub atr: [u8; 36],
+}
+
+/// Identifier for the provider associated with the card type.
+///
+/// [SCardGetCardTypeProviderNameW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetcardtypeprovidernamew)
+/// `dwProviderId` parameter.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ProviderId {
+    /// `SCARD_PROVIDER_PRIMARY`: The function retrieves the name of the smart card's primary service provider as a GUID string.
+    Primary = 1,
+    /// `SCARD_PROVIDER_CSP`: The function retrieves the name of the cryptographic service provider.
+    Csp = 2,
+    /// `SCARD_PROVIDER_KSP`: The function retrieves the name of the smart card key storage provider (KSP).
+    Ksp = 3,
+    /// `SCARD_PROVIDER_CARD_MODULE`: The function retrieves the name of the card module.
+    CardModule = 0x80000001,
+}
+
+impl TryFrom<u32> for ProviderId {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            1 => ProviderId::Primary,
+            2 => ProviderId::Csp,
+            3 => ProviderId::Ksp,
+            0x80000001 => ProviderId::CardModule,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidParameter,
+                    format!("Invalid provider id: {}", value),
+                ))
+            }
+        })
+    }
+}
+
+impl From<ProviderId> for u32 {
+    fn from(value: ProviderId) -> Self {
+        value as u32
+    }
+}
+
 /// This trait provides interface for all available smart card related functions in the `winscard.h`.
 ///
 /// # MSDN
@@ -268,7 +543,14 @@ pub trait WinScard {
     /// The SCardControl function gives you direct control of the reader.
     /// You can call it any time after a successful call to SCardConnect and before a successful call to SCardDisconnect.
     /// The effect on the state of the reader depends on the control code.
-    fn control(&mut self, code: ControlCode, input: &[u8]) -> WinScardResult<Vec<u8>>;
+    /// This method assumes that there is no output data. Otherwise, then use the [WinScard::control_with_output] method.
+    fn control(&mut self, code: ControlCode, input: &[u8]) -> WinScardResult<()>;
+
+    /// [SCardControl](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcontrol)
+    ///
+    /// This function does the same as the [WinScard::control] but allows the used to pass a buffer for
+    /// the operation's output data. The returned value is the number of bytes written to the output buffer.
+    fn control_with_output(&mut self, code: ControlCode, input: &[u8], output: &mut [u8]) -> WinScardResult<usize>;
 
     /// [SCardTransmit](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardtransmit)
     ///
@@ -286,7 +568,37 @@ pub trait WinScard {
     ///
     /// The SCardEndTransaction function completes a previously declared transaction,
     /// allowing other applications to resume interactions with the card.
-    fn end_transaction(&mut self) -> WinScardResult<()>;
+    fn end_transaction(&mut self, disposition: ReaderAction) -> WinScardResult<()>;
+
+    /// [SCardReconnect](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreconnect)
+    ///
+    /// The SCardReconnect function reestablishes an existing connection between the calling application and a smart card.
+    /// This function moves a card handle from direct access to general access, or acknowledges and clears an error condition that is preventing further access to the card.
+    fn reconnect(
+        &mut self,
+        share_mode: ShareMode,
+        preferred_protocol: Option<Protocol>,
+        initialization: ReaderAction,
+    ) -> WinScardResult<Protocol>;
+
+    /// [SCardGetAttrib](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib)
+    ///
+    /// The SCardGetAttrib function retrieves the current reader attributes for the given handle.
+    /// It does not affect the state of the reader, driver, or card.
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>>;
+
+    /// [SCardSetAttrib](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardsetattrib)
+    ///
+    /// The SCardSetAttrib function sets the given reader attribute for the given handle. It does not affect
+    /// the state of the reader, reader driver, or smart card. Not all attributes are supported
+    /// by all readers (nor can they be set at all times) as many of the attributes are under direct control of the transport protocol.
+    fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()>;
+
+    /// [SCardDisconnect](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scarddisconnect)
+    ///
+    /// The SCardDisconnect function terminates a connection previously opened between the calling application and
+    /// a smart card in the target reader.
+    fn disconnect(&mut self, disposition: ReaderAction) -> WinScardResult<()>;
 }
 
 /// This trait provides interface for all available smart card context (resource manager) related
@@ -306,12 +618,18 @@ pub trait WinScardContext {
         reader_name: &str,
         share_mode: ShareMode,
         protocol: Option<Protocol>,
-    ) -> WinScardResult<Box<dyn WinScard>>;
+    ) -> WinScardResult<ScardConnectData>;
 
     /// [SCardListReadersW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadersw)
     ///
     /// Provides the list of readers within a set of named reader groups, eliminating duplicates.
-    fn list_readers(&self) -> Vec<Cow<str>>;
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>>;
+
+    /// [SCardListCardsW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistcardsw)
+    ///
+    /// The SCardListCards function searches the smart card database and provides a list of named cards previously
+    /// introduced to the system by the user.
+    fn list_cards(&self, atr: Option<&[u8]>, required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>>;
 
     /// [SCardGetDeviceTypeIdW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetdevicetypeidw)
     ///
@@ -333,10 +651,34 @@ pub trait WinScardContext {
     /// [SCardReadCacheW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreadcachew)
     ///
     /// The SCardReadCache function retrieves the value portion of a name-value pair from the global cache maintained by the Smart Card Resource Manager.
-    fn read_cache(&self, key: &str) -> Option<&[u8]>;
+    fn read_cache(&self, card_id: Uuid, freshness_counter: u32, key: &str) -> WinScardResult<Cow<[u8]>>;
 
     /// [SCardWriteCacheW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardwritecachew)
     ///
     /// The SCardWriteCache function writes a name-value pair from a smart card to the global cache maintained by the Smart Card Resource Manager.
-    fn write_cache(&mut self, key: String, value: Vec<u8>);
+    fn write_cache(&mut self, card_id: Uuid, freshness_counter: u32, key: String, value: Vec<u8>)
+        -> WinScardResult<()>;
+
+    /// [SCardListReaderGroupsW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadergroupsw)
+    ///
+    /// The SCardListReaderGroups function provides the list of reader groups that have previously been introduced to the system.
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>>;
+
+    /// [SCardCancel](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcancel)
+    ///
+    /// The SCardCancel function terminates all outstanding actions within a specific resource manager context.
+    /// The only requests that you can cancel are those that require waiting for external action by the smart card or user.
+    /// Any such outstanding action requests will terminate with a status indication that the action was canceled.
+    fn cancel(&mut self) -> WinScardResult<()>;
+
+    /// [SCardGetStatusChangeW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew)
+    ///
+    /// The SCardGetStatusChange function blocks execution until the current availability of the cards in a specific set of readers changes.
+    fn get_status_change(&self, timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()>;
+
+    /// [SCardGetCardTypeProviderNameW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetcardtypeprovidernamew)
+    ///
+    /// The SCardGetCardTypeProviderName function returns the name of the module (dynamic link library) that contains the provider for
+    /// a given card name and provider type.
+    fn get_card_type_provider_name(&self, card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<str>>;
 }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -25,7 +25,7 @@ whoami = "1.4"
 sspi = { path = "..", features = ["network_client", "dns_resolver"] }
 ffi-types = { path = "../crates/ffi-types", features = ["winscard"], optional = true }
 picky-asn1-der = "0.4"
-
+uuid = { version = "1.4", default-features = false }
 winscard = { path = "../crates/winscard", features = ["std"], optional = true }
 
 # logging

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", 
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
-windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi"] }
+windows-sys = { version = "0.48", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader"] }
 
 [dev-dependencies]
 sspi = { path = "..", features = ["network_client", "dns_resolver", "test_data"] }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -10,4 +10,5 @@ pub mod sspi;
 mod utils;
 #[cfg(feature = "scard")]
 #[deny(unsafe_op_in_unsafe_fn)]
+#[warn(clippy::undocumented_unsafe_blocks)]
 pub mod winscard;

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -358,11 +358,10 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 fn collect_smart_card_creds(username: &[u8], password: &[u8]) -> Result<SmartCardIdentityBuffers> {
     if username.contains(&b'@') {
         info!("Trying to collect smart card creds...");
-        use winscard::SmartCardInfo;
+        use winscard::{SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
         use crate::sspi::utils::raw_wide_str_trim_nulls;
         use crate::utils::str_encode_utf16;
-        use crate::winscard::scard_context::{DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
 
         match SmartCardInfo::try_from_env() {
             Ok(smart_card_info) => {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -17,17 +17,14 @@ pub unsafe fn c_w_str_to_string(s: *const u16) -> String {
 }
 
 pub unsafe fn raw_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
-    unsafe { from_raw_parts(raw_buffer, len) }
-        .iter()
-        .map(|c| *c as u8)
-        .collect()
+    unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
 }
 
 pub fn str_to_w_buff(data: &str) -> Vec<u16> {
     data.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
-#[cfg(all(feature = "scard", target_os = "windows"))]
+#[cfg(any(feature = "scard", feature = "tsssp"))]
 pub fn str_encode_utf16(data: &str) -> Vec<u8> {
     data.encode_utf16().flat_map(|c| c.to_le_bytes()).collect()
 }

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -27,7 +27,7 @@ pub fn str_to_w_buff(data: &str) -> Vec<u16> {
     data.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
-#[cfg(feature = "scard")]
+#[cfg(all(feature = "scard", target_os = "windows"))]
 pub fn str_encode_utf16(data: &str) -> Vec<u8> {
     data.encode_utf16().flat_map(|c| c.to_le_bytes()).collect()
 }

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -14,6 +14,7 @@ pub const SCARD_AUTOALLOCATE: u32 = 0xffffffff;
 /// * write data in the provided buffer.
 /// * write data length of the requested data in the provided length pointer.
 /// * allocate data by ourselves and write data pointer in the provided buffer.
+#[instrument(level = "debug", ret)]
 pub unsafe fn build_buf_request_type<'data>(
     p_buf: LpByte,
     pcb_buf: LpDword,
@@ -43,6 +44,7 @@ pub unsafe fn build_buf_request_type<'data>(
 
 /// This function behaves as the [build_buf_request_type] but here it expects a pointer
 /// to the `u16` buffer instead of `u8`. So, the buffer length is multiplied by two.
+#[instrument(level = "debug", ret)]
 pub unsafe fn build_buf_request_type_wide<'data>(
     p_buf: LpWStr,
     pcb_buf: LpDword,
@@ -71,11 +73,8 @@ pub unsafe fn build_buf_request_type_wide<'data>(
 }
 
 /// Saves the resulting data after the [RequestedBufferType] processing.
+#[instrument(level = "debug", ret)]
 pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
-    if p_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
-    }
-
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
@@ -91,12 +90,18 @@ pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) 
             // The user requested only the requested data length, so we just return it.
             *pcb_buf = len.try_into()?
         },
-        // SAFETY: We've checked for null above.
-        OutBuffer::Allocated(data) => unsafe {
-            // We allocated a new memory for the requested data, so we need to save the buffer and buffer length.
-            *(p_buf as *mut *mut u8) = data.as_mut_ptr();
-            *pcb_buf = data.len().try_into()?;
-        },
+        OutBuffer::Allocated(data) => {
+            if p_buf.is_null() {
+                return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
+            }
+
+            // SAFETY: We've checked for null above.
+            unsafe {
+                // We allocated a new memory for the requested data, so we need to save the buffer and buffer length.
+                *(p_buf as *mut *mut u8) = data.as_mut_ptr();
+                *pcb_buf = data.len().try_into()?;
+            }
+        }
     }
 
     Ok(())
@@ -104,11 +109,8 @@ pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) 
 
 /// This function behaves as the [save_out_buf] but here it expects a pointer
 /// to the `u16` buffer instead of `u8`. So, the buffer length is divided by two.
+#[instrument(level = "debug", ret)]
 pub unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
-    if p_buf.is_null() {
-        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
-    }
-
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
@@ -118,11 +120,17 @@ pub unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDw
         OutBuffer::Written(len) => unsafe { *pcb_buf = u32::try_from(len)? / 2 },
         // SAFETY: We've checked for null above.
         OutBuffer::DataLen(len) => unsafe { *pcb_buf = u32::try_from(len)? / 2 },
-        // SAFETY: We've checked for null above.
-        OutBuffer::Allocated(data) => unsafe {
-            *(p_buf as *mut *mut u8) = data.as_mut_ptr();
-            *pcb_buf = u32::try_from(data.len())? / 2;
-        },
+        OutBuffer::Allocated(data) => {
+            if p_buf.is_null() {
+                return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
+            }
+
+            // SAFETY: We've checked for null above.
+            unsafe {
+                *(p_buf as *mut *mut u8) = data.as_mut_ptr();
+                *pcb_buf = u32::try_from(data.len())? / 2;
+            }
+        }
     }
 
     Ok(())

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -1,121 +1,129 @@
-use std::iter::once;
 use std::slice::from_raw_parts_mut;
 
-use ffi_types::{LpByte, LpDword, LpStr, LpWStr};
+use ffi_types::{LpByte, LpDword, LpWStr};
 use winscard::{Error, ErrorKind, WinScardResult};
 
-use super::scard_handle::WinScardContextHandle;
-use crate::utils::str_to_w_buff;
+use super::scard_handle::{OutBuffer, RequestedBufferType};
 
 pub const SCARD_AUTOALLOCATE: u32 = 0xffffffff;
 
-pub unsafe fn copy_buff(
-    context: &mut WinScardContextHandle,
-    raw_buff: LpByte,
-    raw_buff_len: LpDword,
-    buff_to_copy: &[u8],
-) -> WinScardResult<()> {
-    let buff_to_copy_len = buff_to_copy.len().try_into()?;
-
-    if raw_buff.is_null() {
-        unsafe {
-            *raw_buff_len = buff_to_copy_len;
-        }
-        return Ok(());
+/// This function decides how to treat the provided buffer by the user and how to return the requested data.
+///
+/// When the user requests some data from the smart card using the WinSCard API, we have three ways
+/// how to handle it:
+/// * write data in the provided buffer.
+/// * write data length of the requested data in the provided length pointer.
+/// * allocate data by ourselves and write data pointer in the provided buffer.
+pub unsafe fn build_buf_request_type<'data>(
+    p_buf: LpByte,
+    pcb_buf: LpDword,
+) -> WinScardResult<RequestedBufferType<'data>> {
+    if pcb_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
 
-    if unsafe { *raw_buff_len } == SCARD_AUTOALLOCATE {
-        // Allocate a new buffer and write an address into raw_buff.
-        let allocated = context.allocate_buffer(buff_to_copy.len())?;
-        unsafe {
-            *(raw_buff as *mut *mut u8) = allocated;
-            *raw_buff_len = buff_to_copy_len;
-            from_raw_parts_mut(allocated, buff_to_copy.len()).copy_from_slice(buff_to_copy);
-        }
+    if p_buf.is_null() {
+        // If this value is NULL, we ignore the buffer length, writes the length of the buffer that
+        // would have been returned if this parameter had not been NULL, and returns a success code.
+        return Ok(RequestedBufferType::Length);
+    }
+    // SAFETY: The `pcb_buf` parameter cannot be null. We've checked for it above.
+    if unsafe { *pcb_buf } == SCARD_AUTOALLOCATE {
+        // If the buffer length is specified as SCARD_AUTOALLOCATE, then data pointer is
+        // converted to a pointer to a byte pointer, and receives the address of a block of memory
+        // containing the attribute.
+        Ok(RequestedBufferType::Allocate)
     } else {
-        if buff_to_copy_len > unsafe { *raw_buff_len } {
-            return Err(Error::new(
-                ErrorKind::InsufficientBuffer,
-                format!(
-                    "expected at least {} bytes but got {}.",
-                    buff_to_copy_len, *raw_buff_len
-                ),
-            ));
-        }
-        unsafe {
-            *raw_buff_len = buff_to_copy_len;
-            from_raw_parts_mut(raw_buff, buff_to_copy.len()).copy_from_slice(buff_to_copy);
-        }
+        // SAFETY: `p_buf` and `pcb_buf` parameters can't be null. We've checked for it above.
+        Ok(RequestedBufferType::Buf(unsafe {
+            from_raw_parts_mut(p_buf, (*pcb_buf).try_into()?)
+        }))
+    }
+}
+
+/// This function behaves as the [build_buf_request_type] but here it expects a pointer
+/// to the `u16` buffer instead of `u8`. So, the buffer length is multiplied by two.
+pub unsafe fn build_buf_request_type_wide<'data>(
+    p_buf: LpWStr,
+    pcb_buf: LpDword,
+) -> WinScardResult<RequestedBufferType<'data>> {
+    if pcb_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
+    }
+
+    Ok(if p_buf.is_null() {
+        // If this value is NULL, SCardGetAttrib ignores the buffer length supplied in pcbAttrLen,
+        // writes the length of the buffer that would have been returned if this parameter had not been NULL
+        // to pcbAttrLen, and returns a success code.
+        RequestedBufferType::Length
+    } else if
+    // SAFETY: The `pcb_buf` parameter cannot be null. We've checked for it above.
+    unsafe { *pcb_buf } == SCARD_AUTOALLOCATE {
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib
+        //
+        // If the buffer length is specified as SCARD_AUTOALLOCATE, then pbAttr is converted to a pointer
+        // to a byte pointer, and receives the address of a block of memory containing the attribute.
+        RequestedBufferType::Allocate
+    } else {
+        // SAFETY: `p_buf` and `pcb_buf` parameters can't be null. We've checked for it above.
+        RequestedBufferType::Buf(unsafe { from_raw_parts_mut(p_buf as *mut u8, usize::try_from(*pcb_buf)? * 2) })
+    })
+}
+
+/// Saves the resulting data after the [RequestedBufferType] processing.
+pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
+    if p_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
+    }
+
+    if pcb_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
+    }
+
+    match out_buf {
+        // SAFETY: We've checked for null above.
+        OutBuffer::Written(len) => unsafe {
+            // We already wrote the requested data in the provided buffer, so we only need to write the data length.
+            *pcb_buf = len.try_into()?
+        },
+        // SAFETY: We've checked for null above.
+        OutBuffer::DataLen(len) => unsafe {
+            // The user requested only the requested data length, so we just return it.
+            *pcb_buf = len.try_into()?
+        },
+        // SAFETY: We've checked for null above.
+        OutBuffer::Allocated(data) => unsafe {
+            // We allocated a new memory for the requested data, so we need to save the buffer and buffer length.
+            *(p_buf as *mut *mut u8) = data.as_mut_ptr();
+            *pcb_buf = data.len().try_into()?;
+        },
     }
 
     Ok(())
 }
 
-pub unsafe fn copy_w_buff(
-    context: &mut WinScardContextHandle,
-    raw_buf: LpWStr,
-    raw_buf_len: LpDword,
-    buff_to_copy: &[u16],
-) -> WinScardResult<()> {
-    let buff_to_copy_len = buff_to_copy.len().try_into()?;
-
-    if raw_buf.is_null() {
-        unsafe {
-            *raw_buf_len = buff_to_copy_len;
-        }
-        return Ok(());
+/// This function behaves as the [save_out_buf] but here it expects a pointer
+/// to the `u16` buffer instead of `u8`. So, the buffer length is divided by two.
+pub unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
+    if p_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "p_buf cannot be null"));
     }
 
-    if unsafe { *raw_buf_len } == SCARD_AUTOALLOCATE {
-        // Allocate a new buffer and write an address into raw_buff.
-        let allocated = context.allocate_buffer(buff_to_copy.len() * 2)? as *mut u16;
-        unsafe {
-            *(raw_buf as *mut *mut u16) = allocated;
-            *raw_buf_len = buff_to_copy_len;
-            from_raw_parts_mut(allocated, buff_to_copy.len()).copy_from_slice(buff_to_copy);
-        }
-    } else {
-        if buff_to_copy_len > unsafe { *raw_buf_len } {
-            return Err(Error::new(
-                ErrorKind::InsufficientBuffer,
-                format!("expected at least {} bytes but got {}.", buff_to_copy_len, *raw_buf_len),
-            ));
-        }
-        unsafe {
-            *raw_buf_len = buff_to_copy_len;
-            from_raw_parts_mut(raw_buf, buff_to_copy.len()).copy_from_slice(buff_to_copy);
-        }
+    if pcb_buf.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
+    }
+
+    match out_buf {
+        // SAFETY: We've checked for null above.
+        OutBuffer::Written(len) => unsafe { *pcb_buf = u32::try_from(len)? / 2 },
+        // SAFETY: We've checked for null above.
+        OutBuffer::DataLen(len) => unsafe { *pcb_buf = u32::try_from(len)? / 2 },
+        // SAFETY: We've checked for null above.
+        OutBuffer::Allocated(data) => unsafe {
+            *(p_buf as *mut *mut u8) = data.as_mut_ptr();
+            *pcb_buf = u32::try_from(data.len())? / 2;
+        },
     }
 
     Ok(())
-}
-
-pub unsafe fn write_multistring_a(
-    context: &mut WinScardContextHandle,
-    strings: &[&str],
-    dest: LpStr,
-    dest_len: LpDword,
-) -> WinScardResult<()> {
-    let buffer: Vec<u8> = strings
-        .iter()
-        .flat_map(|reader| reader.as_bytes().iter().cloned().chain(once(0)))
-        .chain(once(0))
-        .collect();
-
-    unsafe { copy_buff(context, dest, dest_len, &buffer) }
-}
-
-pub unsafe fn write_multistring_w(
-    context: &mut WinScardContextHandle,
-    strings: &[&str],
-    dest: LpWStr,
-    dest_len: LpDword,
-) -> WinScardResult<()> {
-    let buffer: Vec<u16> = strings
-        .iter()
-        .flat_map(|reader| str_to_w_buff(reader))
-        .chain(once(0))
-        .collect();
-
-    unsafe { copy_w_buff(context, dest, dest_len, &buffer) }
 }

--- a/ffi/src/winscard/macros.rs
+++ b/ffi/src/winscard/macros.rs
@@ -4,6 +4,13 @@ macro_rules! check_handle {
             return u32::from(winscard::ErrorKind::InvalidHandle);
         }
     }};
+    ($x:expr, $name:expr) => {{
+        use winscard::{Error, ErrorKind};
+
+        if $x == 0 {
+            return Err(Error::new(ErrorKind::InvalidHandle, $name));
+        }
+    }};
 }
 
 macro_rules! try_execute {
@@ -31,6 +38,13 @@ macro_rules! check_null {
     ($x:expr) => {{
         if $x.is_null() {
             return u32::from(winscard::ErrorKind::InvalidParameter);
+        }
+    }};
+    ($x:expr, $name:expr) => {{
+        use winscard::{Error, ErrorKind};
+
+        if $x.is_null() {
+            return Err(Error::new(ErrorKind::InvalidParameter, $name));
         }
     }};
 }

--- a/ffi/src/winscard/mod.rs
+++ b/ffi/src/winscard/mod.rs
@@ -9,6 +9,7 @@ use crate::utils::into_raw_ptr;
 #[macro_use]
 mod macros;
 mod buf_alloc;
+pub mod pcsc_lite;
 pub mod scard;
 pub mod scard_context;
 mod scard_handle;

--- a/ffi/src/winscard/mod.rs
+++ b/ffi/src/winscard/mod.rs
@@ -13,6 +13,7 @@ pub mod pcsc_lite;
 pub mod scard;
 pub mod scard_context;
 mod scard_handle;
+mod system_scard;
 
 // The constants below are not documented anywhere and were discovered during debugging.
 // Related example: https://github.com/bluetech/pcsc-rust/blob/b397cc8e3834a1dc791631105f37f34d321c8696/pcsc/src/lib.rs#L605-L613

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -1,0 +1,191 @@
+use ffi_types::winscard::{ScardIoRequest, ScardReaderStateA, ScardStatus};
+use ffi_types::{Dword, LpByte, LpCByte, LpCStr, LpCVoid, LpDword, LpStr, LpVoid};
+
+use super::{LpScardContext, LpScardHandle, ScardContext, ScardHandle};
+
+/// Creates an Application Context to the PC/SC Resource Manager.
+///
+/// [SCardEstablishContext](https://pcsclite.apdu.fr/api/group__API.html#gaa1b8970169fd4883a6dc4a8f43f19b67)
+/// This must be the first WinSCard function called in a PC/SC application. Each thread of an application shall use its own `SCARDCONTEXT`,
+/// unless calling `SCardCancel()`, which MUST be called with the same context as the context used to call `SCardGetStatusChange()`.
+pub type SCardEstablishContextFn = unsafe extern "system" fn(Dword, LpVoid, LpVoid, LpScardContext) -> ScardStatus;
+
+/// Destroys a communication context to the PC/SC Resource Manager.
+///
+/// [SCardReleaseContext](https://pcsclite.apdu.fr/api/group__API.html#ga6aabcba7744c5c9419fdd6404f73a934)
+/// This must be the last function called in a PC/SC application.
+pub type SCardReleaseContextFn = unsafe extern "system" fn(h_context: ScardContext) -> ScardStatus;
+
+/// Establishes a connection to the reader specified in * szReader.
+///
+/// [SCardConnect](https://pcsclite.apdu.fr/api/group__API.html#ga4e515829752e0a8dbc4d630696a8d6a5)
+pub type SCardConnectFn = unsafe extern "system" fn(
+    h_context: ScardContext,
+    sz_reader: LpCStr,
+    dw_share_mode: Dword,
+    dw_preferred_protocols: Dword,
+    ph_card: LpScardHandle,
+    pdw_active_protocol: LpDword,
+) -> ScardStatus;
+
+/// Reestablishes a connection to a reader that was previously connected to using `SCardConnect()`.
+///
+/// [SCardReconnect](https://pcsclite.apdu.fr/api/group__API.html#gad5d4393ca8c470112ad9468c44ed8940)
+/// In a multi application environment it is possible for an application to reset the card in shared mode.
+/// When this occurs any other application trying to access certain commands will be returned the value `SCARD_W_RESET_CARD`.
+/// When this occurs `SCardReconnect()` must be called in order to acknowledge that the card was reset and allow it to change its state accordingly.
+pub type SCardReconnectFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    dw_share_mode: Dword,
+    dw_preferred_protocols: Dword,
+    dw_initialization: Dword,
+    pdw_active_protocol: LpDword,
+) -> ScardStatus;
+
+/// Terminates a connection made through SCardConnect().
+///
+/// [SCardDisconnect](https://pcsclite.apdu.fr/api/group__API.html#ga4be198045c73ec0deb79e66c0ca1738a)
+pub type SCardDisconnectFn = unsafe extern "system" fn(h_card: ScardHandle, dw_disposition: Dword) -> ScardStatus;
+
+/// Establishes a temporary exclusive access mode for doing a series of commands in a transaction.
+///
+/// [SCardBeginTransaction](https://pcsclite.apdu.fr/api/group__API.html#gaddb835dce01a0da1d6ca02d33ee7d861)
+/// You might want to use this when you are selecting a few files and then writing a large file,
+/// so you can make sure that another application will not change the current file. If another application has a lock on this reader
+/// or this application is in `SCARD_SHARE_EXCLUSIVE` the function will block until it can continue.
+pub type SCardBeginTransactionFn = unsafe extern "system" fn(h_card: ScardHandle) -> ScardStatus;
+
+/// Ends a previously begun transaction.
+///
+/// [SCardEndTransaction](https://pcsclite.apdu.fr/api/group__API.html#gae8742473b404363e5c587f570d7e2f3b)
+/// The calling application must be the owner of the previously begun transaction or an error will occur.
+pub type SCardEndTransactionFn = unsafe extern "system" fn(h_card: ScardHandle, dw_disposition: Dword) -> ScardStatus;
+
+/// Returns the current status of the reader connected to by hCard.
+///
+/// [SCardStatus](https://pcsclite.apdu.fr/api/group__API.html#gae49c3c894ad7ac12a5b896bde70d0382)
+pub type SCardStatusFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    sz_reader_name: LpStr,
+    pcch_reader_len: LpDword,
+    pdw_state: LpDword,
+    pdw_protocol: LpDword,
+    pb_atr: LpByte,
+    pcb_atr_len: LpDword,
+) -> ScardStatus;
+
+/// Blocks execution until the current availability of the cards in a specific set of readers changes.
+///
+/// [SCardGetStatusChange](https://pcsclite.apdu.fr/api/group__API.html#ga33247d5d1257d59e55647c3bb717db24)
+pub type SCardGetStatusChangeFn = unsafe extern "system" fn(
+    h_context: ScardContext,
+    dw_timeout: Dword,
+    rg_reader_states: *mut ScardReaderStateA,
+    c_readers: Dword,
+) -> ScardStatus;
+
+/// Sends a command directly to the IFD Handler (reader driver) to be processed by the reader.
+///
+/// [SCardControl](https://pcsclite.apdu.fr/api/group__API.html#gac3454d4657110fd7f753b2d3d8f4e32f)
+/// This is useful for creating client side reader drivers for functions like PIN pads, biometrics,
+/// or other extensions to the normal smart card reader that are not normally handled by PC/SC.
+pub type SCardControlFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    dw_control_code: Dword,
+    pb_send_buffer: LpCVoid,
+    cb_send_length: Dword,
+    pb_recv_buffer: LpVoid,
+    cb_recv_length: Dword,
+    lp_bytes_returned: LpDword,
+) -> ScardStatus;
+
+/// Get an attribute from the IFD Handler (reader driver).
+///
+/// [SCardGetAttrib](https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602)
+pub type SCardGetAttribFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    dw_attr_id: Dword,
+    pb_attr: LpByte,
+    pcb_atr_len: LpDword,
+) -> ScardStatus;
+
+/// Set an attribute of the IFD Handler.
+///
+/// [SCardSetAttrib](https://pcsclite.apdu.fr/api/group__API.html#ga060f0038a4ddfd5dd2b8fadf3c3a2e4f)
+pub type SCardSetAttribFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    dw_attr_id: Dword,
+    pb_attr: LpCByte,
+    cb_attr_len: Dword,
+) -> ScardStatus;
+
+/// Sends an APDU to the smart card contained in the reader connected to by `SCardConnect()`.
+///
+/// [SCardTransmit](https://pcsclite.apdu.fr/api/group__API.html#ga9a2d77242a271310269065e64633ab99)
+pub type SCardTransmitFn = unsafe extern "system" fn(
+    h_card: ScardHandle,
+    poi_send_pci: *const ScardIoRequest,
+    pb_send_buffer: LpCByte,
+    cb_send_length: Dword,
+    poi_recv_pci: *mut ScardIoRequest,
+    pb_recv_buffer: LpByte,
+    pcb_recv_length: LpDword,
+) -> ScardStatus;
+
+/// Returns a list of currently available readers on the system.
+///
+/// [SCardListReaders](https://pcsclite.apdu.fr/api/group__API.html#ga93b07815789b3cf2629d439ecf20f0d9)
+pub type SCardListReadersFn = unsafe extern "system" fn(
+    h_context: ScardContext,
+    msz_groups: LpCStr,
+    msc_reader: LpStr,
+    pcch_readers: LpDword,
+) -> ScardStatus;
+
+/// Releases memory that has been returned from the resource manager using the `SCARD_AUTOALLOCATE` length designator.
+///
+/// [SCardFreeMemory](https://pcsclite.apdu.fr/api/group__API.html#ga0522241e3180cb05dfd166e28930e961)
+pub type SCardFreeMemoryFn = unsafe extern "system" fn(h_context: ScardContext, pv_mem: LpCVoid) -> ScardStatus;
+
+/// Returns a list of currently available reader groups on the system.
+///
+/// [SCardListReaderGroups](https://pcsclite.apdu.fr/api/group__API.html#ga9d970d086d5218e080d0079d63f9d496)
+pub type SCardListReaderGroupsFn =
+    unsafe extern "system" fn(h_context: ScardContext, msz_groups: LpStr, pcch_groups: LpDword) -> ScardStatus;
+
+/// Cancels a specific blocking `SCardGetStatusChange()` function.
+///
+/// [SCardCancel](https://pcsclite.apdu.fr/api/group__API.html#gaacbbc0c6d6c0cbbeb4f4debf6fbeeee6)
+/// MUST be called with the same `SCARDCONTEXT` as `SCardGetStatusChange()`.
+pub type SCardCancelFn = unsafe extern "system" fn(h_context: ScardContext) -> ScardStatus;
+
+/// Check if a [ScardContext] is valid.
+///
+/// [SCardIsValidContext](https://pcsclite.apdu.fr/api/group__API.html#ga722eb66bcc44d391f700ff9065cc080b).
+/// Call this function to determine whether a smart card context handle is still valid. After a smart card context handle
+/// has been returned by `SCardEstablishContext()`, it may become invalid if the resource manager service has been shut down.
+pub type SCardIsValidContextFn = unsafe extern "system" fn(h_context: ScardContext) -> ScardStatus;
+
+/// This structure contains all pcsc-lite API functions.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct PcscLiteApiFunctionTable {
+    pub SCardEstablishContext: SCardEstablishContextFn,
+    pub SCardReleaseContext: SCardReleaseContextFn,
+    pub SCardConnect: SCardConnectFn,
+    pub SCardReconnect: SCardReconnectFn,
+    pub SCardDisconnect: SCardDisconnectFn,
+    pub SCardBeginTransaction: SCardBeginTransactionFn,
+    pub SCardEndTransaction: SCardEndTransactionFn,
+    pub SCardStatus: SCardStatusFn,
+    pub SCardGetStatusChange: SCardGetStatusChangeFn,
+    pub SCardControl: SCardControlFn,
+    pub SCardGetAttrib: SCardGetAttribFn,
+    pub SCardSetAttrib: SCardSetAttribFn,
+    pub SCardTransmit: SCardTransmitFn,
+    pub SCardListReaders: SCardListReadersFn,
+    pub SCardFreeMemory: SCardFreeMemoryFn,
+    pub SCardListReaderGroups: SCardListReaderGroupsFn,
+    pub SCardCancel: SCardCancelFn,
+    pub SCardIsValidContext: SCardIsValidContextFn,
+}

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -1,0 +1,76 @@
+#![cfg(not(target_os = "windows"))]
+
+use std::borrow::Cow;
+use std::env;
+use std::ffi::CString;
+
+use libc::{dlopen, dlsym};
+use winscard::{Error, ErrorKind, WinScardResult};
+
+use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
+
+pub mod functions;
+
+/// `hContext` returned by `SCardEstablishContext()`.
+///
+/// https://pcsclite.apdu.fr/api/pcsclite_8h.html#a22530ffaff18b5d3e32260a5f1ce4abd
+pub type ScardContext = i32;
+
+/// Pointer to the [ScardContext].
+pub type LpScardContext = *mut ScardContext;
+
+/// `hCard` returned by `SCardConnect()`.
+///
+/// https://pcsclite.apdu.fr/api/pcsclite_8h.html#af328aca3e11de737ecd771bcf1f75fb5
+pub type ScardHandle = i32;
+
+/// Pointer to the [ScardHandle].
+pub type LpScardHandle = *mut ScardHandle;
+
+/// Path to the `pcsc-lite` library.
+///
+/// The user can use this environment variable to customize the `pcsc-lite` library loading.
+const PCSC_LITE_LIB_PATH_ENV: &str = "PCSC_LITE_LIB_PATH";
+
+pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
+    let pcsc_lite_path = if let Ok(lib_path) = env::var(PCSC_LITE_LIB_PATH_ENV) {
+        Cow::Owned(lib_path)
+    } else {
+        Cow::Borrowed("libpcsclite")
+    };
+    // SAFE: Rust string cannot contain `0` bytes.
+    let pcsc_lite_path = CString::new(pcsc_lite_path.as_ref()).expect("CString creation should not fail");
+
+    let handle = unsafe { dlopen(pcsc_lite_path.as_ptr(), 0) };
+    if handle.is_null() {
+        return Err(Error::new(ErrorKind::InternalError, "Can not load pcsc-lite library"));
+    }
+
+    macro_rules! load_fn {
+        ($func_name:literal) => {{
+            let fn_name = CString::new($func_name).expect("CString creation should not fail");
+            unsafe { std::mem::transmute(dlsym(handle, fn_name.as_ptr())) }
+        }};
+    }
+
+    Ok(PcscLiteApiFunctionTable {
+        SCardEstablishContext: load_fn!("SCardEstablishContext"),
+        SCardReleaseContext: load_fn!("SCardReleaseContext"),
+        SCardConnect: load_fn!("SCardConnect"),
+        SCardReconnect: load_fn!("SCardReconnect"),
+        SCardDisconnect: load_fn!("SCardDisconnect"),
+        SCardBeginTransaction: load_fn!("SCardBeginTransaction"),
+        SCardEndTransaction: load_fn!("SCardEndTransaction"),
+        SCardStatus: load_fn!("SCardStatus"),
+        SCardGetStatusChange: load_fn!("SCardGetStatusChange"),
+        SCardControl: load_fn!("SCardControl"),
+        SCardGetAttrib: load_fn!("SCardGetAttrib"),
+        SCardSetAttrib: load_fn!("SCardSetAttrib"),
+        SCardTransmit: load_fn!("SCardTransmit"),
+        SCardListReaders: load_fn!("SCardListReaders"),
+        SCardFreeMemory: load_fn!("SCardFreeMemory"),
+        SCardListReaderGroups: load_fn!("SCardListReaderGroups"),
+        SCardCancel: load_fn!("SCardCancel"),
+        SCardIsValidContext: load_fn!("SCardIsValidContext"),
+    })
+}

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -38,9 +38,9 @@ pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
     } else {
         Cow::Borrowed("libpcsclite")
     };
-    // SAFE: Rust string cannot contain `0` bytes.
-    let pcsc_lite_path = CString::new(pcsc_lite_path.as_ref()).expect("CString creation should not fail");
+    let pcsc_lite_path = CString::new(pcsc_lite_path.as_ref())?;
 
+    // SAFETY: The library path is type checked.
     let handle = unsafe { dlopen(pcsc_lite_path.as_ptr(), 0) };
     if handle.is_null() {
         return Err(Error::new(ErrorKind::InternalError, "Can not load pcsc-lite library"));
@@ -49,6 +49,8 @@ pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
     macro_rules! load_fn {
         ($func_name:literal) => {{
             let fn_name = CString::new($func_name).expect("CString creation should not fail");
+            // SAFETY: The `handle` is initialized and checked above. The function name should be correct
+            // because it's hardcoded in the code.
             unsafe { std::mem::transmute(dlsym(handle, fn_name.as_ptr())) }
         }};
     }

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -6,6 +6,7 @@ use ffi_types::winscard::{
     ScardContext, ScardHandle, ScardStatus,
 };
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpCWStr, LpDword, LpStr, LpVoid, LpWStr};
+#[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
 use winscard::winscard::Protocol;
 use winscard::{ErrorKind, WinScardResult};
@@ -68,14 +69,16 @@ pub unsafe extern "system" fn SCardConnectA(
         ErrorKind::InvalidParameter
     );
 
-    try_execute!(connect(
-        context,
-        &reader_name,
-        dw_share_mode,
-        dw_preferred_protocols,
-        ph_card,
-        pdw_active_protocol
-    ));
+    try_execute!(unsafe {
+        connect(
+            context,
+            reader_name,
+            dw_share_mode,
+            dw_preferred_protocols,
+            ph_card,
+            pdw_active_protocol,
+        )
+    });
 
     ErrorKind::Success.into()
 }

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -6,16 +6,18 @@ use ffi_types::winscard::{
     ScardContext, ScardHandle, ScardStatus,
 };
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpCWStr, LpDword, LpStr, LpVoid, LpWStr};
+use num_traits::FromPrimitive;
 #[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
-use winscard::winscard::{Protocol, ScardConnectData};
-use winscard::{ErrorKind, WinScardResult};
+use winscard::winscard::{AttributeId, Protocol, ScardConnectData, ShareMode};
+use winscard::{Error, ErrorKind, WinScardResult};
 
-use super::buf_alloc::{copy_buff, write_multistring_a, write_multistring_w};
+use super::buf_alloc::{build_buf_request_type, build_buf_request_type_wide, save_out_buf, save_out_buf_wide};
 use crate::utils::{c_w_str_to_string, into_raw_ptr};
 use crate::winscard::scard_handle::{
-    copy_io_request_to_scard_io_request, scard_context_to_winscard_context, scard_handle_to_winscard,
-    scard_io_request_to_io_request, WinScardContextHandle, WinScardHandle,
+    copy_io_request_to_scard_io_request, raw_scard_context_handle_to_scard_context_handle,
+    raw_scard_handle_to_scard_handle, scard_context_to_winscard_context, scard_handle_to_winscard,
+    scard_io_request_to_io_request, WinScardHandle,
 };
 
 unsafe fn connect(
@@ -26,9 +28,21 @@ unsafe fn connect(
     ph_card: LpScardHandle,
     pdw_active_protocol: LpDword,
 ) -> WinScardResult<()> {
+    if ph_card.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "ph_card cannot be null"));
+    }
+    if pdw_active_protocol.is_null() {
+        return Err(Error::new(
+            ErrorKind::InvalidParameter,
+            "pdw_active_protocol cannot be null",
+        ));
+    }
+
     let share_mode = dw_share_mode.try_into()?;
     let protocol = Protocol::from_bits(dw_preferred_protocols);
 
+    // SAFETY: The user should provide a valid context handle. If it's equal to zero, then
+    // the `scard_context_to_winscard_context` will return an error.
     let scard_context = unsafe { scard_context_to_winscard_context(context)? };
     let ScardConnectData { handle, protocol } = scard_context.connect(reader_name, share_mode, protocol)?;
 
@@ -36,9 +50,12 @@ unsafe fn connect(
 
     let raw_card_handle = into_raw_ptr(scard) as ScardHandle;
 
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
+    // SAFETY: The user should provide a valid context handle. The `context` can't be a zero, because
+    // the `scard_context_to_winscard_context` function didn't return an error.
+    let context = unsafe { raw_scard_context_handle_to_scard_context_handle(context) }?;
     context.add_scard(raw_card_handle)?;
 
+    // SAFETY: We've checked for null above.
     unsafe {
         *ph_card = raw_card_handle;
         *pdw_active_protocol = protocol.bits();
@@ -64,20 +81,30 @@ pub unsafe extern "system" fn SCardConnectA(
     check_null!(pdw_active_protocol);
 
     let reader_name = try_execute!(
+        // SAFETY: The `sz_reader` parameter is not null (checked above).
         unsafe { CStr::from_ptr(sz_reader as *const i8) }.to_str(),
         ErrorKind::InvalidParameter
     );
 
-    try_execute!(unsafe {
-        connect(
-            context,
-            reader_name,
-            dw_share_mode,
-            dw_preferred_protocols,
-            ph_card,
-            pdw_active_protocol,
-        )
-    });
+    try_execute!(
+        // SAFETY: All parameters are validated and/or type checked:
+        // * `context`: it's not a zero. All other guarantees should be provided by the user.
+        // * `reader_name`: it's a `&str`. So, it's a valid string slice.
+        // * `dw_share_mode`: we just pass it. I'll be validated later when transforming into a concrete Rust-type.
+        // * `dw_preferred_protocols`: the sme situation as for `dw_share_mode`.
+        // * `ph_card`: We've checked that it's not null. That's enough. We only write a value to it. Never read.
+        // * `pdw_active_protocol`: We've checked that it's not null. That's enough. We only write a value to it. Never read.
+        unsafe {
+            connect(
+                context,
+                reader_name,
+                dw_share_mode,
+                dw_preferred_protocols,
+                ph_card,
+                pdw_active_protocol,
+            )
+        }
+    );
 
     ErrorKind::Success.into()
 }
@@ -98,18 +125,28 @@ pub unsafe extern "system" fn SCardConnectW(
     check_null!(ph_card);
     check_null!(pdw_active_protocol);
 
+    // SAFETY: The `sz_reader` parameter is not null (checked above).
     let reader_name = unsafe { c_w_str_to_string(sz_reader) };
 
-    try_execute!(unsafe {
-        connect(
-            context,
-            &reader_name,
-            dw_share_mode,
-            dw_preferred_protocols,
-            ph_card,
-            pdw_active_protocol,
-        )
-    });
+    try_execute!(
+        // SAFETY: All parameters are validated and/or type checked:
+        // * `context`: it's not a zero. All other guarantees should be provided by the user.
+        // * `reader_name`: it's a `String`. So, it's a valid string.
+        // * `dw_share_mode`: we just pass it. I'll be validated later when transforming into a concrete Rust-type.
+        // * `dw_preferred_protocols`: the sme situation as for `dw_share_mode`.
+        // * `ph_card`: We've checked that it's not null. That's enough. We only write a value to it. Never read.
+        // * `pdw_active_protocol`: We've checked that it's not null. That's enough. We only write a value to it. Never read.
+        unsafe {
+            connect(
+                context,
+                &reader_name,
+                dw_share_mode,
+                dw_preferred_protocols,
+                ph_card,
+                pdw_active_protocol,
+            )
+        }
+    );
 
     ErrorKind::Success.into()
 }
@@ -117,28 +154,53 @@ pub unsafe extern "system" fn SCardConnectW(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardReconnect"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardReconnect(
-    _handle: ScardHandle,
-    _dw_share_mode: u32,
-    _dw_preferred_protocols: u32,
-    _dw_initialization: u32,
-    _pdw_active_protocol: LpDword,
+pub unsafe extern "system" fn SCardReconnect(
+    handle: ScardHandle,
+    dw_share_mode: u32,
+    dw_preferred_protocols: u32,
+    dw_initialization: u32,
+    pdw_active_protocol: LpDword,
 ) -> ScardStatus {
-    ErrorKind::UnsupportedFeature.into()
+    check_handle!(handle);
+    check_null!(pdw_active_protocol);
+
+    let share_mode = try_execute!(ShareMode::try_from(dw_share_mode));
+    let protocol = Protocol::from_bits(dw_preferred_protocols);
+    let initialization = try_execute!(dw_initialization.try_into(), ErrorKind::InvalidParameter);
+
+    let scard = try_execute!(
+        // SAFETY: The `handle` is not equal to zero (checked above). All other guarantees should be provided by the user.
+        unsafe { scard_handle_to_winscard(handle) }
+    );
+    let active_protocol = try_execute!(scard.reconnect(share_mode, protocol, initialization));
+
+    // SAFETY: `pdw_active_protocol` is checked above, so it is guaranteed not NULL.
+    unsafe {
+        *pdw_active_protocol = active_protocol.bits();
+    }
+
+    ErrorKind::Success.into()
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardDisconnect"))]
 #[instrument(ret)]
 #[no_mangle]
-pub unsafe extern "system" fn SCardDisconnect(handle: ScardHandle, _dw_disposition: u32) -> ScardStatus {
+pub unsafe extern "system" fn SCardDisconnect(handle: ScardHandle, dw_disposition: u32) -> ScardStatus {
     check_handle!(handle);
 
-    let scard = unsafe { Box::from_raw(handle as *mut WinScardHandle) };
-    if let Some(context) = unsafe { (scard.context() as *mut WinScardContextHandle).as_mut() } {
+    let scard = try_execute!(
+        // SAFETY: The `handle` is not equal to zero (checked above).
+        unsafe { raw_scard_handle_to_scard_handle(handle) }
+    );
+    try_execute!(scard
+        .scard_mut()
+        .disconnect(try_execute!(dw_disposition.try_into(), ErrorKind::InvalidParameter)));
+
+    if let Ok(context) = scard.context() {
         if context.remove_scard(handle) {
-            info!(?handle, "Successfully disconnected!");
+            info!(?handle, "Successfully disconnected");
         } else {
-            warn!("ScardHandle does not belong to the specified context.")
+            warn!("ScardHandle does not belong to the specified context")
         }
     }
 
@@ -150,6 +212,8 @@ pub unsafe extern "system" fn SCardDisconnect(handle: ScardHandle, _dw_dispositi
 #[no_mangle]
 pub unsafe extern "system" fn SCardBeginTransaction(handle: ScardHandle) -> ScardStatus {
     check_handle!(handle);
+
+    // SAFETY: The `handle` is not equal to zero (checked above).
     let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
 
     try_execute!(scard.begin_transaction());
@@ -162,6 +226,8 @@ pub unsafe extern "system" fn SCardBeginTransaction(handle: ScardHandle) -> Scar
 #[no_mangle]
 pub unsafe extern "system" fn SCardEndTransaction(handle: ScardHandle, dw_disposition: u32) -> ScardStatus {
     check_handle!(handle);
+
+    // SAFETY: The `handle` is not equal to zero (checked above).
     let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
 
     try_execute!(scard.end_transaction(try_execute!(dw_disposition.try_into())));
@@ -210,21 +276,27 @@ pub unsafe extern "system" fn SCardStatusA(
     // it's not specified in a docs, but `msclmd.dll` can invoke this function with pb_atr = 0.
     check_null!(pcb_atr_len);
 
-    let scard = unsafe { (handle as *mut WinScardHandle).as_ref().unwrap() };
-    let status = try_execute!(scard.scard().status());
-    check_handle!(scard.context());
+    // SAFETY: The `handle` is not zero. All other guarantees should be provided by the user.
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
+    // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
+    let readers_buf_type = try_execute!(unsafe { build_buf_request_type(msz_reader_names, pcch_reader_len) });
+    // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
+    // and the `pcb_atr_len` parameter cannot be null (checked above).
+    let atr_buf_type = try_execute!(unsafe { build_buf_request_type(pb_atr, pcb_atr_len) });
 
-    let readers = status.readers.iter().map(|reader| reader.as_ref()).collect::<Vec<_>>();
-    let context = unsafe { (scard.context() as *mut WinScardContextHandle).as_mut() }.unwrap();
-    try_execute!(unsafe { write_multistring_a(context, &readers, msz_reader_names, pcch_reader_len) });
+    let status = try_execute!(scard.status(readers_buf_type, atr_buf_type));
+
+    // SAFETY: It's safe to deref because `pdw_state` and `pdw_protocol` parameters are not null (checked above).
     unsafe {
         *pdw_state = status.state.into();
         *pdw_protocol = status.protocol.bits();
     }
 
-    if !pb_atr.is_null() {
-        try_execute!(unsafe { copy_buff(context, pb_atr, pcb_atr_len, status.atr.as_ref()) });
-    }
+    // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
+    try_execute!(unsafe { save_out_buf(status.readers, msz_reader_names, pcch_reader_len) });
+
+    // SAFETY: `pb_atr` can be null. `pcb_atr_len` can not be null and checked above.
+    try_execute!(unsafe { save_out_buf(status.atr, pb_atr, pcb_atr_len) });
 
     ErrorKind::Success.into()
 }
@@ -250,21 +322,27 @@ pub unsafe extern "system" fn SCardStatusW(
     // it's not specified in a docs, but `msclmd.dll` can invoke this function with pb_atr = 0.
     check_null!(pcb_atr_len);
 
-    let scard = unsafe { (handle as *mut WinScardHandle).as_ref() }.unwrap();
-    let status = try_execute!(scard.scard().status());
-    check_handle!(scard.context());
+    // SAFETY: The `handle` is not zero. All other guarantees should be provided by the user.
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
+    // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
+    let readers_buf_type = try_execute!(unsafe { build_buf_request_type_wide(msz_reader_names, pcch_reader_len) });
+    // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
+    // and the `pcb_atr_len` parameter cannot be null (checked above).
+    let atr_buf_type = try_execute!(unsafe { build_buf_request_type(pb_atr, pcb_atr_len) });
 
-    let readers = status.readers.iter().map(|reader| reader.as_ref()).collect::<Vec<_>>();
-    let context = unsafe { (scard.context() as *mut WinScardContextHandle).as_mut() }.unwrap();
-    try_execute!(unsafe { write_multistring_w(context, &readers, msz_reader_names, pcch_reader_len) });
+    let status = try_execute!(scard.status_wide(readers_buf_type, atr_buf_type));
+
+    // SAFETY: It's safe to deref because `pdw_state` and `pdw_protocol` parameters are not null (checked above).
     unsafe {
         *pdw_state = status.state.into();
         *pdw_protocol = status.protocol.bits();
     }
 
-    if !pb_atr.is_null() {
-        try_execute!(unsafe { copy_buff(context, pb_atr, pcb_atr_len, status.atr.as_ref()) });
-    }
+    // SAFETY: The `msz_reader_names` and `pcch_reader_len` parameters are not null (cheked above).
+    try_execute!(unsafe { save_out_buf_wide(status.readers, msz_reader_names, pcch_reader_len) });
+
+    // SAFETY: `pb_atr` can be null. `pcb_atr_len` can not be null and checked above.
+    try_execute!(unsafe { save_out_buf(status.atr, pb_atr, pcb_atr_len) });
 
     ErrorKind::Success.into()
 }
@@ -283,9 +361,15 @@ pub unsafe extern "system" fn SCardTransmit(
 ) -> ScardStatus {
     check_handle!(handle);
     check_null!(pio_send_pci);
+    check_null!(pb_send_buffer);
+    check_null!(pcb_recv_length);
+
+    // SAFETY: The `handle` is not null. All other guarantees should be provided by the user.
     let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
 
+    // SAFETY: The `pio_send_pci` parameter cannot be null (checked above).
     let io_request = try_execute!(unsafe { scard_io_request_to_io_request(pio_send_pci) });
+    // SAFETY: The `pb_send_buffer` parameter cannot be null (checked above).
     let input_apdu = unsafe {
         from_raw_parts(
             pb_send_buffer,
@@ -296,21 +380,37 @@ pub unsafe extern "system" fn SCardTransmit(
     let out_data = try_execute!(scard.transmit(io_request, input_apdu));
 
     let out_apdu_len = out_data.output_apdu.len();
-    if out_apdu_len > try_execute!(unsafe { *pcb_recv_length }.try_into(), ErrorKind::InsufficientBuffer)
+    if out_apdu_len
+        > try_execute!(
+            // SAFETY: The `pcb_recv_length` parameter cannot be null (checked above). So, it's safe to deref.
+            unsafe { *pcb_recv_length }.try_into(),
+            ErrorKind::InsufficientBuffer
+        )
         || pb_recv_buffer.is_null()
     {
         return ErrorKind::InsufficientBuffer.into();
     }
 
+    // SAFETY: The `pb_recv_buffer` parameter cannot be null (checked above).
     let recv_buffer = unsafe { from_raw_parts_mut(pb_recv_buffer, out_apdu_len) };
     recv_buffer.copy_from_slice(&out_data.output_apdu);
 
     if !pio_recv_pci.is_null() && out_data.receive_pci.is_some() {
-        try_execute!(unsafe {
-            copy_io_request_to_scard_io_request(out_data.receive_pci.as_ref().unwrap(), pio_recv_pci)
-        });
+        try_execute!(
+            // SAFETY: The `pio_recv_pci` parameter cannot be null (checked above).
+            unsafe {
+                copy_io_request_to_scard_io_request(
+                    out_data
+                        .receive_pci
+                        .as_ref()
+                        .expect("Should not panic: the receive_pci value is checked above"),
+                    pio_recv_pci,
+                )
+            }
+        );
     }
 
+    // SAFETY: The `pcb_recv_length` parameter cannot be null (checked above).
     unsafe {
         *pcb_recv_length = try_execute!(out_apdu_len.try_into(), ErrorKind::InsufficientBuffer);
     }
@@ -338,9 +438,14 @@ pub unsafe extern "system" fn SCardControl(
     lp_bytes_returned: LpDword,
 ) -> ScardStatus {
     check_handle!(handle);
-    let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
+
+    let scard = try_execute!(
+        // SAFETY: The `handle` is not equal to zero (checked above).
+        unsafe { scard_handle_to_winscard(handle) }
+    );
 
     let in_buffer = if !lp_in_buffer.is_null() {
+        // SAFETY: The `lp_in_buffer` parameter cannot be null (checked above).
         unsafe {
             from_raw_parts(
                 lp_in_buffer as *const u8,
@@ -352,6 +457,7 @@ pub unsafe extern "system" fn SCardControl(
     };
 
     if !lp_out_buffer.is_null() {
+        // SAFETY: The `lp_out_buffer` parameter cannot be null (checked above).
         let lp_out_buffer = unsafe {
             from_raw_parts_mut(
                 lp_out_buffer as *mut u8,
@@ -361,6 +467,7 @@ pub unsafe extern "system" fn SCardControl(
 
         let out_bytes_count = try_execute!(scard.control_with_output(dw_control_code, in_buffer, lp_out_buffer));
         if !lp_bytes_returned.is_null() {
+            // SAFETY: The `lp_bytes_returned` parameter cannot be null (checked above).
             unsafe {
                 *lp_bytes_returned = try_execute!(out_bytes_count.try_into(), ErrorKind::InternalError);
             }
@@ -375,25 +482,59 @@ pub unsafe extern "system" fn SCardControl(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardGetAttrib"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardGetAttrib(
-    _handle: ScardHandle,
-    _dw_attr_id: u32,
-    _pb_attr: LpByte,
-    _pcb_attrLen: LpDword,
+pub unsafe extern "system" fn SCardGetAttrib(
+    handle: ScardHandle,
+    dw_attr_id: u32,
+    pb_attr: LpByte,
+    pcb_attr_len: LpDword,
 ) -> ScardStatus {
-    ErrorKind::UnsupportedFeature.into()
+    check_handle!(handle);
+    check_null!(pcb_attr_len);
+
+    let attr_id = try_execute!(AttributeId::from_u32(dw_attr_id).ok_or_else(|| Error::new(
+        ErrorKind::InvalidParameter,
+        format!("invalid attribute id: {}", dw_attr_id)
+    )));
+
+    // SAFETY: The `handle` is not zero. All other guarantees should be provided by the user.
+    let scard = try_execute!(unsafe { raw_scard_handle_to_scard_handle(handle) });
+    // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
+    // and the `pcb_atr_len` parameter cannot be null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type(pb_attr, pcb_attr_len) });
+
+    let out_buf = try_execute!(scard.get_attribute(attr_id, buffer_type));
+
+    // SAFETY: It's safe to call this function because the `pb_atr` parameter is allowed to be null
+    // and the `pcb_atr_len` parameter cannot be null (checked above).
+    try_execute!(unsafe { save_out_buf(out_buf, pb_attr, pcb_attr_len) });
+
+    ErrorKind::Success.into()
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardSetAttrib"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardSetAttrib(
-    _handle: ScardHandle,
-    _dw_attr_id: u32,
-    _pb_attr: LpCByte,
-    _cb_attrLen: u32,
+pub unsafe extern "system" fn SCardSetAttrib(
+    handle: ScardHandle,
+    dw_attr_id: u32,
+    pb_attr: LpCByte,
+    cb_attr_len: u32,
 ) -> ScardStatus {
-    ErrorKind::UnsupportedFeature.into()
+    check_handle!(handle);
+    check_null!(pb_attr);
+
+    // SAFETY: The `pb_attr` parameter is not null (checked above).
+    let attr_data = unsafe { from_raw_parts(pb_attr, cb_attr_len.try_into().unwrap()) };
+    let attr_id = try_execute!(AttributeId::from_u32(dw_attr_id).ok_or_else(|| Error::new(
+        ErrorKind::InvalidParameter,
+        format!("Invalid attribute id: {}", dw_attr_id)
+    )));
+    // SAFETY: The `handle` is not zero (checked above). All other guarantees should be provided by the user.
+    let scard = try_execute!(unsafe { scard_handle_to_winscard(handle) });
+
+    try_execute!(scard.set_attribute(attr_id, attr_data));
+
+    ErrorKind::Success.into()
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardUIDlgSelectCardA"))]

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 use std::ffi::CStr;
-use std::slice::from_raw_parts_mut;
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::sync::{Mutex, OnceLock};
 
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::functions::SCardApiFunctionTable;
 use ffi_types::winscard::{
     LpScardAtrMask, LpScardContext, LpScardReaderStateA, LpScardReaderStateW, ScardContext, ScardStatus,
 };
@@ -10,65 +13,100 @@ use libc::c_void;
 #[cfg(target_os = "windows")]
 use symbol_rename_macro::rename_symbol;
 use uuid::Uuid;
-use winscard::winscard::WinScardContext;
-use winscard::{ErrorKind, ScardContext as PivCardContext, SmartCardInfo, WinScardResult, ATR};
+use winscard::winscard::{CurrentState, ReaderState, WinScardContext};
+use winscard::{ErrorKind, ScardContext as PivCardContext, SmartCardInfo, WinScardResult};
 
-use super::buf_alloc::{copy_w_buff, write_multistring_a, write_multistring_w};
-use crate::utils::{c_w_str_to_string, into_raw_ptr, str_to_w_buff};
-use crate::winscard::buf_alloc::copy_buff;
-use crate::winscard::scard_handle::{scard_context_to_winscard_context, WinScardContextHandle};
+use super::buf_alloc::{build_buf_request_type, build_buf_request_type_wide, save_out_buf, save_out_buf_wide};
+use crate::utils::{c_w_str_to_string, into_raw_ptr, str_encode_utf16};
+use crate::winscard::scard_handle::{
+    raw_scard_context_handle_to_scard_context_handle, scard_context_to_winscard_context, WinScardContextHandle,
+};
+use crate::winscard::system_scard::SystemScardContext;
 
-const SCARD_STATE_CHANGED: u32 = 0x00000002;
-const SCARD_STATE_INUSE: u32 = 0x00000100;
-const SCARD_STATE_PRESENT: u32 = 0x00000020;
-// Undocumented constant that appears in all API captures
-const SCARD_STATE_UNNAMED_CONSTANT: u32 = 0x00010000;
+const ERROR_INVALID_HANDLE: u32 = 6;
 
-// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetcardtypeprovidernamew
-// `dwProviderId` function parameter::
-// The function retrieves the name of the smart card's primary service provider as a GUID string.
-const SCARD_PROVIDER_PRIMARY: u32 = 1;
-// The function retrieves the name of the cryptographic service provider.
-const SCARD_PROVIDER_CSP: u32 = 2;
-// The function retrieves the name of the smart card key storage provider (KSP).
-const SCARD_PROVIDER_KSP: u32 = 3;
-// The function retrieves the name of the card module.
-const SCARD_PROVIDER_CARD_MODULE: u32 = 0x80000001;
+// Environment variable that indicates what smart card type use. It can have the following values:
+// `true` - use a system-provided smart card.
+// `false` (or unset) - use an emulated smart card.
+const SMART_CARD_TYPE: &str = "WINSCARD_USE_SYSTEM_SCARD";
 
-pub const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
-const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
-const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "C:\\Windows\\System32\\msclmd.dll";
+// We need to store all active smart card contexts in one collection.
+// The `SCardIsValidContext` function can be called with already released context. So, with the help
+// of `SCARD_CONTEXTS` we can track all active contexts and correctly check is the passed context is valid.
+// The same applies to the `SCardReleaseContext`. We need to ensure that the passed context handle was not
+// released before.
+static SCARD_CONTEXTS: OnceLock<Mutex<Vec<ScardContext>>> = OnceLock::new();
+// This API table instance is only needed for the `SCardAccessStartedEvent` function. This function
+// doesn't accept any parameters, so we need a separate initialized API table to call the system API.
+#[cfg(target_os = "windows")]
+static WINSCARD_API: OnceLock<SCardApiFunctionTable> = OnceLock::new();
 
-pub const DEFAULT_CARD_NAME: &str = "Cool card";
+fn save_context(context: ScardContext) {
+    SCARD_CONTEXTS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("SCARD_CONTEXTS mutex locking should not fail")
+        .push(context)
+}
 
-// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew
-// To be notified of the arrival of a new smart card reader,
-// set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
-const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
+fn is_present(context: ScardContext) -> bool {
+    SCARD_CONTEXTS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("SCARD_CONTEXTS mutex locking should not fail")
+        .iter()
+        .any(|ctx| *ctx == context)
+}
+
+fn release_context(context: ScardContext) {
+    SCARD_CONTEXTS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("SCARD_CONTEXTS mutex locking should not fail")
+        .retain(|ctx| *ctx != context)
+}
+
+fn create_emulated_smart_card_context() -> WinScardResult<Box<dyn WinScardContext>> {
+    Ok(Box::new(PivCardContext::new(SmartCardInfo::try_from_env()?)?))
+}
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardEstablishContext"))]
 #[instrument(ret)]
 #[no_mangle]
 pub unsafe extern "system" fn SCardEstablishContext(
-    _dw_scope: u32,
+    dw_scope: u32,
     _r1: *const c_void,
     _r2: *const c_void,
     context: LpScardContext,
 ) -> ScardStatus {
     crate::logging::setup_logger();
+
     check_null!(context);
 
-    let scard_info = try_execute!(SmartCardInfo::try_from_env());
-    // We have only one available reader
-    let scard_context: Box<dyn WinScardContext> = Box::new(try_execute!(PivCardContext::new(scard_info)));
+    let scard_context = if let Ok(use_system_card) = std::env::var(SMART_CARD_TYPE) {
+        if use_system_card == "true" {
+            info!("Creating system-provided smart card context");
+            Box::new(try_execute!(SystemScardContext::establish(try_execute!(
+                dw_scope.try_into()
+            ))))
+        } else {
+            info!("Creating emulated smart card context");
+            try_execute!(create_emulated_smart_card_context())
+        }
+    } else {
+        info!("Creating emulated smart card context");
+        try_execute!(create_emulated_smart_card_context())
+    };
 
     let scard_context = WinScardContextHandle::with_scard_context(scard_context);
 
     let raw_ptr = into_raw_ptr(scard_context) as ScardContext;
     info!(new_established_context = ?raw_ptr);
+    // SAFETY: The `context` is not null (checked above).
     unsafe {
         *context = raw_ptr;
     }
+    save_context(raw_ptr);
 
     ErrorKind::Success.into()
 }
@@ -79,20 +117,41 @@ pub unsafe extern "system" fn SCardEstablishContext(
 pub unsafe extern "system" fn SCardReleaseContext(context: ScardContext) -> ScardStatus {
     check_handle!(context);
 
-    let _ = unsafe { Box::from_raw(context as *mut WinScardContextHandle) };
+    if is_present(context) {
+        // SAFETY: The `context` is not zero (checked above). All other guarantees should be provided by the user.
+        let _ = unsafe { Box::from_raw(context as *mut WinScardContextHandle) };
+        release_context(context);
 
-    ErrorKind::Success.into()
+        info!("Scard context has been successfully released");
+
+        ErrorKind::Success.into()
+    } else {
+        warn!("Scard context is invalid or has been released");
+
+        ERROR_INVALID_HANDLE
+    }
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardIsValidContext"))]
 #[no_mangle]
 pub unsafe extern "system" fn SCardIsValidContext(context: ScardContext) -> ScardStatus {
-    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
+    if is_present(context) {
+        check_handle!(context);
 
-    if context.is_valid() {
-        ErrorKind::Success.into()
+        let context = try_execute!(
+            // SAFETY: The `context` is not zero (checked above). All other guarantees should be provided by the user.
+            unsafe { scard_context_to_winscard_context(context) }
+        );
+
+        if context.is_valid() {
+            ErrorKind::Success.into()
+        } else {
+            ERROR_INVALID_HANDLE
+        }
     } else {
-        ErrorKind::InvalidHandle.into()
+        debug!("Provided context is not present in active contexts");
+
+        ERROR_INVALID_HANDLE
     }
 }
 
@@ -128,13 +187,15 @@ pub unsafe extern "system" fn SCardListReadersA(
     check_null!(msz_readers);
     check_null!(pcch_readers);
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    let readers = try_execute!(context.scard_context().list_readers());
-    let readers = readers.iter().map(|reader| reader.to_string()).collect::<Vec<_>>();
-    let readers = readers.iter().map(|reader| reader.as_ref()).collect::<Vec<_>>();
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+    // SAFETY: The `msz_readers` and `pcch_readers` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type(msz_readers, pcch_readers) });
 
-    try_execute!(unsafe { write_multistring_a(context, &readers, msz_readers, pcch_readers) });
+    let out_buf = try_execute!(context.list_readers(buffer_type));
+
+    // SAFETY: The `msz_readers` and `pcch_readers` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf(out_buf, msz_readers, pcch_readers) });
 
     ErrorKind::Success.into()
 }
@@ -152,15 +213,31 @@ pub unsafe extern "system" fn SCardListReadersW(
     check_null!(msz_readers);
     check_null!(pcch_readers);
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    let readers = try_execute!(context.scard_context().list_readers());
-    let readers = readers.iter().map(|reader| reader.to_string()).collect::<Vec<_>>();
-    let readers = readers.iter().map(|reader| reader.as_ref()).collect::<Vec<_>>();
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+    // SAFETY: The `msz_readers` and `pcch_readers` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type_wide(msz_readers, pcch_readers) });
 
-    try_execute!(unsafe { write_multistring_w(context, &readers, msz_readers, pcch_readers) });
+    let out_buf = try_execute!(context.list_readers_wide(buffer_type));
+
+    // SAFETY: The `msz_readers` and `pcch_readers` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf_wide(out_buf, msz_readers, pcch_readers) });
 
     ErrorKind::Success.into()
+}
+
+unsafe fn guids_to_uuids(guids: LpCGuid, len: u32) -> WinScardResult<Option<Vec<Uuid>>> {
+    Ok(if guids.is_null() {
+        None
+    } else {
+        Some(
+            // SAFETY: The `guids` parameter is not null (checked above).
+            unsafe { from_raw_parts(guids, len.try_into()?) }
+                .iter()
+                .map(|id| Uuid::from_fields(id.data1, id.data2, id.data3, &id.data4))
+                .collect::<Vec<_>>(),
+        )
+    })
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardListCardsA"))]
@@ -168,20 +245,38 @@ pub unsafe extern "system" fn SCardListReadersW(
 #[no_mangle]
 pub unsafe extern "system" fn SCardListCardsA(
     context: ScardContext,
-    _pb_atr: LpCByte,
-    _rgquid_nterfaces: LpCGuid,
-    _cguid_interface_count: u32,
+    pb_atr: LpCByte,
+    rgquid_nterfaces: LpCGuid,
+    cguid_interface_count: u32,
     msz_cards: *mut u8,
     pcch_cards: LpDword,
 ) -> ScardStatus {
+    use std::slice::from_raw_parts;
+
     check_handle!(context);
     check_null!(msz_cards);
     check_null!(pcch_cards);
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    // we have only one smart card with only one default name
-    try_execute!(unsafe { write_multistring_a(context, &[DEFAULT_CARD_NAME], msz_cards, pcch_cards) });
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+    // SAFETY: The `msz_cards` and `pcch_cards` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type(msz_cards, pcch_cards) });
+    let atr = if pb_atr.is_null() {
+        None
+    } else {
+        // SAFETY: The `pb_atr` parameter is not null (checked above).
+        Some(unsafe { from_raw_parts(pb_atr, 32) })
+    };
+    let required_interfaces = try_execute!(
+        // SAFETY: The `rgquid_nterfaces` parameter is checked inside the function.
+        // All other guarantees should be provided by the user.
+        unsafe { guids_to_uuids(rgquid_nterfaces, cguid_interface_count) }
+    );
+
+    let out_buf = try_execute!(context.list_cards(atr, required_interfaces.as_deref(), buffer_type));
+
+    // SAFETY: The `msz_cards` and `pcch_cards` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf(out_buf, msz_cards, pcch_cards) });
 
     ErrorKind::UnsupportedFeature.into()
 }
@@ -191,20 +286,38 @@ pub unsafe extern "system" fn SCardListCardsA(
 #[no_mangle]
 pub unsafe extern "system" fn SCardListCardsW(
     context: ScardContext,
-    _pb_atr: LpCByte,
-    _rgquid_nterfaces: LpCGuid,
-    _cguid_interface_count: u32,
+    pb_atr: LpCByte,
+    rgquid_nterfaces: LpCGuid,
+    cguid_interface_count: u32,
     msz_cards: *mut u16,
     pcch_cards: LpDword,
 ) -> ScardStatus {
+    use std::slice::from_raw_parts;
+
     check_handle!(context);
     check_null!(msz_cards);
     check_null!(pcch_cards);
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    // we have only one smart card with only one default name
-    try_execute!(unsafe { write_multistring_w(context, &[DEFAULT_CARD_NAME], msz_cards, pcch_cards) });
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+    // SAFETY: The `msz_cards` and `pcch_cards` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type_wide(msz_cards, pcch_cards) });
+    let atr = if pb_atr.is_null() {
+        None
+    } else {
+        // SAFETY: The `pb_atr` parameter is not null (checked above).
+        Some(unsafe { from_raw_parts(pb_atr, 32) })
+    };
+    let required_interfaces = try_execute!(
+        // SAFETY: The `rgquid_nterfaces` parameter is checked inside the function.
+        // All other guarantees should be provided by the user.
+        unsafe { guids_to_uuids(rgquid_nterfaces, cguid_interface_count) }
+    );
+
+    let out_buf = try_execute!(context.list_cards_wide(atr, required_interfaces.as_deref(), buffer_type));
+
+    // SAFETY: The `msz_cards` and `pcch_cards` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf_wide(out_buf, msz_cards, pcch_cards) });
 
     ErrorKind::Success.into()
 }
@@ -260,32 +373,37 @@ pub extern "system" fn SCardGetProviderIdW(
 #[no_mangle]
 pub unsafe extern "system" fn SCardGetCardTypeProviderNameA(
     context: ScardContext,
-    _sz_card_name: LpCStr,
+    sz_card_name: LpCStr,
     dw_provide_id: u32,
     szProvider: *mut u8,
     pcch_provider: LpDword,
 ) -> ScardStatus {
     check_handle!(context);
+    check_null!(sz_card_name);
     check_null!(szProvider);
     check_null!(pcch_provider);
 
-    let provider = match dw_provide_id {
-        SCARD_PROVIDER_PRIMARY => {
-            error!("Unsupported dw_provider_id: SCARD_PROVIDER_PRIMARY");
-            return ErrorKind::UnsupportedFeature.into();
-        }
-        SCARD_PROVIDER_CSP => MICROSOFT_DEFAULT_CSP,
-        SCARD_PROVIDER_KSP => MICROSOFT_DEFAULT_KSP,
-        SCARD_PROVIDER_CARD_MODULE => MICROSOFT_SCARD_DRIVER_LOCATION,
-        _ => {
-            error!(?dw_provide_id, "Unsupported dw_provider_id.");
-            return ErrorKind::InvalidParameter.into();
-        }
-    };
+    let card_name = try_execute!(
+        // SAFETY: It's safe to construct a slice because the `sz_card_name` is not null (checked above).
+        // All other guarantees should be provided by the user.
+        unsafe { CStr::from_ptr(sz_card_name as *const i8) }.to_str(),
+        ErrorKind::InvalidParameter
+    );
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    try_execute!(unsafe { copy_buff(context, szProvider, pcch_provider, provider.as_bytes()) });
+    // SAFETY: The `context` value is not zero (checked above).
+    let context_handle = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+
+    let context = context_handle.scard_context();
+    let provider_name =
+        try_execute!(context.get_card_type_provider_name(card_name, try_execute!(dw_provide_id.try_into())))
+            .to_string();
+
+    // SAFETY: The `szProvider` and `pcch_provider` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type(szProvider, pcch_provider) });
+    let out_buf = try_execute!(context_handle.write_to_out_buf(provider_name.as_bytes(), buffer_type));
+
+    // SAFETY: The `szProvider` and `pcch_provider` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf(out_buf, szProvider, pcch_provider) });
 
     ErrorKind::Success.into()
 }
@@ -295,33 +413,33 @@ pub unsafe extern "system" fn SCardGetCardTypeProviderNameA(
 #[no_mangle]
 pub unsafe extern "system" fn SCardGetCardTypeProviderNameW(
     context: ScardContext,
-    _sz_card_name: LpCWStr,
+    sz_card_name: LpCWStr,
     dw_provide_id: u32,
     szProvider: *mut u16,
     pcch_provider: LpDword,
 ) -> ScardStatus {
     check_handle!(context);
+    check_null!(sz_card_name);
     check_null!(szProvider);
     check_null!(pcch_provider);
 
-    let provider = match dw_provide_id {
-        SCARD_PROVIDER_PRIMARY => {
-            error!("Unsupported dw_provider_id: SCARD_PROVIDER_PRIMARY");
-            return ErrorKind::UnsupportedFeature.into();
-        }
-        SCARD_PROVIDER_CSP => MICROSOFT_DEFAULT_CSP,
-        SCARD_PROVIDER_KSP => MICROSOFT_DEFAULT_KSP,
-        SCARD_PROVIDER_CARD_MODULE => MICROSOFT_SCARD_DRIVER_LOCATION,
-        _ => {
-            error!(?dw_provide_id, "Unsupported dw_provider_id.");
-            return ErrorKind::InvalidParameter.into();
-        }
-    };
-    let encoded = str_to_w_buff(provider);
+    // SAFETY: The `sz_card_name` parameter is not null (checked above).
+    let card_name = unsafe { c_w_str_to_string(sz_card_name) };
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
-    try_execute!(unsafe { copy_w_buff(context, szProvider, pcch_provider, &encoded) });
+    // SAFETY: The `context` value is not zero (checked above).
+    let context_handle = try_execute!(unsafe { raw_scard_context_handle_to_scard_context_handle(context) });
+
+    let context = context_handle.scard_context();
+    let provider_name =
+        try_execute!(context.get_card_type_provider_name(&card_name, try_execute!(dw_provide_id.try_into())));
+    let wide_provider_name = str_encode_utf16(provider_name.as_ref());
+
+    // SAFETY: The `szProvider` and `pcch_provider` parameters are not null (checked above).
+    let buffer_type = try_execute!(unsafe { build_buf_request_type_wide(szProvider, pcch_provider) });
+    let out_buf = try_execute!(context_handle.write_to_out_buf(&wide_provider_name, buffer_type));
+
+    // SAFETY: The `szProvider` and `pcch_provider` parameters are not null (checked above).
+    try_execute!(unsafe { save_out_buf_wide(out_buf, szProvider, pcch_provider) });
 
     ErrorKind::Success.into()
 }
@@ -508,9 +626,12 @@ pub extern "system" fn SCardForgetCardTypeW(_context: ScardContext, _sz_card_nam
 #[instrument(ret)]
 #[no_mangle]
 pub unsafe extern "system" fn SCardFreeMemory(context: ScardContext, pv_mem: LpCVoid) -> ScardStatus {
-    if let Some(context) = unsafe { (context as *mut WinScardContextHandle).as_mut() } {
+    check_handle!(context);
+
+    // SAFETY: The `context` value is not zero (checked above).
+    if let Ok(context) = unsafe { raw_scard_context_handle_to_scard_context_handle(context) } {
         if context.free_buffer(pv_mem) {
-            info!("Allocated buffer successfully freed.");
+            info!("Allocated buffer successfully freed");
         } else {
             warn!(?pv_mem, "Attempt to free unknown buffer");
         }
@@ -525,45 +646,63 @@ pub unsafe extern "system" fn SCardFreeMemory(context: ScardContext, pv_mem: LpC
 // We use created event to return its handle from the `SCardAccessStartedEvent` function.
 // Note. If the `SCardAccessStartedEvent` frunction is not be called, the event will not be created.
 #[cfg(target_os = "windows")]
-static START_EVENT_HANDLE: std::sync::OnceLock<windows_sys::Win32::Foundation::HANDLE> = std::sync::OnceLock::new();
+static START_EVENT_HANDLE: OnceLock<windows_sys::Win32::Foundation::HANDLE> = OnceLock::new();
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardAccessStartedEvent"))]
 #[instrument(ret)]
 #[no_mangle]
 pub extern "system" fn SCardAccessStartedEvent() -> Handle {
-    // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardaccessstartedevent
-    // The `SCardAccessStartedEvent` function returns an event handle when an event signals that
-    // the smart card resource manager is started. The event-object handle can be specified in a call
-    // to one of the wait functions.
-    //
-    // We create the event once for the entire process and keep it like a singleton in the "signaled" state.
-    // We assume we're always ready for our virtual smart cards. Moreover, we don't use reference counters
-    // because we are always in a ready (signaled) state and have only one handle for the entire process.
     #[cfg(target_os = "windows")]
     {
-        *START_EVENT_HANDLE.get_or_init(|| {
-            use std::ptr::null;
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardaccessstartedevent
+        // The `SCardAccessStartedEvent` function returns an event handle when an event signals that
+        // the smart card resource manager is started. The event-object handle can be specified in a call
+        // to one of the wait functions.
 
-            use windows_sys::Win32::Foundation::GetLastError;
-            use windows_sys::Win32::System::Threading::CreateEventA;
+        use crate::winscard::system_scard::init_scard_api_table;
 
-            let handle = unsafe { CreateEventA(null(), 1, 1, null()) };
-            if handle == 0 {
-                error!(
-                    "Unable to create event: returned event handle is null. Last error: {}",
-                    unsafe { GetLastError() }
-                );
-            }
-            handle
-        })
+        if std::env::var(SMART_CARD_TYPE)
+            .and_then(|use_system_card| Ok(use_system_card == "true"))
+            .unwrap_or_default()
+        {
+            // Use system-provided smart card.
+            let api =
+                WINSCARD_API.get_or_init(|| init_scard_api_table().expect("winscard module loading should not fail"));
+
+            // SAFETY: The `api` is initialized, so it's safe to call this function.
+            unsafe { (api.SCardAccessStartedEvent)() }
+        } else {
+            // Use emulated smart card.
+            //
+            // We create the event once for the entire process and keep it like a singleton in the "signaled" state.
+            // We assume we're always ready for our virtual smart cards. Moreover, we don't use reference counters
+            // because we are always in a ready (signaled) state and have only one handle for the entire process.
+            *START_EVENT_HANDLE.get_or_init(|| {
+                use std::ptr::null;
+
+                use windows_sys::Win32::Foundation::GetLastError;
+                use windows_sys::Win32::System::Threading::CreateEventA;
+
+                // SAFETY: All parameters are correct.
+                let handle = unsafe { CreateEventA(null(), 1, 1, null()) };
+                if handle == 0 {
+                    error!(
+                        "Unable to create event: returned event handle is null. Last error: {}",
+                        // SAFETY: it's safe to call this function.
+                        unsafe { GetLastError() }
+                    );
+                }
+                handle
+            })
+        }
     }
-    // We support the `SCardAccessStartedEvent` function only on Windows OS. Reason:
-    // On non-Windows OS we use pcsc-lite API that doesn't have the `SCardAccessStartedEvent` function.
-    // Thus, we don't need it there.
-    //
-    // The function returns an event HANDLE if it succeeds or NULL if it fails.
     #[cfg(not(target_os = "windows"))]
     {
+        // We support the `SCardAccessStartedEvent` function only on Windows OS. Reason:
+        // On non-Windows OS we use pcsc-lite API that doesn't have the `SCardAccessStartedEvent` function.
+        // Thus, we don't need it there.
+        //
+        // The function returns an event HANDLE if it succeeds or NULL if it fails.
         0
     }
 }
@@ -572,14 +711,60 @@ pub extern "system" fn SCardAccessStartedEvent() -> Handle {
 #[instrument(ret)]
 #[no_mangle]
 pub extern "system" fn SCardReleaseStartedEvent() {
-    // In the current implementation, this function does nothing.
-    //
-    // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreleasestartedevent
-    // The `SCardReleaseStartedEvent` function decrements the reference count for a handle acquired
-    // by a previous call to the `SCardAccessStartedEvent` function.
-    //
-    // But we do not have any reference counters. See comments in [SCardAccessStartedEvent] function
-    // for more details.
+    #[cfg(target_os = "windows")]
+    {
+        use crate::winscard::system_scard::init_scard_api_table;
+
+        if std::env::var(SMART_CARD_TYPE)
+            .and_then(|use_system_card| Ok(use_system_card == "true"))
+            .unwrap_or_default()
+        {
+            // Use system-provided smart card.
+            let api =
+                WINSCARD_API.get_or_init(|| init_scard_api_table().expect("winscard module loading should not fail"));
+
+            // SAFETY: The `api` is initialized, so it's safe to call this function.
+            unsafe { (api.SCardReleaseStartedEvent)() }
+        } else {
+            use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
+
+            // Use emulated smart card.
+            //
+            // We create the event once for the entire process and keep it like a singleton in the "signaled" state.
+            // We assume we're always ready for our virtual smart cards. Moreover, we don't use reference counters
+            // because we are always in a ready (signaled) state and have only one handle for the entire process.
+            let event_handle = *START_EVENT_HANDLE.get_or_init(|| {
+                use std::ptr::null;
+
+                use windows_sys::Win32::System::Threading::CreateEventA;
+
+                // SAFETY: All parameters are correct.
+                let handle = unsafe { CreateEventA(null(), 1, 1, null()) };
+                if handle == 0 {
+                    error!(
+                        "Unable to create event: returned event handle is null. Last error: {}",
+                        // SAFETY: it's safe to call this function.
+                        unsafe { GetLastError() }
+                    );
+                }
+                handle
+            });
+            // SAFETY: It's safe to close the handle.
+            if unsafe { CloseHandle(event_handle) } == 0 {
+                error!(
+                    "Cannot close the event handle. List error: {}",
+                    // SAFETY: it's safe to call this function.
+                    unsafe { GetLastError() }
+                );
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // We support the `SCardReleaseStartedEvent` function only on Windows OS. Reason:
+        // On non-Windows OS we use pcsc-lite API that doesn't have the `SCardReleaseStartedEvent` function.
+        // Thus, we don't need it there.
+    }
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardLocateCardsA"))]
@@ -637,39 +822,46 @@ pub extern "system" fn SCardLocateCardsByATRW(
 #[no_mangle]
 pub unsafe extern "system" fn SCardGetStatusChangeA(
     context: ScardContext,
-    _dw_timeout: u32,
+    dw_timeout: u32,
     rg_reader_states: LpScardReaderStateA,
     c_readers: u32,
 ) -> ScardStatus {
     check_handle!(context);
     check_null!(rg_reader_states);
 
+    // SAFETY: The `context` value is not zero (checked above).
     let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
-    let supported_readers = try_execute!(context.list_readers());
 
-    let reader_states = unsafe {
+    // SAFETY: The `rg_reader_states` parameter is not null (checked above).
+    let c_reader_states = unsafe {
         from_raw_parts_mut(
             rg_reader_states,
             try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer),
         )
     };
+    let mut reader_states = try_execute!(c_reader_states
+        .iter()
+        .map(|c_reader| {
+            check_null!(c_reader.sz_reader, "reader name in reader state");
 
-    for reader_state in reader_states {
-        let reader = try_execute!(
-            unsafe { CStr::from_ptr(reader_state.sz_reader as *const i8) }.to_str(),
-            ErrorKind::InvalidParameter
-        );
+            Ok(ReaderState {
+                // SAFETY: The reader name should not be null (checked above). All other guarantees
+                // should be provided by the user.
+                reader_name: unsafe { CStr::from_ptr(c_reader.sz_reader as *const _) }.to_string_lossy(),
+                user_data: c_reader.pv_user_data as usize,
+                current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
+                event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
+                atr_len: c_reader.cb_atr.try_into()?,
+                atr: c_reader.rgb_atr,
+            })
+        })
+        .collect::<Result<Vec<_>, winscard::Error>>());
+    try_execute!(context.get_status_change(dw_timeout, &mut reader_states));
 
-        if supported_readers.contains(&Cow::Borrowed(reader)) {
-            reader_state.dw_event_state =
-                SCARD_STATE_UNNAMED_CONSTANT | SCARD_STATE_INUSE | SCARD_STATE_PRESENT | SCARD_STATE_CHANGED;
-            reader_state.cb_atr = try_execute!(ATR.len().try_into(), ErrorKind::InsufficientBuffer);
-            reader_state.rgb_atr[0..ATR.len()].copy_from_slice(ATR.as_slice());
-        } else if reader == NEW_READER_NOTIFICATION {
-            reader_state.dw_event_state = SCARD_STATE_UNNAMED_CONSTANT;
-        } else {
-            error!(?reader, "Unsupported reader");
-        }
+    for (reader_state, c_reader_state) in reader_states.iter().zip(c_reader_states.iter_mut()) {
+        c_reader_state.dw_event_state = reader_state.event_state.bits();
+        c_reader_state.cb_atr = try_execute!(reader_state.atr_len.try_into(), ErrorKind::InternalError);
+        c_reader_state.rgb_atr.copy_from_slice(&reader_state.atr);
     }
 
     ErrorKind::Success.into()
@@ -680,34 +872,46 @@ pub unsafe extern "system" fn SCardGetStatusChangeA(
 #[no_mangle]
 pub unsafe extern "system" fn SCardGetStatusChangeW(
     context: ScardContext,
-    _dw_timeout: u32,
+    dw_timeout: u32,
     rg_reader_states: LpScardReaderStateW,
     c_readers: u32,
 ) -> ScardStatus {
     check_handle!(context);
     check_null!(rg_reader_states);
 
+    // SAFETY: The `context` value is not zero (checked above).
     let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
-    let supported_readers = try_execute!(context.list_readers());
 
-    let reader_states = unsafe {
+    // SAFETY: The `rg_reader_states` parameter is not null (checked above).
+    let c_reader_states = unsafe {
         from_raw_parts_mut(
             rg_reader_states,
             try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer),
         )
     };
-    for reader_state in reader_states {
-        let reader = unsafe { c_w_str_to_string(reader_state.sz_reader) };
-        if supported_readers.contains(&Cow::Borrowed(&reader)) {
-            reader_state.dw_event_state =
-                SCARD_STATE_UNNAMED_CONSTANT | SCARD_STATE_INUSE | SCARD_STATE_PRESENT | SCARD_STATE_CHANGED;
-            reader_state.cb_atr = try_execute!(ATR.len().try_into(), ErrorKind::InsufficientBuffer);
-            reader_state.rgb_atr[0..ATR.len()].copy_from_slice(ATR.as_slice());
-        } else if reader == NEW_READER_NOTIFICATION {
-            reader_state.dw_event_state = SCARD_STATE_UNNAMED_CONSTANT;
-        } else {
-            error!(?reader, "Unsupported reader");
-        }
+    let mut reader_states = try_execute!(c_reader_states
+        .iter()
+        .map(|c_reader| {
+            check_null!(c_reader.sz_reader, "reader name in reader state");
+
+            Ok(ReaderState {
+                // SAFETY: The reader name should not be null (checked above). All other guarantees
+                // should be provided by the user.
+                reader_name: Cow::Owned(unsafe { c_w_str_to_string(c_reader.sz_reader) }),
+                user_data: c_reader.pv_user_data as usize,
+                current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
+                event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
+                atr_len: c_reader.cb_atr.try_into()?,
+                atr: c_reader.rgb_atr,
+            })
+        })
+        .collect::<Result<Vec<_>, winscard::Error>>());
+    try_execute!(context.get_status_change(dw_timeout, &mut reader_states));
+
+    for (reader_state, c_reader_state) in reader_states.iter().zip(c_reader_states.iter_mut()) {
+        c_reader_state.dw_event_state = reader_state.event_state.bits();
+        c_reader_state.cb_atr = try_execute!(reader_state.atr_len.try_into(), ErrorKind::InternalError);
+        c_reader_state.rgb_atr.copy_from_slice(&reader_state.atr);
     }
 
     ErrorKind::Success.into()
@@ -716,34 +920,48 @@ pub unsafe extern "system" fn SCardGetStatusChangeW(
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardCancel"))]
 #[instrument(ret)]
 #[no_mangle]
-pub extern "system" fn SCardCancel(_context: ScardContext) -> ScardStatus {
-    // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcancel
-    // The SCardCancel function terminates all outstanding actions within a specific resource manager context.
-    //
-    // We do not have such actions in an emulated scard context
+pub extern "system" fn SCardCancel(context: ScardContext) -> ScardStatus {
+    check_handle!(context);
+
+    // SAFETY: The `context` value is not zero (checked above). All other guarantees should be provided by the user.
+    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
+    try_execute!(context.cancel());
+
     ErrorKind::Success.into()
 }
 
 unsafe fn read_cache(
     context: ScardContext,
-    card_id: Uuid,
+    card_identifier: LpUuid,
     freshness_counter: u32,
     lookup_name: &str,
     data: LpByte,
     data_len: LpDword,
 ) -> WinScardResult<()> {
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
+    check_handle!(context, "scard context handle");
+    check_null!(card_identifier, "scard card identifier");
+    check_null!(data_len, "data buffer length");
 
-    if let Ok(cached_value) = context
-        .scard_context()
-        .read_cache(card_id, freshness_counter, lookup_name)
-    {
-        let cached_value = cached_value.to_vec();
-        unsafe { copy_buff(context, data, data_len, &cached_value) }
-    } else {
-        warn!(cache = ?ErrorKind::CacheItemNotFound);
-        Ok(())
-    }
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = unsafe { raw_scard_context_handle_to_scard_context_handle(context) }?;
+
+    // SAFETY: The `card_identifier` parameter is not null (checked above).
+    let card_id = unsafe {
+        Uuid::from_fields(
+            (*card_identifier).data1,
+            (*card_identifier).data2,
+            (*card_identifier).data3,
+            &(*card_identifier).data4,
+        )
+    };
+    // SAFETY: It's safe to call this function because the `data` parameter is allowed to be null
+    // and the `data_len` parameter cannot be null (checked above).
+    let buffer_type = unsafe { build_buf_request_type(data, data_len) }?;
+
+    let out_buf = context.read_cache(card_id, freshness_counter, lookup_name, buffer_type)?;
+
+    // SAFETY: It's safe to call this function because all parameters are checked above.
+    unsafe { save_out_buf(out_buf, data, data_len) }
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardReadCacheA"))]
@@ -757,25 +975,15 @@ pub unsafe extern "system" fn SCardReadCacheA(
     data: LpByte,
     data_len: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
-    check_null!(card_identifier);
     check_null!(lookup_name);
-    check_null!(data_len);
 
     let lookup_name = try_execute!(
+        // SAFETY: The `lookup_name` parameter is not null (checked above).
         unsafe { CStr::from_ptr(lookup_name as *const i8) }.to_str(),
         ErrorKind::InvalidParameter
     );
-    let card_id = unsafe {
-        Uuid::from_fields(
-            (*card_identifier).data1,
-            (*card_identifier).data2,
-            (*card_identifier).data3,
-            &(*card_identifier).data4,
-        )
-    };
-
-    try_execute!(unsafe { read_cache(context, card_id, freshness_counter, lookup_name, data, data_len) });
+    // SAFETY: The `lookup_name` parameter is type checked. All other parameters are checked inside the function.
+    try_execute!(unsafe { read_cache(context, card_identifier, freshness_counter, lookup_name, data, data_len,) });
 
     ErrorKind::Success.into()
 }
@@ -791,12 +999,40 @@ pub unsafe extern "system" fn SCardReadCacheW(
     data: LpByte,
     data_len: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
-    check_null!(card_identifier);
     check_null!(lookup_name);
-    check_null!(data_len);
 
+    // SAFETY: The `lookup_name` parameter is not null (checked above).
     let lookup_name = unsafe { c_w_str_to_string(lookup_name) };
+    try_execute!(
+        // SAFETY: The `lookup_name` parameter is type checked. All other parameters are checked inside the function.
+        unsafe {
+            read_cache(
+                context,
+                card_identifier,
+                freshness_counter,
+                &lookup_name,
+                data,
+                data_len,
+            )
+        }
+    );
+
+    ErrorKind::Success.into()
+}
+
+unsafe fn write_cache(
+    context: ScardContext,
+    card_identifier: LpUuid,
+    freshness_counter: u32,
+    lookup_name: &str,
+    data: LpByte,
+    data_len: u32,
+) -> WinScardResult<()> {
+    check_handle!(context, "scard context handle");
+    check_null!(card_identifier, "card identified");
+    check_null!(data, "cache data buffer");
+
+    // SAFETY: The `card_identifier` parameter is not null (checked above).
     let card_id = unsafe {
         Uuid::from_fields(
             (*card_identifier).data1,
@@ -806,9 +1042,12 @@ pub unsafe extern "system" fn SCardReadCacheW(
         )
     };
 
-    try_execute!(unsafe { read_cache(context, card_id, freshness_counter, &lookup_name, data, data_len) });
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = unsafe { scard_context_to_winscard_context(context) }?;
+    // SAFETY: The `data` parameter is not null (checked above).
+    let data = unsafe { from_raw_parts_mut(data, data_len.try_into()?) }.to_vec();
 
-    ErrorKind::Success.into()
+    context.write_cache(card_id, freshness_counter, lookup_name.to_owned(), data)
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardWriteCacheA"))]
@@ -822,30 +1061,15 @@ pub unsafe extern "system" fn SCardWriteCacheA(
     data: LpByte,
     data_len: u32,
 ) -> ScardStatus {
-    check_handle!(context);
-    check_null!(card_identifier);
     check_null!(lookup_name);
-    check_null!(data);
 
-    let card_id = unsafe {
-        Uuid::from_fields(
-            (*card_identifier).data1,
-            (*card_identifier).data2,
-            (*card_identifier).data3,
-            &(*card_identifier).data4,
-        )
-    };
-
-    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
     let lookup_name = try_execute!(
+        // SAFETY: The `lookup_name` parameter is not null (checked above).
         unsafe { CStr::from_ptr(lookup_name as *const i8) }.to_str(),
         ErrorKind::InvalidParameter
     );
-    let data =
-        unsafe { from_raw_parts_mut(data, try_execute!(data_len.try_into(), ErrorKind::InsufficientBuffer)) }.to_vec();
-    info!(write_lookup_name = lookup_name, ?data);
-
-    try_execute!(context.write_cache(card_id, freshness_counter, lookup_name.to_owned(), data));
+    // SAFETY: The `lookup_name` parameter is type checked. All other parameters are checked inside the function
+    try_execute!(unsafe { write_cache(context, card_identifier, freshness_counter, lookup_name, data, data_len,) });
 
     ErrorKind::Success.into()
 }
@@ -861,40 +1085,48 @@ pub unsafe extern "system" fn SCardWriteCacheW(
     data: LpByte,
     data_len: u32,
 ) -> ScardStatus {
-    check_handle!(context);
-    check_null!(card_identifier);
     check_null!(lookup_name);
-    check_null!(data);
 
-    let card_id = unsafe {
-        Uuid::from_fields(
-            (*card_identifier).data1,
-            (*card_identifier).data2,
-            (*card_identifier).data3,
-            &(*card_identifier).data4,
-        )
-    };
-
-    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
+    // SAFETY: The `lookup_name` parameter is not null (checked above).
     let lookup_name = unsafe { c_w_str_to_string(lookup_name) };
-    let data =
-        unsafe { from_raw_parts_mut(data, try_execute!(data_len.try_into(), ErrorKind::InsufficientBuffer)) }.to_vec();
-    info!(write_lookup_name = lookup_name, ?data);
-
-    try_execute!(context.write_cache(card_id, freshness_counter, lookup_name, data));
+    // SAFETY: The `lookup_name` parameter is type checked. All other parameters are checked inside the function
+    try_execute!(unsafe {
+        write_cache(
+            context,
+            card_identifier,
+            freshness_counter,
+            &lookup_name,
+            data,
+            data_len,
+        )
+    });
 
     ErrorKind::Success.into()
 }
 
 unsafe fn get_reader_icon(
-    context: &mut WinScardContextHandle,
+    context: ScardContext,
     reader_name: &str,
     pb_icon: LpByte,
     pcb_icon: LpDword,
 ) -> WinScardResult<()> {
-    let icon = context.scard_context().reader_icon(reader_name)?.as_ref().to_vec();
+    check_handle!(context, "scard context handle");
+    // `pb_icon` can be null.
+    check_null!(pcb_icon, "pcb_icon");
 
-    unsafe { copy_buff(context, pb_icon, pcb_icon, icon.as_ref()) }
+    // SAFETY: The `context` value is not zero (checked above). All other guarantees should be provided by the user.
+    let context = unsafe { raw_scard_context_handle_to_scard_context_handle(context) }?;
+
+    // SAFETY: It's safe to call this function because the `pb_icon` parameter is allowed to be null
+    // and the `pcb_icon` parameter cannot be null (checked above).
+    let buffer_type = unsafe { build_buf_request_type(pb_icon, pcb_icon) }?;
+
+    let out_buf = context.get_reader_icon(reader_name, buffer_type)?;
+
+    // SAFETY: It's safe to call this function because all parameters are checked above.
+    unsafe { save_out_buf(out_buf, pb_icon, pcb_icon) }?;
+
+    Ok(())
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardGetReaderIconA"))]
@@ -906,19 +1138,18 @@ pub unsafe extern "system" fn SCardGetReaderIconA(
     pb_icon: LpByte,
     pcb_icon: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
     check_null!(sz_reader_name);
-    // `pb_icon` can be null.
-    check_null!(pcb_icon);
 
-    // safe: checked above
-    let context = unsafe { (context as *mut WinScardContextHandle).as_mut() }.unwrap();
     let reader_name = try_execute!(
+        // SAFETY: The `sz_reader_name` parameter is not null (checked above).
         unsafe { CStr::from_ptr(sz_reader_name as *const i8) }.to_str(),
         ErrorKind::InvalidParameter
     );
 
-    try_execute!(unsafe { get_reader_icon(context, reader_name, pb_icon, pcb_icon) });
+    try_execute!(
+        // SAFETY: The `reader_name` parameter is type checked. All other parameters are checked inside the function
+        unsafe { get_reader_icon(context, reader_name, pb_icon, pcb_icon) }
+    );
 
     ErrorKind::Success.into()
 }
@@ -932,22 +1163,36 @@ pub unsafe extern "system" fn SCardGetReaderIconW(
     pb_icon: LpByte,
     pcb_icon: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
     check_null!(sz_reader_name);
-    // `pb_icon` can be null.
-    check_null!(pcb_icon);
 
-    let (context, reader_name) = unsafe {
-        (
-            // safe: checked above
-            (context as *mut WinScardContextHandle).as_mut().unwrap(),
-            c_w_str_to_string(sz_reader_name),
-        )
-    };
+    // SAFETY: The `sz_reader_name` parameter is not null (checked above).
+    let reader_name = unsafe { c_w_str_to_string(sz_reader_name) };
 
-    try_execute!(unsafe { get_reader_icon(context, &reader_name, pb_icon, pcb_icon) });
+    try_execute!(
+        // SAFETY: The `reader_name` parameter is type checked. All other parameters are checked inside the function.
+        unsafe { get_reader_icon(context, &reader_name, pb_icon, pcb_icon) }
+    );
 
     ErrorKind::Success.into()
+}
+
+unsafe fn get_device_type_id(
+    context: ScardContext,
+    reader_name: &str,
+    pdw_device_type_id: LpDword,
+) -> WinScardResult<()> {
+    check_handle!(context, "scard context handle");
+    check_null!(pdw_device_type_id, "pdw_device_type_id");
+
+    // SAFETY: The `context` value is not zero (checked above).
+    let context = unsafe { scard_context_to_winscard_context(context) }?;
+
+    // SAFETY: The `pdw_device_type_id` parameter is not null (checked above).
+    unsafe {
+        *pdw_device_type_id = context.device_type_id(reader_name)?.into();
+    }
+
+    Ok(())
 }
 
 #[cfg_attr(windows, rename_symbol(to = "Rust_SCardGetDeviceTypeIdA"))]
@@ -958,20 +1203,19 @@ pub unsafe extern "system" fn SCardGetDeviceTypeIdA(
     sz_reader_name: LpCStr,
     pdw_device_type_id: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
     check_null!(sz_reader_name);
-    check_null!(pdw_device_type_id);
 
-    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
     let reader_name = try_execute!(
+        // SAFETY: The `sz_reader_name` parameter is not null (checked above).
         unsafe { CStr::from_ptr(sz_reader_name as *const i8) }.to_str(),
         ErrorKind::InvalidParameter
     );
 
-    let type_id = try_execute!(context.device_type_id(reader_name));
-    unsafe {
-        *pdw_device_type_id = type_id.into();
-    }
+    try_execute!(
+        // SAFETY: `context` and `pdw_device_type_id` parameters are checked inside the function.
+        // `reader_name` is type checked.
+        unsafe { get_device_type_id(context, reader_name, pdw_device_type_id) }
+    );
 
     ErrorKind::Success.into()
 }
@@ -984,17 +1228,16 @@ pub unsafe extern "system" fn SCardGetDeviceTypeIdW(
     sz_reader_name: LpCWStr,
     pdw_device_type_id: LpDword,
 ) -> ScardStatus {
-    check_handle!(context);
     check_null!(sz_reader_name);
-    check_null!(pdw_device_type_id);
 
-    let context = try_execute!(unsafe { scard_context_to_winscard_context(context) });
+    // SAFETY: The `sz_reader_name` parameter is not null (checked above).
     let reader_name = unsafe { c_w_str_to_string(sz_reader_name) };
 
-    let type_id = try_execute!(context.device_type_id(&reader_name));
-    unsafe {
-        *pdw_device_type_id = type_id.into();
-    }
+    try_execute!(
+        // SAFETY: `context` and `pdw_device_type_id` parameters are checked inside the function.
+        // `reader_name` is type checked.
+        unsafe { get_device_type_id(context, &reader_name, pdw_device_type_id) }
+    );
 
     ErrorKind::Success.into()
 }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -1,9 +1,11 @@
+use std::iter::once;
 use std::mem::size_of;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use ffi_types::winscard::{LpScardIoRequest, ScardContext, ScardHandle, ScardIoRequest};
 use ffi_types::LpCVoid;
-use winscard::winscard::{IoRequest, Protocol, WinScard, WinScardContext};
+use uuid::Uuid;
+use winscard::winscard::{AttributeId, IoRequest, Protocol, State, WinScard, WinScardContext};
 use winscard::{Error, ErrorKind, WinScardResult};
 
 /// Scard context handle representation.
@@ -59,11 +61,12 @@ impl WinScardContextHandle {
 
     /// Allocated a new buffer inside the scard context.
     pub fn allocate_buffer(&mut self, size: usize) -> WinScardResult<*mut u8> {
+        // SAFETY: Memory allocation should be safe. Moreover, we check for the null value below.
         let buff = unsafe { libc::malloc(size) as *mut u8 };
         if buff.is_null() {
             return Err(Error::new(
                 ErrorKind::NoMemory,
-                format!("Can not allocate {} bytes", size),
+                format!("cannot allocate {} bytes", size),
             ));
         }
         self.allocations.push(buff as usize);
@@ -78,6 +81,8 @@ impl WinScardContextHandle {
         if let Some(index) = self.allocations.iter().position(|x| *x == buff) {
             self.allocations.remove(index);
 
+            // SAFETY: The `allocations` collection contains only allocated memory pointers, so it's
+            // safe to deallocate them using the `libc::free` function.
             unsafe {
                 libc::free(buff as _);
             }
@@ -87,24 +92,221 @@ impl WinScardContextHandle {
             false
         }
     }
+
+    /// Returns the icon of the specified reader.
+    pub fn get_reader_icon(&mut self, reader: &str, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
+        let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
+
+        self.write_to_out_buf(&reader_icon, buffer_type)
+    }
+
+    /// Lists readers.
+    pub fn list_readers(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
+        let readers: Vec<_> = self
+            .scard_context()
+            .list_readers()?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string(&readers, buffer_type)
+    }
+
+    /// Lists readers but the resulting buffers contain wide strings.
+    pub fn list_readers_wide(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
+        let readers: Vec<_> = self
+            .scard_context()
+            .list_readers()?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string_wide(&readers, buffer_type)
+    }
+
+    /// Lists cards.
+    pub fn list_cards(
+        &mut self,
+        atr: Option<&[u8]>,
+        required_interfaces: Option<&[Uuid]>,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cards: Vec<_> = self
+            .scard_context()
+            .list_cards(atr, required_interfaces)?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string(&cards, buffer_type)
+    }
+
+    /// Lists readers but the resulting buffers contain wide strings.
+    pub fn list_cards_wide(
+        &mut self,
+        atr: Option<&[u8]>,
+        required_interfaces: Option<&[Uuid]>,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cards: Vec<_> = self
+            .scard_context()
+            .list_cards(atr, required_interfaces)?
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect();
+
+        self.write_multi_string_wide(&cards, buffer_type)
+    }
+
+    /// Reads smart card cache.
+    pub fn read_cache(
+        &mut self,
+        card_id: Uuid,
+        freshness_counter: u32,
+        key: &str,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let cached_value = self
+            .scard_context()
+            .read_cache(card_id, freshness_counter, key)?
+            .to_vec();
+
+        self.write_to_out_buf(cached_value.as_ref(), buffer_type)
+    }
+
+    /// Converts provided strings to the C-multi-string and saves it.
+    pub fn write_multi_string(
+        &mut self,
+        values: &[String],
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer<'static>> {
+        let data: Vec<_> = values
+            .iter()
+            .flat_map(|reader| reader.as_bytes().iter().cloned().chain(once(0)))
+            .chain(once(0))
+            .collect();
+
+        self.write_to_out_buf(&data, buffer_type)
+    }
+
+    /// Converts provided strings to the C-multi-string and saves it but the resulting buffers contain
+    /// wide strings.
+    pub fn write_multi_string_wide(
+        &mut self,
+        values: &[String],
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer<'static>> {
+        let data: Vec<_> = values
+            .iter()
+            .flat_map(|reader| reader.encode_utf16().chain(once(0)).flat_map(|i| i.to_le_bytes()))
+            .chain([0, 0])
+            .collect();
+
+        self.write_to_out_buf(&data, buffer_type)
+    }
+
+    /// Saves the provided data in the [OutBuffer] based on the [RequestedBufferType].
+    pub fn write_to_out_buf(
+        &mut self,
+        data: &[u8],
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer<'static>> {
+        Ok(match buffer_type {
+            RequestedBufferType::Buf(buf) => {
+                if buf.len() < data.len() {
+                    return Err(
+                        Error::new(
+                            ErrorKind::InsufficientBuffer, format!(
+                                "provided buffer is too small to fill the requested attribute into: buffer len: {}, attribute data len: {}.",
+                                buf.len(),
+                                data.len()
+                            )
+                        )
+                    );
+                }
+
+                buf[0..data.len()].copy_from_slice(data);
+
+                OutBuffer::Written(data.len())
+            }
+            RequestedBufferType::Length => OutBuffer::DataLen(data.len()),
+            RequestedBufferType::Allocate => {
+                let allocated = self.allocate_buffer(data.len())?;
+                // SAFETY: The `allocated` pointer has been returned from the [WinScarfdContextHandle]
+                // internal method, so it's safe to create a slice.
+                let buf = unsafe { from_raw_parts_mut(allocated, data.len()) };
+
+                buf.copy_from_slice(data);
+
+                OutBuffer::Allocated(buf)
+            }
+        })
+    }
 }
 
 impl Drop for WinScardContextHandle {
     fn drop(&mut self) {
         // [SCardReleaseContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreleasecontext)
         // ...freeing any resources allocated under that context, including SCARDHANDLE objects
-        unsafe {
-            for scard in &self.scards {
-                let _ = Box::from_raw(*scard as *mut WinScardHandle);
-            }
+        for scard in &self.scards {
+            // SAFETY: The `WinScardContextHandle` contains only valid scard handles, and it should
+            // be safe to cast them to `WinScardHandle` pointer.
+            let _ = unsafe { Box::from_raw(*scard as *mut WinScardHandle) };
         }
         // ...and memory allocated using the SCARD_AUTOALLOCATE length designator.
-        unsafe {
-            for buff in &self.allocations {
+        for buff in &self.allocations {
+            // SAFETY: It's safe to call the `free` function because the `WinScardContextHandle`
+            // contains only allocated memory pointers.
+            unsafe {
                 libc::free(*buff as _);
             }
         }
     }
+}
+
+/// Represents how and what data the user want to extract.
+#[derive(Debug)]
+pub enum RequestedBufferType<'data> {
+    /// This means the user wants the data filled in the provided buffer.
+    Buf(&'data mut [u8]),
+    /// The user want to query only the data length.
+    Length,
+    /// The user wants the data to be allocated by the library and returned from the function.
+    Allocate,
+}
+
+/// Represent the requested data buffer from the smart card.
+///
+/// The user can request some data from the smart card. For example, `SCardReadCache` or `SCardGetAttrib` functions.
+/// However, buffer handling can be tricky in such situations. The user may want to allocate the memory
+/// or ask us to do it. This enum aimed to solve this complexity.
+#[derive(Debug)]
+pub enum OutBuffer<'data> {
+    /// The data has been written into provided buffer by [RequestedBufferType::Buf].
+    Written(usize),
+    /// The user wants to know the requested data length to allocate the corresponding buffer in the future.
+    DataLen(usize),
+    /// Allocated buffer.
+    ///
+    /// The inner buffer is leaked and the user should free it using the `SCardFreeMemory` function.
+    Allocated(&'data mut [u8]),
+}
+
+/// Represents the smart card status.
+///
+/// This structure is aimed to represent smart card status data on the FFI layer.
+#[derive(Debug)]
+pub struct FfiScardStatus<'data> {
+    /// List of display names (multi-string) by which the currently connected reader is known.
+    pub readers: OutBuffer<'data>,
+    /// Buffer that receives the ATR string from the currently inserted card, if available.
+    ///
+    /// [ATR string](https://learn.microsoft.com/en-us/windows/win32/secgloss/a-gly).
+    pub atr: OutBuffer<'data>,
+    /// Current state of the smart card in the reader.
+    pub state: State,
+    /// Current protocol, if any. The returned value is meaningful only if the returned value of pdwState is SCARD_SPECIFICMODE.
+    pub protocol: Protocol,
 }
 
 /// Scard handle representation.
@@ -128,52 +330,180 @@ impl WinScardHandle {
         self.scard.as_ref()
     }
 
-    /// Returns the parent [ScardContext] it belongs.
-    pub fn context(&self) -> ScardContext {
-        self.context
+    /// Returns the mutable [WinScard] handle.
+    pub fn scard_mut(&mut self) -> &mut dyn WinScard {
+        self.scard.as_mut()
+    }
+
+    /// Returns mutable reference to the parent [WinScardContextHandle].
+    pub fn context<'context>(&self) -> WinScardResult<&'context mut WinScardContextHandle> {
+        // SAFETY: The WinScardHandle should not contain an invalid context handle.
+        unsafe { raw_scard_context_handle_to_scard_context_handle(self.context) }
+    }
+
+    /// Returns the requested smart card attribute.
+    pub fn get_attribute(
+        &self,
+        attribute_id: AttributeId,
+        buffer_type: RequestedBufferType,
+    ) -> WinScardResult<OutBuffer> {
+        let data = self.scard().get_attribute(attribute_id)?;
+
+        self.context()?.write_to_out_buf(data.as_ref(), buffer_type)
+    }
+
+    /// Returns smart card status.
+    pub fn status(
+        &mut self,
+        readers_buf_type: RequestedBufferType,
+        atr_but_type: RequestedBufferType,
+    ) -> WinScardResult<FfiScardStatus> {
+        let status = self.scard().status()?;
+        let readers: Vec<_> = status.readers.into_iter().map(|r| r.to_string()).collect();
+        let context = self.context()?;
+
+        let readers = context.write_multi_string(&readers, readers_buf_type)?;
+        let atr = context.write_to_out_buf(status.atr.as_ref(), atr_but_type)?;
+
+        Ok(FfiScardStatus {
+            readers,
+            atr,
+            state: status.state,
+            protocol: status.protocol,
+        })
+    }
+
+    /// Returns smart card status but all strings are wide.
+    pub fn status_wide(
+        &mut self,
+        readers_buf_type: RequestedBufferType,
+        atr_but_type: RequestedBufferType,
+    ) -> WinScardResult<FfiScardStatus> {
+        let status = self.scard().status()?;
+        let readers: Vec<_> = status.readers.into_iter().map(|r| r.to_string()).collect();
+        let context = self.context()?;
+
+        let readers = context.write_multi_string_wide(&readers, readers_buf_type)?;
+        let atr = context.write_to_out_buf(status.atr.as_ref(), atr_but_type)?;
+
+        Ok(FfiScardStatus {
+            readers,
+            atr,
+            state: status.state,
+            protocol: status.protocol,
+        })
     }
 }
 
+/// Tries to convert the raw scard handle to the `&mut dyn WinScard`.
 pub unsafe fn scard_handle_to_winscard<'a>(handle: ScardHandle) -> WinScardResult<&'a mut dyn WinScard> {
+    if handle == 0 {
+        return Err(Error::new(ErrorKind::InvalidHandle, "scard handle cannot be zero"));
+    }
+
+    // SAFETY: We've checked above that the scard handle is not a zero. All other guarantees are provided by the user.
     if let Some(scard) = unsafe { (handle as *mut WinScardHandle).as_mut() } {
         Ok(scard.scard.as_mut())
     } else {
         Err(Error::new(
             ErrorKind::InvalidHandle,
-            "Invalid smart card context handle.",
+            "invalid smart card context handle",
         ))
     }
 }
 
+/// Tries to convert the raw scard handle to the [&mut WinScardHandle].
+pub unsafe fn raw_scard_handle_to_scard_handle<'a>(h_card: ScardHandle) -> WinScardResult<&'a mut WinScardHandle> {
+    if h_card == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidHandle,
+            "scard context handle cannot be zero",
+        ));
+    }
+
+    // SAFETY: It should be safe to cast the value. The `h_card` is not null (checked above).
+    // All other guarantees should be provided by the user.
+    unsafe { (h_card as *mut WinScardHandle).as_mut() }
+        .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
+}
+
+/// Tries to convert the raw scard context handle to the [&mut WinScardContextHandle].
+pub unsafe fn raw_scard_context_handle_to_scard_context_handle<'a>(
+    h_context: ScardContext,
+) -> WinScardResult<&'a mut WinScardContextHandle> {
+    if h_context == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidHandle,
+            "scard context handle cannot be zero",
+        ));
+    }
+
+    // SAFETY: It should be safe to cast the value. The `h_context` is not null (checked above).
+    // All other guarantees should be provided by the user.
+    unsafe { (h_context as *mut WinScardContextHandle).as_mut() }
+        .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
+}
+
+/// Tries to convert the raw scard context handle to the `&mut dyn WinScardContext`.
 pub unsafe fn scard_context_to_winscard_context<'a>(
     handle: ScardContext,
 ) -> WinScardResult<&'a mut dyn WinScardContext> {
+    if handle == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidHandle,
+            "scard context handle cannot be zero",
+        ));
+    }
+
+    // SAFETY: We've checked above that the scard context handle is not a zero. All other guarantees are provided by the user.
     if let Some(context) = unsafe { (handle as *mut WinScardContextHandle).as_mut() } {
         Ok(context.scard_context.as_mut())
     } else {
         Err(Error::new(
             ErrorKind::InvalidHandle,
-            "Invalid smart card context handle.",
+            "invalid smart card context handle",
         ))
     }
 }
 
+/// Converts the C `SCARD_IO_REQUEST` ([LpScardIoRequest]) to Rust [IoRequest].
 pub unsafe fn scard_io_request_to_io_request(pio_send_pci: LpScardIoRequest) -> WinScardResult<IoRequest> {
+    if pio_send_pci.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "pio_send_pci cannot be null"));
+    }
+
+    // SAFETY: it's safe to deref because we've checked for null value above.
     let (cb_pci_length, dw_protocol) = unsafe { ((*pio_send_pci).cb_pci_length, (*pio_send_pci).dw_protocol) };
-    let buffer_len = cb_pci_length.try_into()?;
+    // https://learn.microsoft.com/en-us/windows/win32/secauthn/scard-io-request
+    //
+    // Length, in bytes, of the SCARD_IO_REQUEST structure plus any following PCI-specific information.
+    let pci_buf_len: usize = cb_pci_length.try_into()?;
+    let buffer_len = pci_buf_len - size_of::<ScardIoRequest>();
+    // SAFETY: it should be safe to cast a pointer. According to the documentation, the `pci_buffer` data
+    // is placed right after the `ScardIoRequest` structure.
     let buffer = unsafe { (pio_send_pci as *const u8).add(size_of::<ScardIoRequest>()) };
 
     Ok(IoRequest {
         protocol: Protocol::from_bits(dw_protocol).unwrap_or(Protocol::empty()),
+        // SAFETY: According to the documentation, it's safe to create a slice of the pci data.
         pci_info: unsafe { from_raw_parts(buffer, buffer_len) }.to_vec(),
     })
 }
 
+/// Copies data from the Rust [IoRequest] to the C `SCARD_IO_REQUEST` ([LpScardIoRequest]).
 pub unsafe fn copy_io_request_to_scard_io_request(
     io_request: &IoRequest,
     scard_io_request: LpScardIoRequest,
 ) -> WinScardResult<()> {
+    if scard_io_request.is_null() {
+        return Err(Error::new(
+            ErrorKind::InvalidParameter,
+            "scard_io_request cannot be null",
+        ));
+    }
+
     let pci_info_len = io_request.pci_info.len();
+    // SAFETY: it's safe to deref because we've checked for null value above.
     let scard_pci_info_len = unsafe { (*scard_io_request).cb_pci_length }.try_into()?;
 
     if pci_info_len > scard_pci_info_len {
@@ -186,12 +516,16 @@ pub unsafe fn copy_io_request_to_scard_io_request(
         ));
     }
 
+    // SAFETY: it's safe to deref because we check for null value above.
     unsafe {
         (*scard_io_request).dw_protocol = io_request.protocol.bits();
         (*scard_io_request).cb_pci_length = pci_info_len.try_into()?;
     }
 
+    // SAFETY: it should be safe to cast a pointer. According to the documentation, the `pci_buffer` data
+    // is placed right after the `ScardIoRequest` structure.
     let pci_buffer_ptr = unsafe { (scard_io_request as *mut u8).add(size_of::<ScardIoRequest>()) };
+    // SAFETY: According to the documentation, it's safe to create a slice of the pci data.
     let pci_buffer = unsafe { from_raw_parts_mut(pci_buffer_ptr, pci_info_len) };
     pci_buffer.copy_from_slice(&io_request.pci_info);
 

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::iter::once;
 use std::mem::size_of;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
@@ -20,6 +21,16 @@ pub struct WinScardContextHandle {
     /// Allocated buffers in our smart card context.
     /// All buffers are `[u8]`, so we need only pointer and don't need to remember its type.
     allocations: Vec<usize>,
+}
+
+impl fmt::Debug for WinScardContextHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WinScardContextHandle")
+            .field("scards", &self.scards)
+            .field("allocations", &self.allocations)
+            .field("scard_context", &"<scard context obj>")
+            .finish()
+    }
 }
 
 impl WinScardContextHandle {
@@ -49,6 +60,7 @@ impl WinScardContextHandle {
     }
 
     /// Removes the [ScardHandle] from the scard context.
+    #[instrument(level = "debug", ret)]
     pub fn remove_scard(&mut self, scard: ScardHandle) -> bool {
         if let Some(index) = self.scards.iter().position(|x| *x == scard) {
             self.scards.remove(index);
@@ -60,6 +72,7 @@ impl WinScardContextHandle {
     }
 
     /// Allocated a new buffer inside the scard context.
+    #[instrument(level = "debug", ret)]
     pub fn allocate_buffer(&mut self, size: usize) -> WinScardResult<*mut u8> {
         // SAFETY: Memory allocation should be safe. Moreover, we check for the null value below.
         let buff = unsafe { libc::malloc(size) as *mut u8 };
@@ -75,6 +88,7 @@ impl WinScardContextHandle {
     }
 
     /// Deletes the buffer inside the scard context.
+    #[instrument(level = "debug", ret)]
     pub fn free_buffer(&mut self, buff: LpCVoid) -> bool {
         let buff = buff as usize;
 
@@ -94,6 +108,7 @@ impl WinScardContextHandle {
     }
 
     /// Returns the icon of the specified reader.
+    #[instrument(level = "debug", ret)]
     pub fn get_reader_icon(&mut self, reader: &str, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
@@ -101,6 +116,7 @@ impl WinScardContextHandle {
     }
 
     /// Lists readers.
+    #[instrument(level = "debug", ret)]
     pub fn list_readers(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let readers: Vec<_> = self
             .scard_context()
@@ -113,6 +129,7 @@ impl WinScardContextHandle {
     }
 
     /// Lists readers but the resulting buffers contain wide strings.
+    #[instrument(level = "debug", ret)]
     pub fn list_readers_wide(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let readers: Vec<_> = self
             .scard_context()
@@ -125,6 +142,7 @@ impl WinScardContextHandle {
     }
 
     /// Lists cards.
+    #[instrument(level = "debug", ret)]
     pub fn list_cards(
         &mut self,
         atr: Option<&[u8]>,
@@ -142,6 +160,7 @@ impl WinScardContextHandle {
     }
 
     /// Lists readers but the resulting buffers contain wide strings.
+    #[instrument(level = "debug", ret)]
     pub fn list_cards_wide(
         &mut self,
         atr: Option<&[u8]>,
@@ -159,6 +178,7 @@ impl WinScardContextHandle {
     }
 
     /// Reads smart card cache.
+    #[instrument(level = "debug", ret)]
     pub fn read_cache(
         &mut self,
         card_id: Uuid,
@@ -175,6 +195,7 @@ impl WinScardContextHandle {
     }
 
     /// Converts provided strings to the C-multi-string and saves it.
+    #[instrument(level = "debug", ret)]
     pub fn write_multi_string(
         &mut self,
         values: &[String],
@@ -191,6 +212,7 @@ impl WinScardContextHandle {
 
     /// Converts provided strings to the C-multi-string and saves it but the resulting buffers contain
     /// wide strings.
+    #[instrument(level = "debug", ret)]
     pub fn write_multi_string_wide(
         &mut self,
         values: &[String],
@@ -206,6 +228,7 @@ impl WinScardContextHandle {
     }
 
     /// Saves the provided data in the [OutBuffer] based on the [RequestedBufferType].
+    #[instrument(level = "debug", ret)]
     pub fn write_to_out_buf(
         &mut self,
         data: &[u8],
@@ -319,6 +342,15 @@ pub struct WinScardHandle {
     context: ScardContext,
 }
 
+impl fmt::Debug for WinScardHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WinScardContextHandle")
+            .field("context", &self.context)
+            .field("scard", &"<scard obj>")
+            .finish()
+    }
+}
+
 impl WinScardHandle {
     /// Creates a new [WinSCardHandle] based on the provided data.
     pub fn new(scard: Box<dyn WinScard>, context: ScardContext) -> Self {
@@ -342,6 +374,7 @@ impl WinScardHandle {
     }
 
     /// Returns the requested smart card attribute.
+    #[instrument(level = "debug", ret)]
     pub fn get_attribute(
         &self,
         attribute_id: AttributeId,
@@ -353,6 +386,7 @@ impl WinScardHandle {
     }
 
     /// Returns smart card status.
+    #[instrument(level = "debug", ret)]
     pub fn status(
         &mut self,
         readers_buf_type: RequestedBufferType,
@@ -374,6 +408,7 @@ impl WinScardHandle {
     }
 
     /// Returns smart card status but all strings are wide.
+    #[instrument(level = "debug", ret)]
     pub fn status_wide(
         &mut self,
         readers_buf_type: RequestedBufferType,

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,0 +1,415 @@
+use std::borrow::Cow;
+use std::mem::size_of;
+use std::ptr::null_mut;
+use std::slice::from_raw_parts;
+
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::functions::SCardApiFunctionTable;
+use ffi_types::winscard::ScardIoRequest;
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::{ScardContext, ScardHandle};
+use num_traits::ToPrimitive;
+use winscard::winscard::{
+    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, Status, TransmitOutData, WinScard,
+};
+use winscard::{Error, ErrorKind, WinScardResult};
+
+use super::parse_multi_string_owned;
+use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::{initialize_pcsc_lite_api, ScardContext, ScardHandle};
+
+/// Represents a state of the current `SystemScard`.
+#[derive(Copy, Clone)]
+enum HandleState {
+    /// The card is not connected or has been disconnected.
+    Disconnected,
+    /// The card is connected and ready to use.
+    Connected(ScardHandle),
+}
+
+/// Represents a system-provided smart card.
+///
+/// _Hint:_ It's **always better** to explicitly disconnect the card using the [SystemScard::disconnect] method.
+/// Otherwise, the card will be disconnected automatically on the drop. But in such a case,
+/// the user is unable to pass the custom `dwDisposition` parameter in `SCardDisconnect` function.
+pub struct SystemScard {
+    h_card: HandleState,
+    h_card_context: ScardContext,
+    #[cfg(target_os = "windows")]
+    api: SCardApiFunctionTable,
+    #[cfg(not(target_os = "windows"))]
+    api: PcscLiteApiFunctionTable,
+}
+
+impl SystemScard {
+    /// Creates a new instance of the [SystemScard].
+    ///
+    /// _Note._ `h_card` and `h_card_context` parameters (handles) must be initialized using
+    /// the corresponding methods.
+    pub fn new(h_card: ScardHandle, h_card_context: ScardContext) -> WinScardResult<Self> {
+        if h_card == 0 {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                "scard handle can not be a zero",
+            ));
+        }
+
+        if h_card_context == 0 {
+            return Err(Error::new(
+                ErrorKind::InvalidParameter,
+                "scard context handle can not be a zero",
+            ));
+        }
+
+        Ok(Self {
+            h_card: HandleState::Connected(h_card),
+            h_card_context,
+            #[cfg(target_os = "windows")]
+            api: super::init_scard_api_table()?,
+            #[cfg(not(target_os = "windows"))]
+            api: initialize_pcsc_lite_api()?,
+        })
+    }
+
+    fn h_card(&self) -> WinScardResult<ScardHandle> {
+        if let HandleState::Connected(handle) = self.h_card {
+            Ok(handle)
+        } else {
+            Err(Error::new(
+                ErrorKind::InvalidHandle,
+                "smart card is not connected or has been disconnected",
+            ))
+        }
+    }
+}
+
+impl Drop for SystemScard {
+    fn drop(&mut self) {
+        if let HandleState::Connected(handle) = self.h_card {
+            if let Err(err) = try_execute!(
+                // SAFETY: This function is safe to call because the `handle` is valid.
+                unsafe { (self.api.SCardDisconnect)(handle, 0) }
+            ) {
+                error!(?err, "Failed to disconnect the card");
+            }
+        }
+    }
+}
+
+impl WinScard for SystemScard {
+    fn status(&self) -> WinScardResult<Status> {
+        let mut reader_name: *mut u8 = null_mut();
+        let mut reader_name_len = SCARD_AUTOALLOCATE;
+        let mut state = 0;
+        let mut protocol = 0;
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardstatusw
+        //
+        // `pbAtr`: Pointer to a 32-byte buffer that receives the ATR string from the currently
+        // inserted card, if available.
+        //
+        // PCSC-lite docs do not specify that ATR buf should be 32 bytes long, but actually,
+        // the ATR string can not be longer than 32 bytes.
+        let mut atr = vec![0; 32];
+        let mut atr_len = 32;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // https://pcsclite.apdu.fr/api/group__API.html#gae49c3c894ad7ac12a5b896bde70d0382
+            //
+            // If `*pcchReaderLen` is equal to SCARD_AUTOALLOCATE then the function will allocate itself
+            // the needed memory for szReaderName. Use SCardFreeMemory() to release it.
+            try_execute!(
+                // SAFETY: This function is safe to call because `self.h_card` is checked
+                // and all other values is type checked.
+                unsafe {
+                    (self.api.SCardStatus)(
+                        self.h_card()?,
+                        (&mut reader_name as *mut *mut u8) as *mut _,
+                        &mut reader_name_len,
+                        &mut state,
+                        &mut protocol,
+                        atr.as_mut_ptr(),
+                        &mut atr_len,
+                    )
+                },
+                "SCardStatus failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardstatusa
+            // If this buffer length is specified as SCARD_AUTOALLOCATE, then szReaderName is converted to a pointer
+            // to a byte pointer, and it receives the address of a block of memory that contains the multiple-string structure.
+            //
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and all other values is type checked.
+            try_execute!(
+                // SAFETY: This function is safe to call because `self.h_card` is checked
+                // and all other values is type checked.
+                unsafe {
+                    (self.api.SCardStatusA)(
+                        self.h_card()?,
+                        (&mut reader_name as *mut *mut u8) as *mut _,
+                        &mut reader_name_len,
+                        &mut state,
+                        &mut protocol,
+                        atr.as_mut_ptr(),
+                        &mut atr_len,
+                    )
+                },
+                "SCardStatusA failed"
+            )?;
+        }
+
+        // SAFETY: A slice creation is safe in this context because the `reader_name` pointer is
+        // a local pointer that was initialized by the `SCardStatus` function.
+        let multi_string_buffer = unsafe { from_raw_parts(reader_name, reader_name_len.try_into()?) };
+        let readers = if let Ok(readers) = parse_multi_string_owned(multi_string_buffer) {
+            readers
+        } else {
+            try_execute!(
+                // SAFETY: This function is safe to call because `self.h_card_context` is always a valid handle.
+                unsafe { (self.api.SCardFreeMemory)(self.h_card_context, reader_name as *const _) },
+                "SCardFreeMemory failed"
+            )?;
+
+            return Err(Error::new(
+                ErrorKind::InternalError,
+                "returned reader is not valid UTF-8",
+            ));
+        };
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card_context` is always a valid handle.
+            unsafe { (self.api.SCardFreeMemory)(self.h_card_context, reader_name as *const _) },
+            "SCardFreeMemory failed"
+        )?;
+
+        let status = Status {
+            readers,
+            state: state.try_into()?,
+            protocol: Protocol::from_bits(protocol).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InternalError,
+                    format!("Invalid protocol value: {}", protocol),
+                )
+            })?,
+            atr: atr.into(),
+        };
+
+        Ok(status)
+    }
+
+    fn control(&mut self, code: ControlCode, input: &[u8]) -> WinScardResult<()> {
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe {
+                (self.api.SCardControl)(
+                    self.h_card()?,
+                    code,
+                    input.as_ptr() as *const _,
+                    input.len().try_into()?,
+                    null_mut(),
+                    0,
+                    null_mut(),
+                )
+            },
+            "SCardControl failed"
+        )?;
+
+        Ok(())
+    }
+
+    fn control_with_output(&mut self, code: ControlCode, input: &[u8], output: &mut [u8]) -> WinScardResult<usize> {
+        let mut receive_len = 0;
+        let output_buf_len = output.len().try_into()?;
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe {
+                (self.api.SCardControl)(
+                    self.h_card()?,
+                    code,
+                    input.as_ptr() as *const _,
+                    input.len().try_into()?,
+                    output.as_mut_ptr() as *mut _,
+                    output_buf_len,
+                    &mut receive_len,
+                )
+            },
+            "SCardControl failed"
+        )?;
+
+        Ok(receive_len.try_into()?)
+    }
+
+    fn transmit(&mut self, send_pci: IoRequest, input_apdu: &[u8]) -> WinScardResult<TransmitOutData> {
+        // The SCardTransmit function doesn't support SCARD_AUTOALLOCATE attribute. So, we need to allocate
+        // the buffer for the output APDU by ourselves.
+        // The `msclmd.dll` has `I_ClmdCmdExtendedTransmit` and `I_ClmdCmdShortTransmit` functions.
+        // The first one uses 65538-bytes long buffer for output APDU, and the second one uses 258-bytes long buffer.
+        // We decided to always use the larger one.
+        const OUT_APDU_BUF_LEN: usize = 65538;
+
+        // * https://learn.microsoft.com/en-us/windows/win32/secauthn/scard-io-request
+        // * https://pcsclite.apdu.fr/api/structSCARD__IO__REQUEST.html#details
+        //
+        // The SCARD_IO_REQUEST structure begins a protocol control information structure.
+        // Any protocol-specific information then immediately follows this structure.
+        //
+        // Length, in bytes, of the SCARD_IO_REQUEST structure plus any following PCI-specific information.
+        let length = size_of::<ScardIoRequest>() + send_pci.pci_info.len();
+
+        let mut scard_io_request = vec![0_u8; length];
+        scard_io_request[size_of::<ScardIoRequest>()..].copy_from_slice(&send_pci.pci_info);
+
+        let poi_send_pci = scard_io_request.as_mut_ptr() as *mut ScardIoRequest;
+
+        let mut output_apdu_len = OUT_APDU_BUF_LEN.try_into()?;
+        let mut output_apdu = [0; OUT_APDU_BUF_LEN];
+
+        // SAFETY: The `poi_send_pci` pointer is created from the local allocated memory and should
+        // be valid in the current context.
+        unsafe {
+            (*poi_send_pci).dw_protocol = send_pci.protocol.bits();
+            (*poi_send_pci).cb_pci_length = length.try_into()?;
+        }
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe {
+                (self.api.SCardTransmit)(
+                    self.h_card()?,
+                    poi_send_pci,
+                    input_apdu.as_ptr(),
+                    input_apdu.len().try_into()?,
+                    // https://pcsclite.apdu.fr/api/group__API.html#ga9a2d77242a271310269065e64633ab99
+                    // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardtransmit
+                    //
+                    // pioRecvPci: This parameter can be NULL if no PCI is returned.
+                    null_mut(),
+                    output_apdu.as_mut_ptr(),
+                    &mut output_apdu_len,
+                )
+            },
+            "SCardTransmit failed"
+        )?;
+
+        Ok(TransmitOutData {
+            output_apdu: output_apdu[0..output_apdu_len.try_into()?].to_vec(),
+            receive_pci: None,
+        })
+    }
+
+    fn begin_transaction(&mut self) -> WinScardResult<()> {
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked.
+            unsafe { (self.api.SCardBeginTransaction)(self.h_card()?) },
+            "SCardBeginTransaction failed"
+        )
+    }
+
+    fn end_transaction(&mut self, disposition: ReaderAction) -> WinScardResult<()> {
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and the `disposition` parameter is type checked.
+            unsafe { (self.api.SCardEndTransaction)(self.h_card()?, disposition.into()) },
+            "SCardEndTransaction failed"
+        )
+    }
+
+    fn reconnect(
+        &mut self,
+        share_mode: ShareMode,
+        preferred_protocol: Option<Protocol>,
+        initialization: ReaderAction,
+    ) -> WinScardResult<Protocol> {
+        let dw_preferred_protocols = preferred_protocol.unwrap_or_default().bits();
+        let mut active_protocol = 0;
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe {
+                (self.api.SCardReconnect)(
+                    self.h_card()?,
+                    share_mode.into(),
+                    dw_preferred_protocols,
+                    initialization.into(),
+                    &mut active_protocol,
+                )
+            },
+            "SCardReconnect failed"
+        )?;
+
+        Ok(Protocol::from_bits(active_protocol).unwrap_or_default())
+    }
+
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
+        let attr_id = attribute_id
+            .to_u32()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "cannot convert AttributeId -> u32"))?;
+        let mut data_len = 0;
+
+        // https://pcsclite.apdu.fr/api/group__API.html#gaacfec51917255b7a25b94c5104961602
+        // If this value is NULL, SCardGetAttrib() ignores the buffer length supplied in pcbAttrLen, writes the length of the buffer
+        // that would have been returned if this parameter had not been NULL to pcbAttrLen, and returns a success code.
+        //
+        // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetattrib
+        // If this value is NULL, SCardGetAttrib ignores the buffer length supplied in pcbAttrLen,
+        // writes the length of the buffer that would have been returned if this parameter
+        // had not been NULL to pcbAttrLen, and returns a success code.
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe { (self.api.SCardGetAttrib)(self.h_card()?, attr_id, null_mut(), &mut data_len) },
+            "SCardGetAttrib failed"
+        )?;
+
+        let mut data = vec![0; data_len.try_into()?];
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe { (self.api.SCardGetAttrib)(self.h_card()?, attr_id, data.as_mut_ptr(), &mut data_len) },
+            "SCardGetAttrib failed"
+        )?;
+
+        Ok(Cow::Owned(data))
+    }
+
+    fn set_attribute(&mut self, attribute_id: AttributeId, attribute_data: &[u8]) -> WinScardResult<()> {
+        let attr_id = attribute_id
+            .to_u32()
+            .ok_or_else(|| Error::new(ErrorKind::InternalError, "cannot convert AttributeId -> u32"))?;
+
+        let len = attribute_data.len().try_into()?;
+
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is checked
+            // and other function parameters are type checked.
+            unsafe { (self.api.SCardSetAttrib)(self.h_card()?, attr_id, attribute_data.as_ptr(), len) },
+            "SCardSetAttrib failed"
+        )
+    }
+
+    fn disconnect(&mut self, disposition: ReaderAction) -> WinScardResult<()> {
+        try_execute!(
+            // SAFETY: This function is safe to call because `self.h_card` is always a valid handle
+            // and the `disposition` parameter is type checked.
+            unsafe { (self.api.SCardDisconnect)(self.h_card()?, disposition.into()) },
+            "SCardDisconnect failed"
+        )?;
+
+        // Mark the current card handle as disconnected.
+        self.h_card = HandleState::Disconnected;
+
+        Ok(())
+    }
+}

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -1,0 +1,644 @@
+use std::borrow::Cow;
+use std::ffi::CString;
+use std::ptr::{null, null_mut};
+#[cfg(target_os = "windows")]
+use std::slice::from_raw_parts;
+
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::functions::SCardApiFunctionTable;
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::{ScardContext, ScardHandle};
+use uuid::Uuid;
+use winscard::winscard::{
+    DeviceTypeId, Icon, Protocol, ProviderId, ReaderState, ScardConnectData, ScardScope, ShareMode, WinScardContext,
+};
+use winscard::{Error, ErrorKind, WinScardResult};
+
+use super::{parse_multi_string_owned, SystemScard};
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::{initialize_pcsc_lite_api, ScardContext, ScardHandle};
+
+pub struct SystemScardContext {
+    h_context: ScardContext,
+    #[cfg(target_os = "windows")]
+    api: SCardApiFunctionTable,
+    #[cfg(not(target_os = "windows"))]
+    api: PcscLiteApiFunctionTable,
+}
+
+impl SystemScardContext {
+    #[allow(dead_code)]
+    pub fn establish(scope: ScardScope) -> WinScardResult<Self> {
+        let mut h_context = 0;
+
+        #[cfg(target_os = "windows")]
+        let api = super::init_scard_api_table()?;
+        #[cfg(not(target_os = "windows"))]
+        let api = initialize_pcsc_lite_api()?;
+
+        try_execute!(
+            // SAFETY: This function is safe to call because the `scope` parameter value is type checked
+            // and `*mut h_context` can't be `null`.
+            unsafe { (api.SCardEstablishContext)(scope.into(), null_mut(), null_mut(), &mut h_context) },
+            "SCardEstablishContext failed"
+        )?;
+
+        if h_context == 0 {
+            return Err(Error::new(
+                ErrorKind::InternalError,
+                "can not establish context: SCardEstablishContext did not set the context handle",
+            ));
+        }
+
+        Ok(Self { h_context, api })
+    }
+}
+
+impl Drop for SystemScardContext {
+    fn drop(&mut self) {
+        if let Err(err) = try_execute!(
+            // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+            unsafe { (self.api.SCardReleaseContext)(self.h_context) },
+            "SCardReleaseContext failed"
+        ) {
+            error!(?err, "Can not release the scard context");
+        }
+    }
+}
+
+impl WinScardContext for SystemScardContext {
+    fn connect(
+        &self,
+        reader_name: &str,
+        share_mode: ShareMode,
+        protocol: Option<Protocol>,
+    ) -> WinScardResult<ScardConnectData> {
+        let c_string = CString::new(reader_name)?;
+
+        let mut scard: ScardHandle = 0;
+        let mut active_protocol = 0;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardConnect)(
+                        self.h_context,
+                        c_string.as_ptr() as *const _,
+                        share_mode.into(),
+                        protocol.unwrap_or_default().bits(),
+                        &mut scard,
+                        &mut active_protocol,
+                    )
+                },
+                "SCardConnect failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardConnectA)(
+                        self.h_context,
+                        c_string.as_ptr() as *const _,
+                        share_mode.into(),
+                        protocol.unwrap_or_default().bits(),
+                        &mut scard,
+                        &mut active_protocol,
+                    )
+                },
+                "SCardConnectA failed"
+            )?;
+        }
+
+        let handle = Box::new(SystemScard::new(scard, self.h_context)?);
+
+        Ok(ScardConnectData {
+            handle,
+            protocol: Protocol::from_bits(active_protocol).unwrap_or_default(),
+        })
+    }
+
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>> {
+        let mut readers_buf_len = 0;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // https://pcsclite.apdu.fr/api/group__API.html#ga93b07815789b3cf2629d439ecf20f0d9
+            //
+            // If the application sends mszGroups and mszReaders as NULL then this function will return the size of the buffer needed to allocate in pcchReaders.
+            // `mszGroups`: List of groups to list readers (not used).
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe { (self.api.SCardListReaders)(self.h_context, null(), null_mut(), &mut readers_buf_len) },
+                "SCardListReaders failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadersa
+            //
+            //  If this value is NULL, SCardListReaders ignores the buffer length supplied in pcchReaders,
+            //  writes the length of the buffer that would have been returned if this parameter
+            //  had not been NULL to pcchReaders, and returns a success code.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe { (self.api.SCardListReadersA)(self.h_context, null(), null_mut(), &mut readers_buf_len) },
+                "SCardListReadersA failed"
+            )?;
+        }
+
+        let mut readers = vec![0; readers_buf_len.try_into()?];
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListReaders)(self.h_context, null(), readers.as_mut_ptr(), &mut readers_buf_len)
+                },
+                "SCardListReaders failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListReadersA)(self.h_context, null(), readers.as_mut_ptr(), &mut readers_buf_len)
+                },
+                "SCardListReadersA failed"
+            )?;
+        }
+
+        parse_multi_string_owned(&readers)
+    }
+
+    fn device_type_id(&self, _reader_name: &str) -> WinScardResult<DeviceTypeId> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetDeviceTypeId function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use num_traits::FromPrimitive;
+
+            let mut device_type_id = 0;
+
+            let c_reader_name = CString::new(_reader_name)?;
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardGetDeviceTypeIdA)(
+                        self.h_context,
+                        c_reader_name.as_ptr() as *const _,
+                        &mut device_type_id,
+                    )
+                },
+                "SCardGetDeviceTypeIdA failed"
+            )?;
+
+            DeviceTypeId::from_u32(device_type_id).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InternalError,
+                    format!("WinSCard has returned invalid device type id: {}", device_type_id),
+                )
+            })
+        }
+    }
+
+    fn reader_icon(&self, _reader_name: &str) -> WinScardResult<Icon> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetReaderIcon function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let c_reader_name = CString::new(_reader_name)?;
+
+            let mut icon_buf_len = 0;
+
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetreadericona
+            //
+            // If this value is NULL, the function ignores the buffer length supplied in the pcbIcon parameter,
+            // writes the length of the buffer that would have been returned to pcbIcon if this parameter
+            // had not been NULL, and returns a success code.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardGetReaderIconA)(
+                        self.h_context,
+                        c_reader_name.as_ptr() as *const _,
+                        null_mut(),
+                        &mut icon_buf_len,
+                    )
+                },
+                "SCardGetReaderIconA failed"
+            )?;
+
+            let mut icon_buf = vec![0; icon_buf_len.try_into()?];
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardGetReaderIconA)(
+                        self.h_context,
+                        c_reader_name.as_ptr() as *const _,
+                        icon_buf.as_mut_ptr(),
+                        &mut icon_buf_len,
+                    )
+                },
+                "SCardGetReaderIconA failed"
+            )?;
+
+            Ok(icon_buf.into())
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        try_execute!(
+            // SAFETY: This function is safe to call because we are allowed to pass any value.
+            unsafe { (self.api.SCardIsValidContext)(self.h_context) },
+            "SCardIsValidContext failed"
+        )
+        .is_ok()
+    }
+
+    fn read_cache(&self, _card_id: Uuid, _freshness_counter: u32, _key: &str) -> WinScardResult<Cow<[u8]>> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardReadCache function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use super::uuid_to_c_guid;
+            use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
+
+            let mut data_len = SCARD_AUTOALLOCATE;
+
+            let c_cache_key = CString::new(_key)?;
+            let mut card_id = uuid_to_c_guid(_card_id);
+
+            let mut data: *mut u8 = null_mut();
+
+            // It's not specified in the `SCardReadCacheA` function documentation, but after some
+            // `msclmd.dll` reversing, we found out that this function supports the `SCARD_AUTOALLOCATE`.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardReadCacheA)(
+                        self.h_context,
+                        &mut card_id,
+                        _freshness_counter,
+                        c_cache_key.into_raw() as *mut _,
+                        ((&mut data) as *mut *mut u8) as *mut _,
+                        &mut data_len,
+                    )
+                },
+                "SCardReadCacheA failed"
+            )?;
+
+            let data_len: usize = if let Ok(len) = data_len.try_into() {
+                len
+            } else {
+                try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+                    unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
+                    "SCardFreeMemory failed"
+                )?;
+
+                return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
+            };
+
+            let mut cache_item = vec![0; data_len];
+            cache_item.copy_from_slice(
+                // SAFETY: A slice creation is safe here because the `data` pointer is a local pointer and
+                // was initialized by `SCardReadCacheA` function.
+                unsafe { from_raw_parts(data, data_len) },
+            );
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+                unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
+                "SCardFreeMemory failed"
+            )?;
+
+            Ok(Cow::Owned(cache_item))
+        }
+    }
+
+    fn write_cache(
+        &mut self,
+        _card_id: Uuid,
+        _freshness_counter: u32,
+        _key: String,
+        mut _value: Vec<u8>,
+    ) -> WinScardResult<()> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardWriteCache function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use super::uuid_to_c_guid;
+
+            let c_cache_key = CString::new(_key.as_str())?;
+            let mut card_id = uuid_to_c_guid(_card_id);
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardWriteCacheA)(
+                        self.h_context,
+                        &mut card_id,
+                        _freshness_counter,
+                        c_cache_key.into_raw() as *mut _,
+                        _value.as_mut_ptr(),
+                        _value.len().try_into()?,
+                    )
+                },
+                "SCardWriteCacheA failed"
+            )
+        }
+    }
+
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {
+        let mut reader_groups_buf_len = 0;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // https://pcsclite.apdu.fr/api/group__API.html#ga9d970d086d5218e080d0079d63f9d496
+            //
+            // If the application sends mszGroups as NULL then this function will return the size of the buffer needed to allocate in pcchGroups.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe { (self.api.SCardListReaderGroups)(self.h_context, null_mut(), &mut reader_groups_buf_len) },
+                "SCardListReaderGroups failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadergroupsw
+            //
+            // If this value is NULL, SCardListReaderGroups ignores the buffer length supplied in pcchGroups,
+            // writes the length of the buffer that would have been returned if this parameter had not been
+            // NULL to pcchGroups, and returns a success code.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe { (self.api.SCardListReaderGroupsA)(self.h_context, null_mut(), &mut reader_groups_buf_len) },
+                "SCardListReaderGroupsA failed"
+            )?;
+        }
+
+        let mut reader_groups = vec![0; reader_groups_buf_len.try_into()?];
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListReaderGroups)(
+                        self.h_context,
+                        reader_groups.as_mut_ptr(),
+                        &mut reader_groups_buf_len,
+                    )
+                },
+                "SCardListReaderGroups failed"
+            )?;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListReaderGroupsA)(
+                        self.h_context,
+                        reader_groups.as_mut_ptr(),
+                        &mut reader_groups_buf_len,
+                    )
+                },
+                "SCardListReaderGroupsA failed"
+            )?;
+        }
+
+        parse_multi_string_owned(&reader_groups)
+    }
+
+    fn cancel(&mut self) -> WinScardResult<()> {
+        // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+        try_execute!(unsafe { (self.api.SCardCancel)(self.h_context) }, "SCardCancel failed")
+    }
+
+    fn get_status_change(&self, _timeout: u32, _reader_states: &mut [ReaderState]) -> WinScardResult<()> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetStatusChangeW function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use std::ffi::NulError;
+
+            use ffi_types::winscard::ScardReaderStateA;
+            use winscard::winscard::CurrentState;
+
+            let mut states = Vec::with_capacity(_reader_states.len());
+            let c_readers = _reader_states
+                .iter()
+                .map(|reader_state| CString::new(reader_state.reader_name.as_ref()))
+                .collect::<Result<Vec<CString>, NulError>>()?;
+
+            for (reader_state, c_reader) in _reader_states.iter_mut().zip(c_readers.iter()) {
+                states.push(ScardReaderStateA {
+                    sz_reader: c_reader.as_ptr() as *const _,
+                    pv_user_data: reader_state.user_data as _,
+                    dw_current_state: reader_state.current_state.bits(),
+                    dw_event_state: reader_state.event_state.bits(),
+                    cb_atr: reader_state.atr_len.try_into()?,
+                    rgb_atr: reader_state.atr,
+                });
+            }
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardGetStatusChangeA)(
+                        self.h_context,
+                        _timeout,
+                        states.as_mut_ptr(),
+                        _reader_states.len().try_into()?,
+                    )
+                },
+                "SCardGetStatusChangeA failed"
+            )?;
+
+            // We do not need to change all fields. Only event state and atr values can be changed.
+            for (state, reader_state) in states.iter().zip(_reader_states.iter_mut()) {
+                reader_state.event_state = CurrentState::from_bits(state.dw_event_state)
+                    .ok_or_else(|| Error::new(ErrorKind::InternalError, "invalid dwEventState"))?;
+                reader_state.atr_len = state.cb_atr.try_into()?;
+                reader_state.atr = state.rgb_atr;
+            }
+
+            Ok(())
+        }
+    }
+
+    fn list_cards(&self, _atr: Option<&[u8]>, _required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetStatusChangeW function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use crate::winscard::system_scard::uuid_to_c_guid;
+
+            let mut cards_buf_len = 0;
+            let atr = _atr.map(|a| a.as_ptr()).unwrap_or(null());
+            let uuids = _required_interfaces
+                .into_iter()
+                .flatten()
+                .cloned()
+                .map(uuid_to_c_guid)
+                .collect::<Vec<ffi_types::Uuid>>();
+            let uuids_len = uuids.len().try_into()?;
+            let c_uuids = if uuids.is_empty() { null() } else { uuids.as_ptr() };
+
+            // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistcardsw
+            //
+            // mszCards: If this value is NULL, SCardListCards ignores the buffer length supplied in
+            // pcchCards, returning the length of the buffer that would have been returned if this
+            // parameter had not been NULL to pcchCards and a success code.
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListCardsA)(self.h_context, atr, c_uuids, uuids_len, null_mut(), &mut cards_buf_len)
+                },
+                "SCardListCardsA failed"
+            )?;
+
+            let mut cards = vec![0; cards_buf_len.try_into()?];
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardListCardsA)(
+                        self.h_context,
+                        atr,
+                        c_uuids,
+                        uuids_len,
+                        cards.as_mut_ptr(),
+                        &mut cards_buf_len,
+                    )
+                },
+                "SCardListCardsA failed"
+            )?;
+
+            parse_multi_string_owned(&cards)
+        }
+    }
+
+    fn get_card_type_provider_name(&self, _card_name: &str, _provider_id: ProviderId) -> WinScardResult<Cow<str>> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            Err(Error::new(
+                ErrorKind::UnsupportedFeature,
+                "SCardGetCardTypeProviderNameW function is not supported in PCSC-lite API",
+            ))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
+
+            let mut data_len = SCARD_AUTOALLOCATE;
+            let mut data: *mut u8 = null_mut();
+
+            let c_card_name = CString::new(_card_name)?;
+
+            try_execute!(
+                // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
+                // and other parameters are type checked.
+                unsafe {
+                    (self.api.SCardGetCardTypeProviderNameA)(
+                        self.h_context,
+                        c_card_name.as_ptr() as *const _,
+                        _provider_id.into(),
+                        ((&mut data) as *mut *mut u8) as *mut _,
+                        &mut data_len,
+                    )
+                },
+                "SCardGetCardTypeProviderNameA failed"
+            )?;
+
+            let data_len: usize = if let Ok(len) = data_len.try_into() {
+                len
+            } else {
+                try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+                    unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
+                    "SCardFreeMemory failed"
+                )?;
+
+                return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
+            };
+
+            let name = if let Ok(name) = String::from_utf8(
+                // SAFETY: A slice create is safe because the `data` pointer is a local pointer and
+                // was initialized by `SCardGetCardTypeProviderNameA` function.
+                unsafe { from_raw_parts(data, data_len) }.to_vec(),
+            ) {
+                name
+            } else {
+                try_execute!(
+                    // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle.
+                    unsafe { (self.api.SCardFreeMemory)(self.h_context, data as *const _) },
+                    "SCardFreeMemory failed"
+                )?;
+
+                return Err(Error::new(ErrorKind::InternalError, "u32 to usize conversion error"));
+            };
+
+            Ok(Cow::Owned(name))
+        }
+    }
+}

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -1,0 +1,16 @@
+macro_rules! try_execute {
+    ($x:expr, $msg:expr) => {{
+        use num_traits::FromPrimitive;
+        use winscard::{Error, ErrorKind};
+
+        let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);
+        if error_kind == ErrorKind::Success {
+            Ok(())
+        } else {
+            Err(Error::new(error_kind, $msg))
+        }
+    }};
+    ($x:expr) => {
+        try_execute!($x, "")
+    };
+}

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,0 +1,166 @@
+#![cfg(feature = "scard")]
+#![warn(clippy::undocumented_unsafe_blocks)]
+
+#[macro_use]
+mod macros;
+
+mod card;
+mod context;
+
+use std::borrow::Cow;
+
+pub use card::SystemScard;
+pub use context::SystemScardContext;
+#[cfg(target_os = "windows")]
+use ffi_types::winscard::functions::SCardApiFunctionTable;
+use winscard::WinScardResult;
+
+fn parse_multi_string(buf: &[u8]) -> WinScardResult<Vec<&str>> {
+    let res: Result<Vec<&str>, _> = buf
+        .split(|&c| c == 0)
+        .filter(|v| !v.is_empty())
+        .map(std::str::from_utf8)
+        .collect();
+
+    Ok(res?)
+}
+
+fn parse_multi_string_owned(buf: &[u8]) -> WinScardResult<Vec<Cow<'static, str>>> {
+    Ok(parse_multi_string(buf)?
+        .into_iter()
+        .map(|r| Cow::Owned(r.to_owned()))
+        .collect())
+}
+
+#[cfg(target_os = "windows")]
+fn uuid_to_c_guid(id: uuid::Uuid) -> ffi_types::Uuid {
+    let (data1, data2, data3, data4) = id.as_fields();
+
+    ffi_types::Uuid {
+        data1,
+        data2,
+        data3,
+        data4: *data4,
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn init_scard_api_table() -> WinScardResult<SCardApiFunctionTable> {
+    use std::env;
+    use std::ffi::CString;
+    use std::mem::transmute;
+
+    use windows_sys::s;
+    use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
+    use winscard::{Error, ErrorKind};
+
+    /// Path to the `winscard` module.
+    ///
+    /// The user can use this environment variable to customize the `winscard` library loading.
+    const WINSCARD_LIB_PATH_ENV: &str = "WINSCARD_LIB_PATH";
+
+    let file_name = CString::new(if let Ok(lib_path) = env::var(WINSCARD_LIB_PATH_ENV) {
+        lib_path.into_bytes()
+    } else {
+        "WinSCard.dll".as_bytes().to_vec()
+    })?;
+
+    // SAFETY: This function is safe to call because the `file_name.as_ptr()` is guaranteed to be
+    // the null-terminated C string by `CString` type.
+    let winscard_module = unsafe { LoadLibraryA(file_name.as_ptr() as *const _) };
+
+    if winscard_module == 0 {
+        return Err(Error::new(
+            ErrorKind::InternalError,
+            "can not load the winscard module: LoadLibrary function has returned NULL",
+        ));
+    } else {
+        info!("The winscard module has been loaded");
+    }
+
+    macro_rules! load_fn {
+        ($func_name:literal) => {{
+            // SAFETY: This function is safe to call because we've checked the `winscard_mofule`
+            // handle above and the `$func_name` is correct and hardcoded in the code.
+            unsafe { transmute(GetProcAddress(winscard_module, s!($func_name))) }
+        }};
+    }
+
+    Ok(SCardApiFunctionTable {
+        dw_version: 0,
+        dw_flags: 0,
+        SCardEstablishContext: load_fn!("SCardEstablishContext"),
+        SCardReleaseContext: load_fn!("SCardReleaseContext"),
+        SCardIsValidContext: load_fn!("SCardIsValidContext"),
+        SCardListReaderGroupsA: load_fn!("SCardListReaderGroupsA"),
+        SCardListReaderGroupsW: load_fn!("SCardListReaderGroupsW"),
+        SCardListReadersA: load_fn!("SCardListReadersA"),
+        SCardListReadersW: load_fn!("SCardListReadersW"),
+        SCardListCardsA: load_fn!("SCardListCardsA"),
+        SCardListCardsW: load_fn!("SCardListCardsW"),
+        SCardListInterfacesA: load_fn!("SCardListInterfacesA"),
+        SCardListInterfacesW: load_fn!("SCardListInterfacesW"),
+        SCardGetProviderIdA: load_fn!("SCardGetProviderIdA"),
+        SCardGetProviderIdW: load_fn!("SCardGetProviderIdW"),
+        SCardGetCardTypeProviderNameA: load_fn!("SCardGetCardTypeProviderNameA"),
+        SCardGetCardTypeProviderNameW: load_fn!("SCardGetCardTypeProviderNameW"),
+        SCardIntroduceReaderGroupA: load_fn!("SCardIntroduceReaderGroupA"),
+        SCardIntroduceReaderGroupW: load_fn!("SCardIntroduceReaderGroupW"),
+        SCardForgetReaderGroupA: load_fn!("SCardForgetReaderGroupA"),
+        SCardForgetReaderGroupW: load_fn!("SCardForgetReaderGroupW"),
+        SCardIntroduceReaderA: load_fn!("SCardIntroduceReaderA"),
+        SCardIntroduceReaderW: load_fn!("SCardIntroduceReaderW"),
+        SCardForgetReaderA: load_fn!("SCardForgetReaderA"),
+        SCardForgetReaderW: load_fn!("SCardForgetReaderW"),
+        SCardAddReaderToGroupA: load_fn!("SCardAddReaderToGroupA"),
+        SCardAddReaderToGroupW: load_fn!("SCardAddReaderToGroupW"),
+        SCardRemoveReaderFromGroupA: load_fn!("SCardRemoveReaderFromGroupA"),
+        SCardRemoveReaderFromGroupW: load_fn!("SCardRemoveReaderFromGroupW"),
+        SCardIntroduceCardTypeA: load_fn!("SCardIntroduceCardTypeA"),
+        SCardIntroduceCardTypeW: load_fn!("SCardIntroduceCardTypeW"),
+        SCardSetCardTypeProviderNameA: load_fn!("SCardSetCardTypeProviderNameA"),
+        SCardSetCardTypeProviderNameW: load_fn!("SCardSetCardTypeProviderNameW"),
+        SCardFreeMemory: load_fn!("SCardFreeMemory"),
+        SCardAccessStartedEvent: load_fn!("SCardAccessStartedEvent"),
+        SCardReleaseStartedEvent: load_fn!("SCardReleaseStartedEvent"),
+        SCardLocateCardsA: load_fn!("SCardLocateCardsA"),
+        SCardLocateCardsW: load_fn!("SCardLocateCardsW"),
+        SCardLocateCardsByATRA: load_fn!("SCardLocateCardsByATRA"),
+        SCardLocateCardsByATRW: load_fn!("SCardLocateCardsByATRW"),
+        SCardGetStatusChangeA: load_fn!("SCardGetStatusChangeA"),
+        SCardGetStatusChangeW: load_fn!("SCardGetStatusChangeW"),
+        SCardCancel: load_fn!("SCardCancel"),
+        SCardConnectA: load_fn!("SCardConnectA"),
+        SCardConnectW: load_fn!("SCardConnectW"),
+        SCardReconnect: load_fn!("SCardReconnect"),
+        SCardDisconnect: load_fn!("SCardDisconnect"),
+        SCardBeginTransaction: load_fn!("SCardBeginTransaction"),
+        SCardEndTransaction: load_fn!("SCardEndTransaction"),
+        SCardCancelTransaction: load_fn!("SCardCancelTransaction"),
+        SCardState: load_fn!("SCardState"),
+        SCardStatusA: load_fn!("SCardStatusA"),
+        SCardStatusW: load_fn!("SCardStatusW"),
+        SCardTransmit: load_fn!("SCardTransmit"),
+        SCardGetTransmitCount: load_fn!("SCardGetTransmitCount"),
+        SCardControl: load_fn!("SCardControl"),
+        SCardGetAttrib: load_fn!("SCardGetAttrib"),
+        SCardSetAttrib: load_fn!("SCardSetAttrib"),
+        SCardUIDlgSelectCardA: load_fn!("SCardUIDlgSelectCardA"),
+        SCardUIDlgSelectCardW: load_fn!("SCardUIDlgSelectCardW"),
+        GetOpenCardNameA: load_fn!("GetOpenCardNameA"),
+        GetOpenCardNameW: load_fn!("GetOpenCardNameW"),
+        SCardReadCacheA: load_fn!("SCardReadCacheA"),
+        SCardReadCacheW: load_fn!("SCardReadCacheW"),
+        SCardWriteCacheA: load_fn!("SCardWriteCacheA"),
+        SCardWriteCacheW: load_fn!("SCardWriteCacheW"),
+        SCardGetReaderIconA: load_fn!("SCardGetReaderIconA"),
+        SCardGetReaderIconW: load_fn!("SCardGetReaderIconW"),
+        SCardGetDeviceTypeIdA: load_fn!("SCardGetDeviceTypeIdA"),
+        SCardGetDeviceTypeIdW: load_fn!("SCardGetDeviceTypeIdW"),
+        SCardGetReaderDeviceInstanceIdA: load_fn!("SCardGetReaderDeviceInstanceIdA"),
+        SCardGetReaderDeviceInstanceIdW: load_fn!("SCardGetReaderDeviceInstanceIdW"),
+        SCardListReadersWithDeviceInstanceIdA: load_fn!("SCardListReadersWithDeviceInstanceIdA"),
+        SCardListReadersWithDeviceInstanceIdW: load_fn!("SCardListReadersWithDeviceInstanceIdW"),
+        SCardAudit: load_fn!("SCardAudit"),
+    })
+}

--- a/ffi/src/winscard/system_scard/mod.rs
+++ b/ffi/src/winscard/system_scard/mod.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "scard")]
-#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 mod macros;

--- a/src/cert_utils.rs
+++ b/src/cert_utils.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "scard", target_os = "windows"))]
+
 use std::ffi::c_void;
 use std::ptr::{null, null_mut};
 use std::slice::from_raw_parts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ pub mod pku2u;
 #[allow(unreachable_patterns)]
 mod auth_identity;
 mod ber;
-#[cfg(feature = "scard")]
 pub mod cert_utils;
 mod crypto;
 mod decrypt_buffer;
@@ -76,16 +75,11 @@ mod dns;
 mod kdc;
 mod krb;
 mod secret;
-#[cfg(feature = "scard")]
-#[allow(dead_code)]
 mod smartcard;
 mod utils;
 
 #[cfg(all(feature = "tsssp", not(target_os = "windows")))]
 compile_error!("tsssp feature should be used only on Windows");
-
-#[cfg(all(feature = "scard", not(target_os = "windows")))]
-compile_error!("scard feature should be used only on Windows");
 
 use std::{error, fmt, io, result, str, string};
 

--- a/src/smartcard.rs
+++ b/src/smartcard.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "scard")]
+
 use std::borrow::Cow;
 use std::fmt;
 
@@ -9,15 +11,8 @@ use winscard::SmartCard as PivSmartCard;
 
 use crate::{Error, ErrorKind, Result};
 
-// ISO/IEC 7816-4
-const CLA_BYTE_NO_CHAINING: u8 = 0x00;
-const CLA_BYTE_CHAINING: u8 = 0x10;
-// the max amount of data a one APDU command can contain
-const APDU_COMMAND_DATA_SIZE: usize = 255;
-// tag is always 1 byte in length
-const TLV_TAG_LENGTH: usize = 1;
-
 pub enum SmartCardApi {
+    #[allow(dead_code)]
     WinSCard(Card),
     PivSmartCard(Box<PivSmartCard<'static>>),
 }
@@ -39,6 +34,7 @@ pub struct SmartCard {
 }
 
 impl SmartCard {
+    #[allow(dead_code)]
     pub fn new(pin: Vec<u8>, scard_reader_name: &str, private_key_file_index: u8) -> Result<Self> {
         let context = Context::establish(Scope::User)?;
         let readers_len = context.list_readers_len()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,44 +56,44 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
         KDC_ERR_NONE => (ErrorKind::Unknown, "No error".into()),
         KDC_ERR_NAME_EXP => (
             ErrorKind::InvalidParameter,
-            "Client's entry in database has expired".into(),
+            "client's entry in database has expired".into(),
         ),
         KDC_ERR_SERVICE_EXP => (
             ErrorKind::InvalidParameter,
-            "Server's entry in database has expired".into(),
+            "server's entry in database has expired".into(),
         ),
         KDC_ERR_BAD_PVNO => (
             ErrorKind::KdcInvalidRequest,
-            "Requested protocol version number not supported".into(),
+            "requested protocol version number not supported".into(),
         ),
         KDC_ERR_C_OLD_MAST_KVNO => (
             ErrorKind::EncryptFailure,
-            "Client's key encrypted in old master key".into(),
+            "client's key encrypted in old master key".into(),
         ),
         KDC_ERR_S_OLD_MAST_KVNO => (
             ErrorKind::EncryptFailure,
-            "Server's key encrypted in old master key".into(),
+            "server's key encrypted in old master key".into(),
         ),
         KDC_ERR_C_PRINCIPAL_UNKNOWN => (
             ErrorKind::UnknownCredentials,
-            "Client not found in Kerberos database".into(),
+            "client not found in Kerberos database".into(),
         ),
         KDC_ERR_S_PRINCIPAL_UNKNOWN => (
             ErrorKind::UnknownCredentials,
-            "Server not found in Kerberos database".into(),
+            "server not found in Kerberos database".into(),
         ),
         KDC_ERR_PRINCIPAL_NOT_UNIQUE => (
             ErrorKind::TooManyPrincipals,
-            "Multiple principal entries database".into(),
+            "multiple principal entries database".into(),
         ),
-        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "The client or server has a null key".into()),
+        KDC_ERR_NULL_KEY => (ErrorKind::EncryptFailure, "the client or server has null key".into()),
         KDC_ERR_CANNOT_POSTDATE => (
             ErrorKind::KdcInvalidRequest,
-            "Ticket not eligible for postdating".into(),
+            "ticket not eligible for postdating".into(),
         ),
         KDC_ERR_NEVER_VALID => (
             ErrorKind::KdcInvalidRequest,
-            "Requested starttime is later than end time".into(),
+            "requested starttime is later than end time".into(),
         ),
         KDC_ERR_POLICY => (ErrorKind::KdcInvalidRequest, "KDC policy rejects request".into()),
         KDC_ERR_BADOPTION => (
@@ -118,109 +118,109 @@ pub fn map_keb_error_code_to_sspi_error(krb_error_code: u32) -> (ErrorKind, Stri
         ),
         KDC_ERR_CLIENT_REVOKED => (
             ErrorKind::UnknownCredentials,
-            "Clients credentials have been revoked".into(),
+            "clients credentials have been revoked".into(),
         ),
         KDC_ERR_SERVICE_REVOKED => (
             ErrorKind::UnknownCredentials,
-            "Credentials for server have been revoked".into(),
+            "credentials for server have been revoked".into(),
         ),
         KDC_ERR_TGT_REVOKED => (ErrorKind::UnknownCredentials, "TGT has been revoked".into()),
         KDC_ERR_CLIENT_NOTYET => (
             ErrorKind::UnknownCredentials,
-            "Client not yet valid; try again later".into(),
+            "client not yet valid; try again later".into(),
         ),
         KDC_ERR_SERVICE_NOTYET => (
             ErrorKind::UnknownCredentials,
-            "Server not yet valid; try again later".into(),
+            "server not yet valid; try again later".into(),
         ),
         KDC_ERR_KEY_EXPIRED => (
             ErrorKind::InvalidParameter,
-            "Password has expired; change password to reset".into(),
+            "password has expired; change password to reset".into(),
         ),
         KDC_ERR_PREAUTH_FAILED => (
             ErrorKind::KdcInvalidRequest,
-            "Pre-authentication information was invalid".into(),
+            "pre-authentication information was invalid".into(),
         ),
         KDC_ERR_PREAUTH_REQUIRED => (
             ErrorKind::KdcInvalidRequest,
-            "Additional preauthentication required".into(),
+            "additional preauthentication required".into(),
         ),
         KDC_ERR_SERVER_NOMATCH => (
             ErrorKind::KdcInvalidRequest,
-            "Requested server and ticket don't match".into(),
+            "requested server and ticket don't match".into(),
         ),
         KDC_ERR_MUST_USE_USER2USER => (
             ErrorKind::KdcInvalidRequest,
-            "Server principal valid for user2user only".into(),
+            "server principal valid for user2user only".into(),
         ),
         KDC_ERR_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "KDC Policy rejects transited path".into()),
-        KDC_ERR_SVC_UNAVAILABLE => (ErrorKind::KdcInvalidRequest, "A service is not available".into()),
+        KDC_ERR_SVC_UNAVAILABLE => (ErrorKind::KdcInvalidRequest, "a service is not available".into()),
         KRB_AP_ERR_BAD_INTEGRITY => (
             ErrorKind::MessageAltered,
-            "Integrity check on decrypted field failed".into(),
+            "integrity check on decrypted field failed".into(),
         ),
-        KRB_AP_ERR_TKT_EXPIRED => (ErrorKind::ContextExpired, "Ticket expired".into()),
-        KRB_AP_ERR_TKT_NYV => (ErrorKind::InvalidToken, "Ticket not yet valid".into()),
-        KRB_AP_ERR_REPEAT => (ErrorKind::KdcInvalidRequest, "Request is a replay".into()),
-        KRB_AP_ERR_NOT_US => (ErrorKind::InvalidToken, "The ticket isn't for us".into()),
+        KRB_AP_ERR_TKT_EXPIRED => (ErrorKind::ContextExpired, "ticket expired".into()),
+        KRB_AP_ERR_TKT_NYV => (ErrorKind::InvalidToken, "ticket not yet valid".into()),
+        KRB_AP_ERR_REPEAT => (ErrorKind::KdcInvalidRequest, "request is a replay".into()),
+        KRB_AP_ERR_NOT_US => (ErrorKind::InvalidToken, "the ticket isn't for us".into()),
         KRB_AP_ERR_BADMATCH => (
             ErrorKind::KdcInvalidRequest,
-            "Ticket and authenticator don't match".into(),
+            "ticket and authenticator don't match".into(),
         ),
-        KRB_AP_ERR_SKEW => (ErrorKind::TimeSkew, "Clock skew too great".into()),
-        KRB_AP_ERR_BADADDR => (ErrorKind::InvalidParameter, "Incorrect net address".into()),
-        KRB_AP_ERR_BADVERSION => (ErrorKind::KdcInvalidRequest, "Protocol version mismatch".into()),
-        KRB_AP_ERR_MSG_TYPE => (ErrorKind::InvalidToken, "Invalid msg type".into()),
-        KRB_AP_ERR_MODIFIED => (ErrorKind::MessageAltered, "Message stream modified".into()),
-        KRB_AP_ERR_BADORDER => (ErrorKind::OutOfSequence, "Message out of order".into()),
+        KRB_AP_ERR_SKEW => (ErrorKind::TimeSkew, "clock skew too great".into()),
+        KRB_AP_ERR_BADADDR => (ErrorKind::InvalidParameter, "incorrect net address".into()),
+        KRB_AP_ERR_BADVERSION => (ErrorKind::KdcInvalidRequest, "protocol version mismatch".into()),
+        KRB_AP_ERR_MSG_TYPE => (ErrorKind::InvalidToken, "invalid msg type".into()),
+        KRB_AP_ERR_MODIFIED => (ErrorKind::MessageAltered, "message stream modified".into()),
+        KRB_AP_ERR_BADORDER => (ErrorKind::OutOfSequence, "message out of order".into()),
         KRB_AP_ERR_BADKEYVER => (
             ErrorKind::KdcInvalidRequest,
-            "Specified version of key is not available".into(),
+            "specified version of key is not available".into(),
         ),
-        KRB_AP_ERR_NOKEY => (ErrorKind::NoKerbKey, "Service key not available".into()),
-        KRB_AP_ERR_MUT_FAIL => (ErrorKind::MutualAuthFailed, "Mutual authentication failed".into()),
-        KRB_AP_ERR_BADDIRECTION => (ErrorKind::OutOfSequence, "Incorrect message direction".into()),
+        KRB_AP_ERR_NOKEY => (ErrorKind::NoKerbKey, "service key not available".into()),
+        KRB_AP_ERR_MUT_FAIL => (ErrorKind::MutualAuthFailed, "mutual authentication failed".into()),
+        KRB_AP_ERR_BADDIRECTION => (ErrorKind::OutOfSequence, "incorrect message direction".into()),
         KRB_AP_ERR_METHOD => (
             ErrorKind::InvalidToken,
-            "Alternative authentication method required".into(),
+            "alternative authentication method required".into(),
         ),
-        KRB_AP_ERR_BADSEQ => (ErrorKind::OutOfSequence, "Incorrect sequence number in message".into()),
+        KRB_AP_ERR_BADSEQ => (ErrorKind::OutOfSequence, "incorrect sequence number in message".into()),
         KRB_AP_ERR_INAPP_CKSUM => (
             ErrorKind::InvalidToken,
-            "Inappropriate type of checksum in message".into(),
+            "inappropriate type of checksum in message".into(),
         ),
-        KRB_AP_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "Policy rejects transited path".into()),
+        KRB_AP_PATH_NOT_ACCEPTED => (ErrorKind::KdcInvalidRequest, "policy rejects transited path".into()),
         KRB_ERR_RESPONSE_TOO_BIG => (
             ErrorKind::InvalidParameter,
-            "Response too big for UDP; retry with TC".into(),
+            "response too big for UDP; retry with TC".into(),
         ),
-        KRB_ERR_GENERIC => (ErrorKind::InternalError, "Generic error (description in e-text)".into()),
+        KRB_ERR_GENERIC => (ErrorKind::InternalError, "generic error (description in e-text)".into()),
         KRB_ERR_FIELD_TOOLONG => (
             ErrorKind::KdcInvalidRequest,
-            "Field is too long for this implementation".into(),
+            "field is too long for this implementation".into(),
         ),
-        KDC_ERROR_CLIENT_NOT_TRUSTED => (ErrorKind::InvalidParameter, "Client is not trusted".into()),
+        KDC_ERROR_CLIENT_NOT_TRUSTED => (ErrorKind::InvalidParameter, "client is not trusted".into()),
         KDC_ERROR_KDC_NOT_TRUSTED => (ErrorKind::InvalidParameter, "KDC is not trusted".into()),
-        KDC_ERROR_INVALID_SIG => (ErrorKind::MessageAltered, "Invalid signature".into()),
-        KDC_ERR_KEY_TOO_WEAK => (ErrorKind::EncryptFailure, "Key is too weak".into()),
-        KDC_ERR_CERTIFICATE_MISMATCH => (ErrorKind::InvalidParameter, "Certificated mismatch".into()),
+        KDC_ERROR_INVALID_SIG => (ErrorKind::MessageAltered, "invalid signature".into()),
+        KDC_ERR_KEY_TOO_WEAK => (ErrorKind::EncryptFailure, "key is too weak".into()),
+        KDC_ERR_CERTIFICATE_MISMATCH => (ErrorKind::InvalidParameter, "certificated mismatch".into()),
         KRB_AP_ERR_NO_TGT => (
             ErrorKind::NoTgtReply,
-            "No TGT available to validate USER-TO-USER".into(),
+            "no TGT available to validate USER-TO-USER".into(),
         ),
-        KDC_ERR_WRONG_REALM => (ErrorKind::InvalidParameter, "Wrong Realm".into()),
-        KRB_AP_ERR_USER_TO_USER_REQUIRED => (ErrorKind::KdcInvalidRequest, "Ticket must be for USER-TO-USER".into()),
+        KDC_ERR_WRONG_REALM => (ErrorKind::InvalidParameter, "wrong Realm".into()),
+        KRB_AP_ERR_USER_TO_USER_REQUIRED => (ErrorKind::KdcInvalidRequest, "ticket must be for USER-TO-USER".into()),
         KDC_ERR_CANT_VERIFY_CERTIFICATE => (
             ErrorKind::KdcInvalidRequest,
             "KDC can not verify the certificate".into(),
         ),
-        KDC_ERR_INVALID_CERTIFICATE => (ErrorKind::InvalidParameter, "Invalid certificate".into()),
-        KDC_ERR_REVOKED_CERTIFICATE => (ErrorKind::KdcCertRevoked, "Revoked certificate".into()),
-        KDC_ERR_REVOCATION_STATUS_UNKNOWN => (ErrorKind::InternalError, "Revoked status unknown".into()),
-        KDC_ERR_REVOCATION_STATUS_UNAVAILABLE => (ErrorKind::InternalError, "Revoked status unavailable".into()),
-        KDC_ERR_CLIENT_NAME_MISMATCH => (ErrorKind::InvalidParameter, "Client name mismatch".into()),
+        KDC_ERR_INVALID_CERTIFICATE => (ErrorKind::InvalidParameter, "invalid certificate".into()),
+        KDC_ERR_REVOKED_CERTIFICATE => (ErrorKind::KdcCertRevoked, "revoked certificate".into()),
+        KDC_ERR_REVOCATION_STATUS_UNKNOWN => (ErrorKind::InternalError, "revoked status unknown".into()),
+        KDC_ERR_REVOCATION_STATUS_UNAVAILABLE => (ErrorKind::InternalError, "revoked status unavailable".into()),
+        KDC_ERR_CLIENT_NAME_MISMATCH => (ErrorKind::InvalidParameter, "client name mismatch".into()),
         KDC_ERR_KDC_NAME_MISMATCH => (ErrorKind::InvalidParameter, "KDC name mismatch".into()),
-        code => (ErrorKind::Unknown, format!("Unknown Kerberos error: {}", code)),
+        code => (ErrorKind::Unknown, format!("unknown Kerberos error: {}", code)),
     }
 }
 
@@ -258,7 +258,7 @@ pub fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [DecryptBuf
             return Err(Error::new(
                 ErrorKind::DecryptFailure,
                 format!(
-                    "Decrypted data length ({}) does not match the stream buffer length ({})",
+                    "decrypted data length ({}) does not match the stream buffer length ({})",
                     decrypted_len, stream_buffer_len,
                 ),
             ));
@@ -278,7 +278,7 @@ pub fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [DecryptBuf
             return Err(Error::new(
                 ErrorKind::DecryptFailure,
                 format!(
-                    "Decrypted data length ({}) does not match the data buffer length ({})",
+                    "decrypted data length ({}) does not match the data buffer length ({})",
                     decrypted.len(),
                     data.len(),
                 ),
@@ -315,14 +315,14 @@ pub fn parse_target_name(target_name: &str) -> Result<(&str, &str)> {
     let divider = target_name.find('/').ok_or_else(|| {
         Error::new(
             ErrorKind::InvalidParameter,
-            "Invalid service principal name: missing '/'",
+            "invalid service principal name: missing '/'",
         )
     })?;
 
     if divider == 0 || divider == target_name.len() - 1 {
         return Err(Error::new(
             ErrorKind::InvalidParameter,
-            "Invalid service principal name",
+            "invalid service principal name",
         ));
     }
 


### PR DESCRIPTION
Hi,
In this PR I've implemented the system provided smart cards support. Now the user can use real smart cards using our library as well as emulated ones.

More information you can read in those pull requests descriptions:

* https://github.com/Devolutions/sspi-rs/pull/246
* https://github.com/Devolutions/sspi-rs/pull/248
* https://github.com/Devolutions/sspi-rs/pull/249
* https://github.com/Devolutions/sspi-rs/pull/250
* https://github.com/Devolutions/sspi-rs/pull/251

## Implementation notes

1. The `sspi` loads all additional libraries (like `libpcsclite` or `winscard.dll`) in the runtime. Related discussion: https://github.com/Devolutions/sspi-rs/pull/246#discussion_r1621256727.
2. The system scards implementation is hidden under the `WinScard` and `WinScardContext`. The system scard is just another implementation of these traits. Our custom FFI layer works only with high-lever Rust API. It gives us a few advantages:
    * Easier to maintain the system scard implementation.
    * Easier to maintain our FFI layer.
    * Easier to debug.
    * Fewer `if`/`match` expressions in the FFI layer.
3. We've introduced the `RequestBufferType` and `OutBuff` types to improve the memory management.

## Configuration

The user should set the `WINSCARD_USE_SYSTEM_SCARD` env variable with the value set to `true` to use system-provided smart cards.

The `sspi` library uses the _PCSC Lite_ library on Linux and macOS to access the system-provided smart card. This library is loaded in the runtime. The user can use the `PCSC_LITE_LIB_PATH` env variable to specify the `libpcsclite` location.
The standard `WinSCard` will be used on Windows. But the user has an ability to confiture the `winscard.dll` location using the `WINSCARD_LIB_PATH` env variable. It can be helpful in situations when the original `winscard.dll` is hooked and we need to call the original one anyway.

## Demo

Using [`mstscex`](https://github.com/devolutions/msrdpex/):

https://github.com/Devolutions/sspi-rs/assets/43034350/172137a8-b8f4-41a4-b6c8-6853418f37e0

Using [`FreeRDP`](https://github.com/FreeRDP/FreeRDP/):

https://github.com/Devolutions/sspi-rs/assets/43034350/1ce20d19-4032-4997-bc15-ac5984bf87e2

## **_Note_**

Currently, only the _winscard_ part pf the `sspi-rs` is modified. Currently, our CredSSP implementation can use only the emulated smart card. We plan to improve the CredSSP module in next iterations.

## Docs & references:

* [`winscard.h`](https://learn.microsoft.com/en-us/windows/win32/api/winscard/)
* [`PCSC Lite`](https://pcsclite.apdu.fr/)

cc @awakecoding 