### PR TITLE
refactor: move hardware-independent code out of scard feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,7 @@ dependencies = [
 [[package]]
 name = "aws-lc-sys"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+source = "git+https://github.com/awakecoding/aws-lc-rs?branch=v0.19.0-patched#95da179cfd9a6ae9ab51ce33326d6416a9dd20a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -2386,6 +2385,7 @@ dependencies = [
  "proptest",
  "rand",
  "reqwest",
+ "rsa",
  "rustls",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tokio = { version = "1.38", features = ["time", "rt", "rt-multi-thread"], option
 pcsc = { version = "2.8", optional = true }
 async-recursion = "1.1"
 winscard = { version = "0.1", path = "./crates/winscard", optional = true }
+rsa = { version = "0.9.6", features = ["sha1"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"

--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -223,7 +223,6 @@ impl TryFrom<AuthIdentityBuffers> for AuthIdentity {
     }
 }
 
-#[cfg(feature = "scard")]
 mod scard_credentials {
     use picky::key::PrivateKey;
     use picky_asn1_x509::Certificate;
@@ -296,7 +295,7 @@ mod scard_credentials {
             Ok(Self {
                 certificate: picky_asn1_der::to_vec(&value.certificate)?,
                 reader_name: utils::string_to_utf16(value.reader_name),
-                pin: value.pin.as_ref().clone().into(),
+                pin: utils::string_to_utf16(String::from_utf8_lossy(value.pin.as_ref())).into(),
                 username: utils::string_to_utf16(value.username),
                 card_name: value.card_name.map(utils::string_to_utf16),
                 container_name: utils::string_to_utf16(value.container_name),
@@ -338,7 +337,6 @@ mod scard_credentials {
     }
 }
 
-#[cfg(feature = "scard")]
 pub use self::scard_credentials::{SmartCardIdentity, SmartCardIdentityBuffers};
 
 /// Generic enum that encapsulates raw credentials for any type of authentication
@@ -346,7 +344,6 @@ pub use self::scard_credentials::{SmartCardIdentity, SmartCardIdentityBuffers};
 pub enum CredentialsBuffers {
     /// Raw auth identity buffers for the password based authentication
     AuthIdentity(AuthIdentityBuffers),
-    #[cfg(feature = "scard")]
     /// Raw smart card identity buffers for the smart card based authentication
     SmartCard(SmartCardIdentityBuffers),
 }
@@ -380,7 +377,6 @@ impl CredentialsBuffers {
 pub enum Credentials {
     /// Auth identity for the password based authentication
     AuthIdentity(AuthIdentity),
-    #[cfg(feature = "scard")]
     /// Smart card identity for the smart card based authentication
     SmartCard(Box<SmartCardIdentity>),
 }
@@ -395,7 +391,6 @@ impl Credentials {
     }
 }
 
-#[cfg(feature = "scard")]
 impl From<SmartCardIdentity> for Credentials {
     fn from(value: SmartCardIdentity) -> Self {
         Self::SmartCard(Box::new(value))
@@ -414,7 +409,6 @@ impl TryFrom<Credentials> for CredentialsBuffers {
     fn try_from(value: Credentials) -> Result<Self, Self::Error> {
         Ok(match value {
             Credentials::AuthIdentity(identity) => Self::AuthIdentity(identity.into()),
-            #[cfg(feature = "scard")]
             Credentials::SmartCard(identity) => Self::SmartCard((*identity).try_into()?),
         })
     }

--- a/src/credssp/ts_request/mod.rs
+++ b/src/credssp/ts_request/mod.rs
@@ -5,17 +5,13 @@ use core::fmt;
 use std::io::{self, Read};
 
 use picky_asn1::wrapper::{ExplicitContextTag0, ExplicitContextTag1, IntegerAsn1, OctetStringAsn1};
-#[cfg(feature = "scard")]
 use picky_asn1::wrapper::{ExplicitContextTag2, ExplicitContextTag3, ExplicitContextTag4, Optional};
-#[cfg(feature = "scard")]
 use picky_krb::constants::cred_ssp::AT_KEYEXCHANGE;
 use picky_krb::constants::cred_ssp::TS_PASSWORD_CREDS;
 use picky_krb::credssp::{TsCredentials, TsPasswordCreds};
-#[cfg(feature = "scard")]
 use picky_krb::credssp::{TsCspDataDetail, TsSmartCardCreds};
 
 use super::CredSspMode;
-#[cfg(feature = "scard")]
 use crate::SmartCardIdentityBuffers;
 use crate::{ber, AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind};
 
@@ -257,7 +253,6 @@ impl TsRequest {
 }
 
 #[instrument(ret)]
-#[cfg(feature = "scard")]
 fn write_smart_card_credentials(credentials: &SmartCardIdentityBuffers) -> crate::Result<Vec<u8>> {
     let smart_card_creds = TsSmartCardCreds {
         pin: ExplicitContextTag0::from(OctetStringAsn1::from(credentials.pin.as_ref().to_vec())),
@@ -292,7 +287,6 @@ pub fn write_ts_credentials(credentials: &CredentialsBuffers, cred_ssp_mode: Cre
         CredentialsBuffers::AuthIdentity(creds) => {
             (TS_PASSWORD_CREDS, write_password_credentials(creds, cred_ssp_mode)?)
         }
-        #[cfg(feature = "scard")]
         CredentialsBuffers::SmartCard(creds) => (
             picky_krb::constants::cred_ssp::TS_SMART_CARD_CREDS,
             write_smart_card_credentials(creds)?,
@@ -356,7 +350,6 @@ pub fn read_ts_credentials(mut buffer: impl io::Read) -> crate::Result<Credentia
         Some(&TS_PASSWORD_CREDS) => Ok(CredentialsBuffers::AuthIdentity(read_password_credentials(
             &ts_credentials.credentials.0 .0,
         )?)),
-        #[cfg(feature = "scard")]
         Some(&picky_krb::constants::cred_ssp::TS_SMART_CARD_CREDS) => Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "Reading of the TsSmartCard credentials is not supported yet",

--- a/src/kerberos/pa_datas.rs
+++ b/src/kerberos/pa_datas.rs
@@ -1,12 +1,8 @@
-#[cfg(feature = "scard")]
 use picky_asn1_x509::signed_data::SignedData;
-#[cfg(feature = "scard")]
 use picky_krb::crypto::diffie_hellman::{generate_key, DhNonce};
-#[cfg(feature = "scard")]
 use picky_krb::crypto::CipherSuite;
 use picky_krb::data_types::PaData;
 use picky_krb::messages::AsRep;
-#[cfg(feature = "scard")]
 use picky_krb::pkinit::PaPkAsRep;
 
 use super::client::extractors::extract_session_key_from_as_rep;
@@ -14,22 +10,18 @@ use super::{
     generate_pa_datas_for_as_req as generate_password_based, EncryptionParams,
     GenerateAsPaDataOptions as AuthIdentityPaDataOptions,
 };
-#[cfg(feature = "scard")]
 use crate::pk_init::{
     extract_server_dh_public_key, generate_pa_datas_for_as_req as generate_private_key_based, DhParameters,
     GenerateAsPaDataOptions as SmartCardPaDataOptions, Wrapper,
 };
-#[cfg(feature = "scard")]
 use crate::pku2u::{extract_pa_pk_as_rep, extract_server_nonce, validate_server_p2p_certificate, validate_signed_data};
 use crate::Result;
-#[cfg(feature = "scard")]
 use crate::{check_if_empty, pku2u, Error, ErrorKind};
 
 // PA-DATAs are very different for the Kerberos logon using username+password and smart card.
 // This enum provides a unified way to generate PA-DATAs based on the provided options.
 pub enum AsReqPaDataOptions<'a> {
     AuthIdentity(AuthIdentityPaDataOptions<'a>),
-    #[cfg(feature = "scard")]
     SmartCard(Box<SmartCardPaDataOptions<'a>>),
 }
 
@@ -37,7 +29,6 @@ impl AsReqPaDataOptions<'_> {
     pub fn generate(&self) -> Result<Vec<PaData>> {
         match self {
             AsReqPaDataOptions::AuthIdentity(options) => generate_password_based(options),
-            #[cfg(feature = "scard")]
             AsReqPaDataOptions::SmartCard(options) => generate_private_key_based(options),
         }
     }
@@ -45,7 +36,6 @@ impl AsReqPaDataOptions<'_> {
     pub fn with_pre_auth(&mut self, pre_auth: bool) {
         match self {
             AsReqPaDataOptions::AuthIdentity(options) => options.with_pre_auth = pre_auth,
-            #[cfg(feature = "scard")]
             AsReqPaDataOptions::SmartCard(options) => options.with_pre_auth = pre_auth,
         }
     }
@@ -53,7 +43,6 @@ impl AsReqPaDataOptions<'_> {
     pub fn with_salt(&mut self, salt: Vec<u8>) {
         match self {
             AsReqPaDataOptions::AuthIdentity(options) => options.salt = salt,
-            #[cfg(feature = "scard")]
             AsReqPaDataOptions::SmartCard(_) => {}
         }
     }
@@ -68,7 +57,6 @@ pub enum AsRepSessionKeyExtractor<'a> {
         password: &'a str,
         enc_params: &'a EncryptionParams,
     },
-    #[cfg(feature = "scard")]
     SmartCard {
         dh_parameters: &'a mut DhParameters,
         enc_params: &'a mut EncryptionParams,
@@ -84,7 +72,6 @@ impl AsRepSessionKeyExtractor<'_> {
                 password,
                 enc_params,
             } => extract_session_key_from_as_rep(as_rep, salt, password, enc_params),
-            #[cfg(feature = "scard")]
             AsRepSessionKeyExtractor::SmartCard {
                 dh_parameters,
                 enc_params,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ use utils::map_keb_error_code_to_sspi_error;
 pub use utils::string_to_utf16;
 
 pub use self::auth_identity::{AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, Username};
-#[cfg(feature = "scard")]
 pub use self::auth_identity::{SmartCardIdentity, SmartCardIdentityBuffers};
 pub use self::builders::{
     AcceptSecurityContextResult, AcquireCredentialsHandleResult, InitializeSecurityContextResult,
@@ -1841,6 +1840,15 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<rsa::Error> for Error {
+    fn from(value: rsa::Error) -> Self {
+        Error::new(
+            ErrorKind::InternalError,
+            format!("Error: an unexpected RsaError happened: {}", value),
+        )
+    }
+}
+
 impl From<Asn1DerError> for Error {
     fn from(err: Asn1DerError) -> Self {
         Self::new(ErrorKind::InvalidToken, format!("ASN1 DER error: {:?}", err))
@@ -1990,7 +1998,6 @@ impl From<pcsc::Error> for Error {
     }
 }
 
-#[cfg(feature = "scard")]
 impl From<picky::key::KeyError> for Error {
     fn from(err: picky::key::KeyError) -> Self {
         Self::new(ErrorKind::InternalError, format!("RSA key error: {:?}", err))

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -518,7 +518,6 @@ impl<'a> Negotiate {
             self.auth_identity = Some(CredentialsBuffers::AuthIdentity(auth_identity.into()));
         }
 
-        #[cfg(feature = "scard")]
         if let Some(Some(CredentialsBuffers::SmartCard(identity))) = builder.credentials_handle {
             if let NegotiatedProtocol::Ntlm(_) = &self.protocol {
                 let username = crate::utils::bytes_to_utf16_string(&identity.username);

--- a/src/smartcard.rs
+++ b/src/smartcard.rs
@@ -54,6 +54,8 @@ impl SmartCard {
         })
     }
 
+    // FIXME: This code will be used when support for system-provided smart cards is added
+    #[allow(dead_code)]
     pub fn new_emulated(
         reader_name: Cow<'_, str>,
         pin: Vec<u8>,
@@ -74,6 +76,8 @@ impl SmartCard {
         })
     }
 
+    // FIXME: This code will be used when support for system-provided smart cards is added
+    #[allow(dead_code)]
     pub fn sign(&mut self, data: impl AsRef<[u8]>) -> Result<Vec<u8>> {
         match self.smart_card_type {
             SmartCardApi::WinSCard(ref scard) => {


### PR DESCRIPTION
This PR aims to move code that doesn't depend on real smart card reader out of `scard` feature.