### PR TITLE
fix(sspi): tls connection: improve cipher block size calculation

### DIFF
--- a/src/credssp/sspi_cred_ssp/cipher_block_size.rs
+++ b/src/credssp/sspi_cred_ssp/cipher_block_size.rs
@@ -1,0 +1,67 @@
+use rustls::CipherSuite;
+
+// [Block Size and Padding](https://www.rfc-editor.org/rfc/rfc3826#section-3.1.1.3)
+// The block size of the AES cipher is 128 bits
+const AES_BLOCK_SIZE: u32 = 16;
+
+// [Data Size](https://www.rfc-editor.org/rfc/rfc1851#section-1.3)
+// The 3DES algorithm operates on blocks of eight octets. This often requires padding after
+// the end of the unencrypted payload data.
+const DES_BLOCK_SIZE: u32 = 8;
+
+use crate::{Error, ErrorKind, Result};
+
+pub fn get_cipher_block_size(cipher: CipherSuite) -> Result<u32> {
+    match cipher {
+        // Block ciphers
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_256_GCM_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_128_GCM_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_256_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_AES_128_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA => Ok(DES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_RSA_WITH_AES_256_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_RSA_WITH_AES_128_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_DSS_WITH_AES_256_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_DSS_WITH_AES_128_CBC_SHA => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA => Ok(DES_BLOCK_SIZE),
+        CipherSuite::TLS_PSK_WITH_AES_256_GCM_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_PSK_WITH_AES_128_GCM_SHA256 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_PSK_WITH_AES_256_CBC_SHA384 => Ok(AES_BLOCK_SIZE),
+        CipherSuite::TLS_PSK_WITH_AES_128_CBC_SHA256 => Ok(AES_BLOCK_SIZE),
+        // Stream ciphers
+        CipherSuite::TLS13_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_PSK_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256 => Ok(0),
+        CipherSuite::TLS_RSA_WITH_RC4_128_SHA => Ok(0),
+        CipherSuite::TLS_RSA_WITH_RC4_128_MD5 => Ok(0),
+        CipherSuite::TLS_RSA_EXPORT1024_WITH_RC4_56_SHA => Ok(0),
+        CipherSuite::TLS_RSA_EXPORT_WITH_RC4_40_MD5 => Ok(0),
+        // Unsupported ciphers or others
+        cipher => Err(Error::new(
+            ErrorKind::InternalError,
+            format!("can not get block size of cipher: {:?}", cipher),
+        )),
+    }
+}

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -1,3 +1,4 @@
+mod cipher_block_size;
 mod tls_connection;
 
 use std::sync::Arc;

--- a/src/credssp/ts_request/mod.rs
+++ b/src/credssp/ts_request/mod.rs
@@ -4,16 +4,15 @@ mod test;
 use core::fmt;
 use std::io::{self, Read};
 
-use picky_asn1::wrapper::{ExplicitContextTag0, ExplicitContextTag1, IntegerAsn1, OctetStringAsn1};
-use picky_asn1::wrapper::{ExplicitContextTag2, ExplicitContextTag3, ExplicitContextTag4, Optional};
-use picky_krb::constants::cred_ssp::AT_KEYEXCHANGE;
-use picky_krb::constants::cred_ssp::TS_PASSWORD_CREDS;
-use picky_krb::credssp::{TsCredentials, TsPasswordCreds};
-use picky_krb::credssp::{TsCspDataDetail, TsSmartCardCreds};
+use picky_asn1::wrapper::{
+    ExplicitContextTag0, ExplicitContextTag1, ExplicitContextTag2, ExplicitContextTag3, ExplicitContextTag4,
+    IntegerAsn1, OctetStringAsn1, Optional,
+};
+use picky_krb::constants::cred_ssp::{AT_KEYEXCHANGE, TS_PASSWORD_CREDS};
+use picky_krb::credssp::{TsCredentials, TsCspDataDetail, TsPasswordCreds, TsSmartCardCreds};
 
 use super::CredSspMode;
-use crate::SmartCardIdentityBuffers;
-use crate::{ber, AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind};
+use crate::{ber, AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind, SmartCardIdentityBuffers};
 
 pub const TS_REQUEST_VERSION: u32 = 6;
 


### PR DESCRIPTION
Hi,
In this pull request, I've improved the cipher block size extraction. Related comment: https://github.com/Devolutions/sspi-rs/pull/263#discussion_r1671978937 

I browsed the new API and tried different methods. Conclusion: there is no good way of extracting the cipher block size. So, I decided to take supported cipher suites in SChannel (Windows 10/11) + popular ones and list all of them in one `match`.
Such a code is more explicit and easy to maintain.