### PR TITLE
Fix smart card private key handling

### DIFF
--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -383,7 +383,7 @@ fn collect_smart_card_creds(username: &[u8], password: &[u8]) -> Result<SmartCar
                     csp_name: str_encode_utf16(MICROSOFT_DEFAULT_CSP),
                     pin: pin.into(),
                     private_key_file_index: None,
-                    private_key_pem: Some(smart_card_info.auth_pk_pem.as_bytes().to_vec()),
+                    private_key_pem: Some(str_encode_utf16(smart_card_info.auth_pk_pem.as_ref())),
                 });
             }
             Err(err) => {


### PR DESCRIPTION
Hi,
In this PR, I've fixed the scared pk handling. Now we convert it to UTF-8 as other credentials buffers.

We encountered this problem after this PR: https://github.com/Devolutions/sspi-rs/pull/260/files#diff-40e9fc919e63077bc0b25847ecf6746216d0438cd3808de82d713a7cc71bce56R753-R756 

cc @awakecoding 