### PR TITLE
fix(sspi): make TLS backend configurable via features

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -144,12 +144,6 @@ jobs:
           sudo apt install gcc-10
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
 
-      # No pregenerated bindings are provided for Android at this time.
-      # See: https://github.com/aws/aws-lc-rs/tree/main/aws-lc-sys#pregenerated-bindings-availability
-      - name: Install bindgen CLI
-        if: matrix.os == 'android'
-        run: cargo install --force --locked bindgen-cli
-
       - name: Build sspi (${{matrix.os}}-${{matrix.arch}}) (${{matrix.build}})
         shell: pwsh
         run: |
@@ -210,6 +204,13 @@ jobs:
 
           if ($DotNetOs -Eq 'win') {
             $CargoArgs += @('--features', 'scard,tsssp')
+          }
+
+          # No pregenerated Android bindings are provided for aws-lc-sys at this time.
+          # See: https://github.com/aws/aws-lc-rs/tree/main/aws-lc-sys#pregenerated-bindings-availability
+          # For simplicity, we’re using the ring crypto backend.
+          if ($DotNetOs -Eq 'android') {
+            $CargoArgs += @('--no-default-features', '--features', 'ring')
           }
 
           $CargoCmd = $(@('cargo') + $CargoArgs) -Join ' '

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -135,6 +135,15 @@ jobs:
         if: ${{ matrix.os == 'linux' }}
         run: sudo apt update
 
+      # We need a newer version of GCC because aws-lc-rs rejects versions affected
+      # by this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+      # These lines can be safely removed once we switch to ubuntu-22.04 runner.
+      - name: Install GCC 10.x
+        if: ${{ matrix.os == 'linux' }}
+        run: |
+          sudo apt install gcc-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+
       - name: Build sspi (${{matrix.os}}-${{matrix.arch}}) (${{matrix.build}})
         shell: pwsh
         run: |

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -144,6 +144,12 @@ jobs:
           sudo apt install gcc-10
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
 
+      # No pregenerated bindings are provided for Android at this time.
+      # See: https://github.com/aws/aws-lc-rs/tree/main/aws-lc-sys#pregenerated-bindings-availability
+      - name: Install bindgen CLI
+        if: matrix.os == 'android'
+        run: cargo install --force --locked bindgen-cli
+
       - name: Build sspi (${{matrix.os}}-${{matrix.arch}}) (${{matrix.build}})
         shell: pwsh
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -140,8 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.19.0"
-source = "git+https://github.com/awakecoding/aws-lc-rs?branch=v0.19.0-patched#95da179cfd9a6ae9ab51ce33326d6416a9dd20a1"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
 dependencies = [
  "bindgen",
  "cc",
@@ -965,7 +966,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1966,7 +1966,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg 0.52.0",
 ]
 
@@ -2062,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2107,9 +2106,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2166,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -2179,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2378,6 +2377,7 @@ dependencies = [
  "reqwest",
  "rsa",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_derive",
  "sha1",
@@ -2905,15 +2905,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,38 @@ name = "kerberos"
 required-features = ["network_client"]
 
 [workspace]
+resolver = "2"
 members = [
   "ffi",
   "ffi/symbol-rename-macro",
   "crates/winscard",
-  "crates/ffi-types"
+  "crates/ffi-types",
 ]
-exclude = ["tools/sspi-ffi-attacker", "tools/wasm-testcompile"]
+exclude = [
+  "tools/wasm-testcompile",
+]
 
 [features]
-default = []
-network_client = ["dep:reqwest", "dep:portpicker"]
+default = ["aws-lc-rs"]
+
+# Enable reqwest for HTTP requests.
+network_client = ["dep:reqwest", "dep:portpicker", "dep:rustls-native-certs", "__rustls-used"]
+# KDC discovery by querying DNS records.
 dns_resolver = ["dep:trust-dns-resolver", "dep:tokio"]
-# TSSSP should be used only on Windows as a native CREDSSP replacement
-tsssp = ["dep:rustls"]
-# Turns on Kerberos smart card login (available only on Windows and users WinSCard API)
+# TSSSP should be used only on Windows as a native CredSSP replacement.
+tsssp = ["dep:rustls", "__rustls-used"]
+# Turns on Kerberos smart card login (available only on Windows and users WinSCard API).
 scard = ["dep:pcsc", "dep:winscard"]
-test_data = []
+# Use AWS LC as TLS cryptography provider.
+aws-lc-rs = ["rustls?/aws-lc-rs", "__install-crypto-provider"]
+# Use ring as TLS cryptography provider.
+ring = ["rustls?/ring", "reqwest?/rustls-tls-native-roots", "__install-crypto-provider"]
+
+# Internal (PRIVATE!) features. Do not rely on these whatsoever. They may disappear at anytime.
+
+__test-data = []
+__rustls-used = []
+__install-crypto-provider = ["dep:rustls"]
 
 [dependencies]
 byteorder = "1.5"
@@ -39,40 +54,41 @@ bitflags = "2.6"
 rand = "0.8"
 cfg-if = "1"
 time = { version = "0.3", default-features = false, features = ["std"] }
-md-5 = "0.10"
-md4 = "0.10"
-sha2 = "0.10"
-sha1 = "0.10"
-hmac = "0.12"
-crypto-mac = "0.11"
 num-derive = "0.4"
 num-traits = "0.2"
 lazy_static = "1.5"
 serde = "1"
 serde_derive = "1"
 url = "2.5"
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "rustls-tls-native-roots"], optional = true, default-features = false }
+oid = "0.2"
+uuid = { version = "1.10", features = ["v4"] }
+async-recursion = "1.1"
+tracing = "0.1"
 
 picky = { version = "7.0.0-rc.9", default-features = false }
 picky-krb = "0.9"
 picky-asn1 = { version = "0.9", features = ["time_conversion"] }
 picky-asn1-der = "0.5"
 picky-asn1-x509 = { version = "0.13", features = ["pkcs7"] }
+num-bigint-dig = "0.8"
+crypto-mac = "0.11"
+md-5 = "0.10"
+md4 = "0.10"
+sha2 = "0.10"
+sha1 = "0.10"
+hmac = "0.12"
+rsa = { version = "0.9.6", features = ["sha1"], default-features = false }
+zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
-oid = "0.2"
-uuid = { version = "1.10", features = ["v4"] }
+reqwest = { version = "0.12", optional = true, default-features = false, features = ["blocking", "rustls-tls-no-provider"] }
 trust-dns-resolver = { version = "0.23", optional = true }
 portpicker = { version = "0.1", optional = true }
-num-bigint-dig = "0.8"
-tracing = "0.1"
-rustls = { version = "0.23", optional = true }
-zeroize = { version = "1.8", features = ["zeroize_derive"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "std", "tls12"] }
+rustls-native-certs = { version = "0.7", optional = true }
 # `rt-multi-thread` feature is required for `tokio::task::block_in_place` function.
-tokio = { version = "1.39", features = ["time", "rt", "rt-multi-thread"], optional = true }
+tokio = { version = "1.39", optional = true, features = ["time", "rt", "rt-multi-thread"] }
 pcsc = { version = "2.8", optional = true }
-async-recursion = "1.1"
-winscard = { version = "0.1", path = "./crates/winscard", optional = true }
-rsa = { version = "0.9.6", features = ["sha1"], default-features = false }
+winscard = { version = "0.1", optional = true, path = "./crates/winscard" }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
@@ -92,6 +108,3 @@ picky = { version = "7.0.0-rc.9", features = ["x509"] }
 tracing-subscriber = "0.3"
 proptest = "1.5"
 cfg-if = "1"
-
-[patch.crates-io]
-aws-lc-sys = { git = "https://github.com/awakecoding/aws-lc-rs", branch = "v0.19.0-patched" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ ring = ["rustls?/ring", "reqwest?/rustls-tls-native-roots", "__install-crypto-pr
 # Internal (PRIVATE!) features. Do not rely on these whatsoever. They may disappear at anytime.
 
 __test-data = []
-__rustls-used = []
-__install-crypto-provider = ["dep:rustls"]
+__rustls-used = ["dep:rustls"]
+__install-crypto-provider = []
 
 [dependencies]
 byteorder = "1.5"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,7 +24,7 @@ cfg-if = "1"
 libc = "0.2"
 num-traits = "0.2"
 whoami = "1.5"
-sspi = { path = "..", features = ["network_client", "dns_resolver"] }
+sspi = { path = "..", default-features = false, features = ["network_client", "dns_resolver"] }
 ffi-types = { path = "../crates/ffi-types", features = ["winscard"], optional = true }
 picky-asn1-der = "0.5"
 uuid = { version = "1.10", default-features = false }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -37,4 +37,4 @@ symbol-rename-macro = { path = "./symbol-rename-macro" }
 windows-sys = { version = "0.52", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_Security", "Win32_System_Threading"] }
 
 [dev-dependencies]
-sspi = { path = "..", features = ["network_client", "dns_resolver", "test_data"] }
+sspi = { path = "..", features = ["network_client", "dns_resolver", "__test-data"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -13,9 +13,11 @@ name = "sspi"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["aws-lc-rs"]
 tsssp = ["sspi/tsssp"]
 scard = ["sspi/scard", "dep:ffi-types", "dep:winscard"]
+aws-lc-rs = ["sspi/aws-lc-rs"]
+ring = ["sspi/ring"]
 
 [dependencies]
 cfg-if = "1"

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -58,6 +58,13 @@ pub struct SspiCredSsp {
 
 impl SspiCredSsp {
     pub fn new_client(sspi_context: SspiContext) -> Result<Self> {
+        crate::rustls::install_default_crypto_provider_if_necessary().map_err(|()| {
+            Error::new(
+                ErrorKind::SecurityPackageNotFound,
+                "failed to install the default crypto provider for TLS",
+            )
+        })?;
+
         Ok(Self {
             state: CredSspState::Tls,
             cred_ssp_context: Box::new(CredSspContext::new(sspi_context)),
@@ -69,6 +76,13 @@ impl SspiCredSsp {
 
     /// * `sspi_context` is a security package that will be used for authorization
     pub fn new_server(sspi_context: SspiContext) -> Result<Self> {
+        crate::rustls::install_default_crypto_provider_if_necessary().map_err(|()| {
+            Error::new(
+                ErrorKind::SecurityPackageNotFound,
+                "failed to install the default crypto provider for TLS",
+            )
+        })?;
+
         Ok(Self {
             state: CredSspState::Tls,
             cred_ssp_context: Box::new(CredSspContext::new(sspi_context)),

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -989,7 +989,7 @@ impl SspiEx for Kerberos {
     }
 }
 
-#[cfg(any(feature = "test_data", test))]
+#[cfg(any(feature = "__test-data", test))]
 pub mod test_data {
     use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
     use picky_krb::crypto::CipherSuite;
@@ -1088,7 +1088,7 @@ mod tests {
             .unwrap();
 
         let mut buffer = message[0].data().to_vec();
-        buffer.extend_from_slice(&message[1].data());
+        buffer.extend_from_slice(message[1].data());
 
         let mut message = [SecurityBuffer::Stream(&mut buffer), SecurityBuffer::Data(&mut [])];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ pub mod ntlm;
 mod pk_init;
 pub mod pku2u;
 
-#[allow(unreachable_patterns)]
 mod auth_identity;
 mod ber;
 pub mod cert_utils;
@@ -73,6 +72,7 @@ mod crypto;
 mod dns;
 mod kdc;
 mod krb;
+mod rustls;
 mod secret;
 mod security_buffer;
 mod smartcard;

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -971,7 +971,7 @@ xFnLp2UBrhxA9GYrpJ5i0onRmexQnTVSl5DDq07s+3dbr9YAKjrg9IDZYqLbdwP1
             .unwrap();
 
         let mut buffer = message[0].data().to_vec();
-        buffer.extend_from_slice(&message[1].data());
+        buffer.extend_from_slice(message[1].data());
 
         let mut message = [SecurityBuffer::Stream(&mut buffer), SecurityBuffer::Data(&mut [])];
 

--- a/src/rustls.rs
+++ b/src/rustls.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "__rustls-used")]
+
+/// Call this before using rustls.
+pub(crate) fn install_default_crypto_provider_if_necessary() -> Result<(), ()> {
+    #[cfg(feature = "__install-crypto-provider")]
+    {
+        static INSTALL: std::sync::OnceLock<Result<(), ()>> = std::sync::OnceLock::new();
+
+        let result = INSTALL.get_or_init(|| {
+            // A crypto provider is already installed.
+            if rustls::crypto::CryptoProvider::get_default().is_some() {
+                return Ok(());
+            }
+
+            #[cfg(feature = "aws-lc-rs")]
+            {
+                rustls::crypto::aws_lc_rs::default_provider()
+                    .install_default()
+                    .map_err(|_| ())
+            }
+
+            #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+            {
+                rustls::crypto::ring::default_provider()
+                    .install_default()
+                    .map_err(|_| ())
+            }
+        });
+
+        *result
+    }
+
+    #[cfg(not(feature = "__install-crypto-provider"))]
+    {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "network_client")]
+pub(crate) fn load_native_certs(builder: reqwest::blocking::ClientBuilder) -> Option<reqwest::blocking::ClientBuilder> {
+    #[cfg(feature = "aws-lc-rs")]
+    {
+        let mut builder = builder;
+
+        for cert in rustls_native_certs::load_native_certs().ok()? {
+            // Continue on parsing errors, as native stores often include ancient or syntactically
+            // invalid certificates, like root certificates without any X509 extensions.
+            // Inspiration: https://github.com/rustls/rustls/blob/633bf4ba9d9521a95f68766d04c22e2b01e68318/rustls/src/anchors.rs#L105-L112
+            match reqwest::Certificate::from_der(&cert) {
+                Ok(cert) => builder = builder.add_root_certificate(cert),
+                Err(error) => {
+                    debug!(%error, "failed to parse native certificate");
+                }
+            };
+        }
+
+        Some(builder)
+    }
+
+    // We enable the rustls-tls-native-roots feature of reqwest when ring is used.
+    #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+    {
+        Some(builder)
+    }
+}


### PR DESCRIPTION
The aws-lc-rs backend is enabled by default.