### PR TITLE
Fix Linux/macOS system smart card support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -108,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -128,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
@@ -161,17 +155,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -274,9 +268,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cbc"
@@ -289,13 +283,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -336,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
@@ -361,15 +355,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -385,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crypto"
@@ -525,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -597,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -619,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -651,7 +645,7 @@ checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -798,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -843,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -910,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -933,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
@@ -958,16 +952,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.7.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -976,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -989,7 +983,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -1038,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iso7816"
@@ -1078,18 +1071,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1126,12 +1119,12 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1242,15 +1235,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -1260,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1372,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -1390,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -1630,26 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polyval"
@@ -1717,15 +1681,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1763,7 +1730,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1777,16 +1744,17 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.0.0",
  "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1811,22 +1779,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1881,23 +1849,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1911,13 +1879,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1928,9 +1896,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1958,7 +1926,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2051,18 +2019,18 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2089,19 +2057,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
@@ -2115,11 +2070,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
  "rustls-pki-types",
 ]
 
@@ -2161,11 +2115,11 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2203,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2228,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -2248,11 +2202,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2402,7 +2357,7 @@ dependencies = [
  "reqwest",
  "rsa",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "serde",
  "serde_derive",
  "sha1",
@@ -2469,9 +2424,9 @@ version = "0.0.0"
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2489,30 +2444,31 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2604,31 +2560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2758,21 +2693,21 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -2828,9 +2763,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2864,19 +2799,20 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2889,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2901,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2911,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2924,15 +2860,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3078,6 +3014,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3257,6 +3202,27 @@ dependencies = [
  "rand_core",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,11 +2427,13 @@ dependencies = [
 name = "sspi-ffi"
 version = "0.10.1"
 dependencies = [
+ "bitflags 2.6.0",
  "cfg-if",
  "ffi-types",
  "libc",
  "num-traits",
  "picky-asn1-der",
+ "picky-asn1-x509",
  "sspi",
  "symbol-rename-macro",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "ffi-types",
  "libc",
  "num-traits",
+ "picky",
  "picky-asn1-der",
  "picky-asn1-x509",
  "sspi",

--- a/crates/ffi-types/src/common.rs
+++ b/crates/ffi-types/src/common.rs
@@ -4,6 +4,7 @@ pub type LpStr = *mut u8;
 pub type LpCStr = *const u8;
 pub type Dword = u32;
 pub type LpDword = *mut u32;
+pub type WChar = u16;
 pub type LpWStr = *mut u16;
 pub type LpCWStr = *const u16;
 pub type LpCByte = *const u8;

--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -68,8 +68,8 @@ pub type SCardReadCacheAFn =
     unsafe extern "system" fn(ScardContext, LpUuid, u32, LpStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardReadCacheWFn =
     unsafe extern "system" fn(ScardContext, LpUuid, u32, LpWStr, LpByte, LpDword) -> ScardStatus;
-pub type SCardWriteCacheAFn = unsafe extern "system" fn(ScardContext, LpUuid, u32, LpStr, LpByte, u32) -> ScardStatus;
-pub type SCardWriteCacheWFn = unsafe extern "system" fn(ScardContext, LpUuid, u32, LpWStr, LpByte, u32) -> ScardStatus;
+pub type SCardWriteCacheAFn = unsafe extern "system" fn(ScardContext, LpUuid, u32, LpStr, LpCByte, u32) -> ScardStatus;
+pub type SCardWriteCacheWFn = unsafe extern "system" fn(ScardContext, LpUuid, u32, LpWStr, LpCByte, u32) -> ScardStatus;
 pub type SCardGetReaderIconAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardGetReaderIconWFn = unsafe extern "system" fn(ScardContext, LpCWStr, LpByte, LpDword) -> ScardStatus;
 pub type SCardGetDeviceTypeIdAFn = unsafe extern "system" fn(ScardContext, LpCStr, LpDword) -> ScardStatus;

--- a/crates/winscard/src/env.rs
+++ b/crates/winscard/src/env.rs
@@ -1,3 +1,10 @@
+use std::fs;
+
+use picky::key::PrivateKey;
+use picky::x509::Cert;
+
+use crate::{Error, ErrorKind, WinScardResult};
+
 /// Emulated smart card PIN code.
 pub const WINSCARD_PIN_ENV: &str = "WINSCARD_SMARTCARD_PIN";
 /// Path to the user certificate to be used in emulated smart card.
@@ -16,3 +23,81 @@ pub const WINSCARD_PK_DATA_ENV: &str = "WINSCARD_PRIVATE_KEY_FILE_DATA";
 pub const WINSCARD_CONTAINER_NAME_ENV: &str = "WINSCARD_SMARTCARD_CONTAINER_NAME";
 /// Emulated smart card reader name.
 pub const WINSCARD_READER_NAME_ENV: &str = "WINSCARD_SMARTCARD_READER_NAME";
+
+/// Tries to get the smart card container name from the environment variable.
+///
+/// For the successful execution, the [WINSCARD_CONTAINER_NAME_ENV] variable should be set.
+pub fn container_name() -> WinScardResult<String> {
+    env!(WINSCARD_CONTAINER_NAME_ENV)
+}
+
+/// Tries to read the smart card auth certificate from the environment variable.
+///
+/// For the successful execution, either [WINSCARD_CERT_DATA_ENV] or [WINSCARD_CERT_PATH_ENV] variable should be set.
+pub fn auth_cert_from_env() -> WinScardResult<Cert> {
+    if let Ok(cert_data) = env!(WINSCARD_CERT_DATA_ENV) {
+        use base64::Engine;
+
+        let cert_der = base64::engine::general_purpose::STANDARD.decode(cert_data)?;
+
+        Ok(Cert::from_der(&cert_der)?)
+    } else if let Ok(cert_path) = env!(WINSCARD_CERT_PATH_ENV) {
+        let raw_certificate = fs::read_to_string(cert_path).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidParameter,
+                format!("Unable to read certificate from the provided file: {}", e),
+            )
+        })?;
+        Ok(Cert::from_pem_str(&raw_certificate)?)
+    } else {
+        return Err(Error::new(
+            ErrorKind::InvalidParameter,
+            format!(
+                "Either \"{}\" or \"{}\" environment variable must be present",
+                WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV
+            ),
+        ));
+    }
+}
+
+/// Tries to read the smart card certificate private key from the environment variable.
+///
+/// For the successful execution, either [WINSCARD_PK_DATA_ENV] or [WINSCARD_PK_PATH_ENV] variable should be set.
+pub fn private_key_from_env() -> WinScardResult<(String, PrivateKey)> {
+    if let Ok(private_key_data) = env!(WINSCARD_PK_DATA_ENV) {
+        use base64::Engine;
+
+        let private_key_der = base64::engine::general_purpose::STANDARD.decode(private_key_data)?;
+
+        let private_key = PrivateKey::from_pkcs8(&private_key_der)?;
+        let raw_private_key = private_key.to_pem_str()?;
+
+        Ok((raw_private_key, private_key))
+    } else if let Ok(pk_path) = env!(WINSCARD_PK_PATH_ENV) {
+        let raw_private_key = fs::read_to_string(pk_path).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidParameter,
+                format!("Unable to read private key from the provided file: {}", e),
+            )
+        })?;
+        let private_key = PrivateKey::from_pem_str(&raw_private_key).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidParameter,
+                format!(
+                    "Error while trying to read a private key from a pem-encoded string: {}",
+                    e
+                ),
+            )
+        })?;
+
+        Ok((raw_private_key, private_key))
+    } else {
+        return Err(Error::new(
+            ErrorKind::InvalidParameter,
+            format!(
+                "Either \"{}\" or \"{}\" environment variable must be present",
+                WINSCARD_PK_DATA_ENV, WINSCARD_PK_PATH_ENV
+            ),
+        ));
+    }
+}

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -11,7 +11,7 @@ mod macros;
 mod ber_tlv;
 mod card_capability_container;
 mod chuid;
-pub mod compression;
+mod compression;
 mod dummy_rng;
 /// Contains env variables names that represent smart card credentials.
 #[cfg(feature = "std")]
@@ -38,7 +38,9 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use picky::key::KeyError;
 use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
-pub use scard_context::{Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, NEW_READER_NOTIFICATION};
+pub use scard_context::{
+    Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, NEW_READER_NOTIFICATION,
+};
 
 /// The [WinScardResult] type.
 pub type WinScardResult<T> = result::Result<T, Error>;

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -11,7 +11,7 @@ mod macros;
 mod ber_tlv;
 mod card_capability_container;
 mod chuid;
-mod compression;
+pub mod compression;
 mod dummy_rng;
 /// Contains env variables names that represent smart card credentials.
 #[cfg(feature = "std")]

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -39,7 +39,8 @@ use picky::key::KeyError;
 use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
 pub use scard_context::{
-    Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, NEW_READER_NOTIFICATION,
+    Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, MICROSOFT_DEFAULT_KSP,
+    MICROSOFT_SCARD_DRIVER_LOCATION, NEW_READER_NOTIFICATION,
 };
 
 /// The [WinScardResult] type.

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -40,7 +40,7 @@ use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
 pub use scard_context::{
     Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, MICROSOFT_DEFAULT_KSP,
-    MICROSOFT_SCARD_DRIVER_LOCATION, NEW_READER_NOTIFICATION,
+    MICROSOFT_SCARD_DRIVER_LOCATION,
 };
 
 /// The [WinScardResult] type.

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -38,7 +38,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use picky::key::KeyError;
 use picky::x509::certificate::CertError;
 pub use scard::{SmartCard, ATR, CHUNK_SIZE, PIV_AID, SUPPORTED_CONNECTION_PROTOCOL};
-pub use scard_context::{Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP};
+pub use scard_context::{Reader, ScardContext, SmartCardInfo, DEFAULT_CARD_NAME, MICROSOFT_DEFAULT_CSP, NEW_READER_NOTIFICATION};
 
 /// The [WinScardResult] type.
 pub type WinScardResult<T> = result::Result<T, Error>;

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -477,7 +477,7 @@ impl<'a> WinScardContext for ScardContext<'a> {
         Ok(())
     }
 
-    fn get_status_change(&self, _timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()> {
+    fn get_status_change(&mut self, _timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()> {
         use crate::ATR;
 
         let supported_readers = self.list_readers()?;

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -15,10 +15,10 @@ use crate::winscard::{
 };
 use crate::{Error, ErrorKind, WinScardResult};
 
-// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew
-// To be notified of the arrival of a new smart card reader,
-// set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
-const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
+/// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew
+/// To be notified of the arrival of a new smart card reader,
+/// set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
+pub const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
 
 /// Default name of the emulated smart card.
 pub const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -24,8 +24,10 @@ pub const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
 pub const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";
 /// Default CSP name.
 pub const MICROSOFT_DEFAULT_CSP: &str = "Microsoft Base Smart Card Crypto Provider";
-const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
-const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "msclmd.dll";
+/// Default KSP name.
+pub const MICROSOFT_DEFAULT_KSP: &str = "Microsoft Smart Card Key Storage Provider";
+/// Default smart card driver location.
+pub const MICROSOFT_SCARD_DRIVER_LOCATION: &str = "msclmd.dll\0";
 
 /// Describes a smart card reader.
 #[derive(Debug, Clone)]

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -18,7 +18,7 @@ use crate::{Error, ErrorKind, WinScardResult};
 /// https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew
 /// To be notified of the arrival of a new smart card reader,
 /// set the szReader member of a SCARD_READERSTATE structure to "\\?PnP?\Notification",
-pub const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
+const NEW_READER_NOTIFICATION: &str = "\\\\?PnP?\\Notification";
 
 /// Default name of the emulated smart card.
 pub const DEFAULT_CARD_NAME: &str = "Sspi-rs emulated smart card";

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -56,7 +56,7 @@ pub struct SmartCardInfo<'a> {
 }
 
 impl<'a> SmartCardInfo<'a> {
-    fn reader_icon() -> &'static [u8] {
+    pub fn reader_icon() -> &'static [u8] {
         include_bytes!("../assets/reader_icon.bmp")
     }
 

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -312,7 +312,7 @@ impl<'a> ScardContext<'a> {
                 (compressed.len() + 2 /* unknown flags */ + 2/* uncompressed certificate len */) as u32;
             value.extend_from_slice(&total_value_len.to_le_bytes());
 
-            value.extend_from_slice(&[0x01, 0x00]); // unknown flags
+            value.extend_from_slice(&[0x01, 0x00]); // flags that specify that the certificate is compressed
             value.extend_from_slice(&(smart_card_info.auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
             value.extend_from_slice(&compressed_cert);
 

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -56,6 +56,7 @@ pub struct SmartCardInfo<'a> {
 }
 
 impl<'a> SmartCardInfo<'a> {
+    /// Returns image bytes (BMP encoded) of the stadard Windowss Reader Icon.
     pub fn reader_icon() -> &'static [u8] {
         include_bytes!("../assets/reader_icon.bmp")
     }
@@ -64,82 +65,16 @@ impl<'a> SmartCardInfo<'a> {
     /// Required environment variables are listed in the `env` module of this crate.
     #[cfg(feature = "std")]
     pub fn try_from_env() -> WinScardResult<Self> {
-        use std::fs;
-
-        use picky::x509::Cert;
-
         use crate::env::{
-            WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV, WINSCARD_CONTAINER_NAME_ENV, WINSCARD_PIN_ENV,
-            WINSCARD_PK_DATA_ENV, WINSCARD_PK_PATH_ENV, WINSCARD_READER_NAME_ENV,
+            auth_cert_from_env, container_name, private_key_from_env, WINSCARD_PIN_ENV, WINSCARD_READER_NAME_ENV,
         };
 
-        let container_name = env!(WINSCARD_CONTAINER_NAME_ENV)?.into();
+        let container_name = container_name()?.into();
         let reader_name: Cow<'_, str> = env!(WINSCARD_READER_NAME_ENV)?.into();
         let pin = env!(WINSCARD_PIN_ENV)?.into();
 
-        let auth_cert_der = if let Ok(cert_data) = env!(WINSCARD_CERT_DATA_ENV) {
-            use base64::Engine;
-            use picky_asn1_x509::Certificate;
-
-            let cert_der = base64::engine::general_purpose::STANDARD.decode(cert_data)?;
-
-            // Deserialize the certificate to ensure the provided data is a valid ASN1 DER certificate.
-            let _: Certificate = picky_asn1_der::from_bytes(&cert_der)?;
-
-            cert_der
-        } else if let Ok(cert_path) = env!(WINSCARD_CERT_PATH_ENV) {
-            let raw_certificate = fs::read_to_string(cert_path).map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidParameter,
-                    format!("Unable to read certificate from the provided file: {}", e),
-                )
-            })?;
-            Cert::from_pem_str(&raw_certificate)?.to_der()?
-        } else {
-            return Err(Error::new(
-                ErrorKind::InvalidParameter,
-                format!(
-                    "Either \"{}\" or \"{}\" environment variable must be present",
-                    WINSCARD_CERT_DATA_ENV, WINSCARD_CERT_PATH_ENV
-                ),
-            ));
-        };
-
-        let (raw_private_key, private_key) = if let Ok(private_key_data) = env!(WINSCARD_PK_DATA_ENV) {
-            use base64::Engine;
-
-            let private_key_der = base64::engine::general_purpose::STANDARD.decode(private_key_data)?;
-
-            let private_key = PrivateKey::from_pkcs8(&private_key_der)?;
-            let raw_private_key = private_key.to_pem_str()?;
-
-            (raw_private_key, private_key)
-        } else if let Ok(pk_path) = env!(WINSCARD_PK_PATH_ENV) {
-            let raw_private_key = fs::read_to_string(pk_path).map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidParameter,
-                    format!("Unable to read private key from the provided file: {}", e),
-                )
-            })?;
-            let private_key = PrivateKey::from_pem_str(&raw_private_key).map_err(|e| {
-                Error::new(
-                    ErrorKind::InvalidParameter,
-                    format!(
-                        "Error while trying to read a private key from a pem-encoded string: {}",
-                        e
-                    ),
-                )
-            })?;
-            (raw_private_key, private_key)
-        } else {
-            return Err(Error::new(
-                ErrorKind::InvalidParameter,
-                format!(
-                    "Either \"{}\" or \"{}\" environment variable must be present",
-                    WINSCARD_PK_DATA_ENV, WINSCARD_PK_PATH_ENV
-                ),
-            ));
-        };
+        let auth_cert_der = auth_cert_from_env()?.to_der()?;
+        let (raw_private_key, private_key) = private_key_from_env()?;
 
         // Standard Windows Reader Icon
         let icon: &[u8] = Self::reader_icon();

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -523,6 +523,7 @@ bitflags! {
 /// The `SCARD_READERSTATEW` structure is used by functions for tracking smart cards within readers.
 ///
 /// [SCARD_READERSTATEW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/ns-winscard-scard_readerstatew).
+#[derive(Debug)]
 pub struct ReaderState<'data> {
     /// The name of the reader being monitored.
     pub reader_name: Cow<'data, str>,
@@ -729,7 +730,7 @@ pub trait WinScardContext {
     /// [SCardGetStatusChangeW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew)
     ///
     /// The SCardGetStatusChange function blocks execution until the current availability of the cards in a specific set of readers changes.
-    fn get_status_change(&self, timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()>;
+    fn get_status_change(&mut self, timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()>;
 
     /// [SCardGetCardTypeProviderNameW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetcardtypeprovidernamew)
     ///

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -60,6 +60,12 @@ impl From<ReaderAction> for u32 {
     }
 }
 
+impl From<ReaderAction> for u64 {
+    fn from(value: ReaderAction) -> Self {
+        value as u64
+    }
+}
+
 /// A smart card attribute id.
 ///
 /// This enum represents a scard attribute id. A set of variants is formed by merging `WinSCard` attr ids and `pscsc-lite` attr ids.
@@ -293,6 +299,12 @@ impl From<ScardScope> for u32 {
     }
 }
 
+impl From<ScardScope> for u64 {
+    fn from(value: ScardScope) -> Self {
+        value as u64
+    }
+}
+
 /// [SCardConnectW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardconnectw)
 ///
 /// `dwShareMode` parameter:
@@ -312,6 +324,12 @@ pub enum ShareMode {
 impl From<ShareMode> for u32 {
     fn from(value: ShareMode) -> Self {
         value as u32
+    }
+}
+
+impl From<ShareMode> for u64 {
+    fn from(value: ShareMode) -> Self {
+        value as u64
     }
 }
 

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -450,7 +450,7 @@ impl<'a> Status<'a> {
         } = self;
 
         Status {
-            readers: readers.into_iter().map(|r| r.to_string().into()).collect(),
+            readers: readers.into_iter().map(|r| r.into_owned().into()).collect(),
             state,
             protocol,
             atr,

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -439,6 +439,25 @@ pub struct Status<'a> {
     pub atr: Atr,
 }
 
+impl<'a> Status<'a> {
+    /// Returns owned [Status].
+    pub fn into_owned(self) -> Status<'static> {
+        let Status {
+            atr,
+            readers,
+            protocol,
+            state,
+        } = self;
+
+        Status {
+            readers: readers.into_iter().map(|r| r.to_string().into()).collect(),
+            state,
+            protocol,
+            atr,
+        }
+    }
+}
+
 /// [SCARD_IO_REQUEST](https://learn.microsoft.com/en-us/windows/win32/secauthn/scard-io-request)
 ///
 /// The SCARD_IO_REQUEST structure begins a protocol control information structure.
@@ -523,7 +542,7 @@ bitflags! {
 /// The `SCARD_READERSTATEW` structure is used by functions for tracking smart cards within readers.
 ///
 /// [SCARD_READERSTATEW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/ns-winscard-scard_readerstatew).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReaderState<'data> {
     /// The name of the reader being monitored.
     pub reader_name: Cow<'data, str>,

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -33,6 +33,8 @@ winscard = { path = "../crates/winscard", features = ["std"], optional = true }
 # logging
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", "env-filter"] }
+bitflags = "2.6.0"
+picky-asn1-x509 = "0.13.0"
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", "env-filter"] }
 bitflags = "2.6.0"
 picky-asn1-x509 = "0.13.0"
+picky = { version = "7.0.0-rc.9", default-features = false, features = ["x509"] }
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 [features]
 default = ["aws-lc-rs"]
 tsssp = ["sspi/tsssp"]
-scard = ["sspi/scard", "dep:ffi-types", "dep:winscard"]
+scard = ["sspi/scard", "dep:ffi-types", "dep:winscard", "dep:bitflags", "dep:picky-asn1-x509", "dep:picky"]
 aws-lc-rs = ["sspi/aws-lc-rs"]
 ring = ["sspi/ring"]
 
@@ -33,13 +33,15 @@ winscard = { path = "../crates/winscard", features = ["std"], optional = true }
 # logging
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["std", "fmt", "local-time", "env-filter"] }
-bitflags = "2.6.0"
-picky-asn1-x509 = "0.13.0"
-picky = { version = "7.0.0-rc.9", default-features = false, features = ["x509"] }
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
 windows-sys = { version = "0.52", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_Security", "Win32_System_Threading"] }
+
+[target.'cfg(not(windows))'.dependencies]
+bitflags = { version = "2.6.0", optional = true }
+picky-asn1-x509 = { version = "0.13.0", optional = true }
+picky = { version = "7.0.0-rc.9", default-features = false, features = ["x509"], optional = true }
 
 [dev-dependencies]
 sspi = { path = "..", features = ["network_client", "dns_resolver", "__test-data"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -39,9 +39,9 @@ symbol-rename-macro = { path = "./symbol-rename-macro" }
 windows-sys = { version = "0.52", features = ["Win32_Security_Cryptography", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_Security", "Win32_System_Threading"] }
 
 [target.'cfg(not(windows))'.dependencies]
-bitflags = { version = "2.6.0", optional = true }
-picky-asn1-x509 = { version = "0.13.0", optional = true }
-picky = { version = "7.0.0-rc.9", default-features = false, features = ["x509"], optional = true }
+bitflags = { version = "2.6", optional = true }
+picky-asn1-x509 = { version = "0.13", optional = true }
+picky = { version = "7.0.0-rc", default-features = false, features = ["x509"], optional = true }
 
 [dev-dependencies]
 sspi = { path = "..", features = ["network_client", "dns_resolver", "__test-data"] }

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -73,7 +73,7 @@ pub unsafe fn build_buf_request_type_wide<'data>(
 }
 
 /// Saves the resulting data after the [RequestedBufferType] processing.
-#[instrument(level = "debug", ret)]
+#[instrument(level = "debug", ret, skip(out_buf))]
 pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -73,7 +73,6 @@ pub unsafe fn build_buf_request_type_wide<'data>(
 }
 
 /// Saves the resulting data after the [RequestedBufferType] processing.
-#[instrument(level = "debug", ret, skip(out_buf))]
 pub unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -1,7 +1,7 @@
 use ffi_types::winscard::{ScardIoRequest, ScardReaderStateA};
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpStr, LpVoid};
 
-use super::{LpScardContext, LpScardHandle, ScardContext, ScardHandle, ScardStatus, Dword, LpDword};
+use super::{Dword, LpDword, LpScardContext, LpScardHandle, ScardContext, ScardHandle, ScardStatus};
 
 /// Creates an Application Context to the PC/SC Resource Manager.
 ///

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -1,7 +1,9 @@
-use ffi_types::winscard::{ScardIoRequest, ScardReaderStateA};
 use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpStr, LpVoid};
 
-use super::{Dword, LpDword, LpScardContext, LpScardHandle, ScardContext, ScardHandle, ScardStatus};
+use super::{
+    Dword, LpDword, LpScardContext, LpScardHandle, ScardContext, ScardHandle, ScardIoRequest, ScardReaderState,
+    ScardStatus,
+};
 
 /// Creates an Application Context to the PC/SC Resource Manager.
 ///

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -1,7 +1,7 @@
-use ffi_types::winscard::{ScardIoRequest, ScardReaderStateA, ScardStatus};
-use ffi_types::{Dword, LpByte, LpCByte, LpCStr, LpCVoid, LpDword, LpStr, LpVoid};
+use ffi_types::winscard::{ScardIoRequest, ScardReaderStateA};
+use ffi_types::{LpByte, LpCByte, LpCStr, LpCVoid, LpStr, LpVoid};
 
-use super::{LpScardContext, LpScardHandle, ScardContext, ScardHandle};
+use super::{LpScardContext, LpScardHandle, ScardContext, ScardHandle, ScardStatus, Dword, LpDword};
 
 /// Creates an Application Context to the PC/SC Resource Manager.
 ///

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -82,7 +82,7 @@ pub type SCardStatusFn = unsafe extern "system" fn(
 pub type SCardGetStatusChangeFn = unsafe extern "system" fn(
     h_context: ScardContext,
     dw_timeout: Dword,
-    rg_reader_states: *mut ScardReaderStateA,
+    rg_reader_states: *mut ScardReaderState,
     c_readers: Dword,
 ) -> ScardStatus;
 

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -50,10 +50,7 @@ pub type Dword = c_ulong;
 
 pub type LpDword = *mut Dword;
 
-#[cfg(target_os = "macos")]
-pub const SCARD_AUTOALLOCATE: Dword = 0xffffffff;
-#[cfg(not(target_os = "macos"))]
-pub const SCARD_AUTOALLOCATE: Dword = 0xffffffffffffffff;
+pub const SCARD_AUTOALLOCATE: Dword = Dword::MAX;
 
 /// `hContext` returned by `SCardEstablishContext()`.
 ///

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -18,6 +18,8 @@ pub type Dword = c_ulong;
 
 pub type LpDword = *mut Dword;
 
+pub const SCARD_AUTOALLOCATE: Dword = 0xffffffffffffffff;
+
 /// `hContext` returned by `SCardEstablishContext()`.
 ///
 /// https://pcsclite.apdu.fr/api/pcsclite_8h.html#a22530ffaff18b5d3e32260a5f1ce4abd

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::env;
 use std::ffi::CString;
 
-use libc::{dlopen, dlsym, RTLD_LOCAL, RTLD_LAZY};
+use libc::{dlopen, dlsym, RTLD_LAZY, RTLD_LOCAL};
 use winscard::{Error, ErrorKind, WinScardResult};
 
 use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
@@ -72,7 +72,10 @@ pub fn initialize_pcsc_lite_api() -> WinScardResult<PcscLiteApiFunctionTable> {
     // SAFETY: The library path is type checked.
     let handle = unsafe { dlopen(pcsc_lite_path.as_ptr(), RTLD_LOCAL | RTLD_LAZY) };
     if handle.is_null() {
-        return Err(Error::new(ErrorKind::InternalError, format!("Can not load pcsc-lite library: {}", pcsc_lite_path.to_str().unwrap())));
+        return Err(Error::new(
+            ErrorKind::InternalError,
+            format!("Can not load pcsc-lite library: {}", pcsc_lite_path.to_str().unwrap()),
+        ));
     }
 
     macro_rules! load_fn {

--- a/ffi/src/winscard/pcsc_lite/mod.rs
+++ b/ffi/src/winscard/pcsc_lite/mod.rs
@@ -42,13 +42,22 @@ pub type LpScardHandle = *mut ScardHandle;
 // https://pcsclite.apdu.fr/api/group__API.html#differences
 // > SCardStatus() returns a bit field on pcsc-lite but a enumeration on Windows.
 bitflags::bitflags! {
+    /// [SCardStatus](https://pcsclite.apdu.fr/api/group__API.html#gae49c3c894ad7ac12a5b896bde70d0382)
+    ///
+    /// Current state of this reader: is a DWORD possibly OR'd with the following values:
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
     pub struct State: Dword {
+        /// There is no card in the reader.
         const Absent = 0x0002;
+        /// There is a card in the reader, but it has not been moved into position for use.
         const Present = 0x0004;
+        /// There is a card in the reader in position for use. The card is not powered.
         const Swallowed = 0x0008;
+        /// Power is being provided to the card, but the reader driver is unaware of the mode of the card.
         const Powered = 0x0010;
+        /// The card has been reset and is awaiting PTS negotiation.
         const Negotiable = 0x0020;
+        /// The card has been reset and specific communication protocols have been established.
         const Specific = 0x0040;
     }
 }

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -1025,7 +1025,7 @@ unsafe fn write_cache(
     card_identifier: LpUuid,
     freshness_counter: u32,
     lookup_name: &str,
-    data: LpByte,
+    data: LpCByte,
     data_len: u32,
 ) -> WinScardResult<()> {
     check_handle!(context, "scard context handle");
@@ -1045,7 +1045,7 @@ unsafe fn write_cache(
     // SAFETY: The `context` value is not zero (checked above).
     let context = unsafe { scard_context_to_winscard_context(context) }?;
     // SAFETY: The `data` parameter is not null (checked above).
-    let data = unsafe { from_raw_parts_mut(data, data_len.try_into()?) }.to_vec();
+    let data = unsafe { from_raw_parts(data, data_len.try_into()?) }.to_vec();
 
     context.write_cache(card_id, freshness_counter, lookup_name.to_owned(), data)
 }
@@ -1058,7 +1058,7 @@ pub unsafe extern "system" fn SCardWriteCacheA(
     card_identifier: LpUuid,
     freshness_counter: u32,
     lookup_name: LpStr,
-    data: LpByte,
+    data: LpCByte,
     data_len: u32,
 ) -> ScardStatus {
     check_null!(lookup_name);
@@ -1082,7 +1082,7 @@ pub unsafe extern "system" fn SCardWriteCacheW(
     card_identifier: LpUuid,
     freshness_counter: u32,
     lookup_name: LpWStr,
-    data: LpByte,
+    data: LpCByte,
     data_len: u32,
 ) -> ScardStatus {
     check_null!(lookup_name);

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -85,9 +85,13 @@ pub unsafe extern "system" fn SCardEstablishContext(
 
     let scard_context = if let Ok(use_system_card) = std::env::var(SMART_CARD_TYPE) {
         if use_system_card == "true" {
-            info!("Creating system-provided smart card context");
+            info!("Creating system-provided smart card context: 1");
             Box::new(try_execute!(SystemScardContext::establish(try_execute!(
-                dw_scope.try_into()
+                {
+                    let dw_scope_res = dw_scope.try_into();
+                    debug!(?dw_scope_res, "conversion");
+                    dw_scope_res
+                }
             ))))
         } else {
             info!("Creating emulated smart card context");

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -85,7 +85,7 @@ pub unsafe extern "system" fn SCardEstablishContext(
 
     let scard_context = if let Ok(use_system_card) = std::env::var(SMART_CARD_TYPE) {
         if use_system_card == "true" {
-            info!("Creating system-provided smart card context: 1");
+            info!("Creating system-provided smart card context");
             Box::new(try_execute!(SystemScardContext::establish(try_execute!(
                 dw_scope.try_into()
             ))))

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -87,11 +87,7 @@ pub unsafe extern "system" fn SCardEstablishContext(
         if use_system_card == "true" {
             info!("Creating system-provided smart card context: 1");
             Box::new(try_execute!(SystemScardContext::establish(try_execute!(
-                {
-                    let dw_scope_res = dw_scope.try_into();
-                    debug!(?dw_scope_res, "conversion");
-                    dw_scope_res
-                }
+                dw_scope.try_into()
             ))))
         } else {
             info!("Creating emulated smart card context");
@@ -130,7 +126,7 @@ pub unsafe extern "system" fn SCardReleaseContext(context: ScardContext) -> Scar
 
         ErrorKind::Success.into()
     } else {
-        warn!("Scard context is invalid or has been released");
+        warn!(context, "Scard context is invalid or has been released");
 
         ERROR_INVALID_HANDLE
     }
@@ -153,7 +149,7 @@ pub unsafe extern "system" fn SCardIsValidContext(context: ScardContext) -> Scar
             ERROR_INVALID_HANDLE
         }
     } else {
-        debug!("Provided context is not present in active contexts");
+        debug!(context, "Provided context is not present in active contexts");
 
         ERROR_INVALID_HANDLE
     }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -108,7 +108,6 @@ impl WinScardContextHandle {
     }
 
     /// Returns the icon of the specified reader.
-    // #[instrument(level = "debug", ret)]
     pub fn get_reader_icon(&mut self, reader: &str, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
@@ -228,7 +227,6 @@ impl WinScardContextHandle {
     }
 
     /// Saves the provided data in the [OutBuffer] based on the [RequestedBufferType].
-    // #[instrument(level = "debug", skip(data))]
     pub fn write_to_out_buf(
         &mut self,
         data: &[u8],

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -108,7 +108,7 @@ impl WinScardContextHandle {
     }
 
     /// Returns the icon of the specified reader.
-    #[instrument(level = "debug", ret)]
+    // #[instrument(level = "debug", ret)]
     pub fn get_reader_icon(&mut self, reader: &str, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
@@ -228,7 +228,7 @@ impl WinScardContextHandle {
     }
 
     /// Saves the provided data in the [OutBuffer] based on the [RequestedBufferType].
-    #[instrument(level = "debug", ret)]
+    // #[instrument(level = "debug", skip(data))]
     pub fn write_to_out_buf(
         &mut self,
         data: &[u8],

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -193,7 +193,11 @@ impl WinScard for SystemScard {
             },
             #[cfg(target_os = "windows")]
             state: state.try_into()?,
-            protocol: Protocol::from_bits(protocol.try_into()?).ok_or_else(|| {
+            protocol: Protocol::from_bits(
+                #[allow(clippy::useless_conversion)]
+                protocol.try_into()?,
+            )
+            .ok_or_else(|| {
                 Error::new(
                     ErrorKind::InternalError,
                     format!("Invalid protocol value: {}", protocol),
@@ -350,7 +354,11 @@ impl WinScard for SystemScard {
             "SCardReconnect failed"
         )?;
 
-        Ok(Protocol::from_bits(active_protocol.try_into()?).unwrap_or_default())
+        Ok(Protocol::from_bits(
+            #[allow(clippy::useless_conversion)]
+            active_protocol.try_into()?,
+        )
+        .unwrap_or_default())
     }
 
     fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -186,11 +186,9 @@ impl WinScard for SystemScard {
         let status = Status {
             readers,
             #[cfg(not(target_os = "windows"))]
-            state: {
-                use crate::winscard::pcsc_lite::State;
-
-                State::from_bits(state).unwrap_or(State::Specific).into()
-            },
+            state: crate::winscard::pcsc_lite::State::from_bits(state)
+                .unwrap_or(State::Specific)
+                .into(),
             #[cfg(target_os = "windows")]
             state: state.try_into()?,
             protocol: Protocol::from_bits(

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -171,7 +171,7 @@ impl WinScard for SystemScard {
                 unsafe {
                     (self.api.SCardStatusA)(
                         self.h_card()?,
-                        (&mut reader_name as *mut *mut u8) as *mut _,
+                        reader_name.as_mut_ptr(),
                         &mut reader_name_len,
                         &mut state,
                         &mut protocol,
@@ -214,12 +214,13 @@ impl WinScard for SystemScard {
         //     "SCardFreeMemory failed"
         // )?;
 
-        let state_b = crate::winscard::pcsc_lite::State::from_bits(state);
-        debug!(state, ?state_b);
+        // let state_b = crate::winscard::pcsc_lite::State::from_bits(state);
+        // debug!(state, ?state_b);
 
         let status = Status {
             readers,
-            state: state_b.map(|s| s.into()).unwrap_or(winscard::winscard::State::Specific),
+            // state: state_b.map(|s| s.into()).unwrap_or(winscard::winscard::State::Specific),
+            state: state.try_into()?,
             protocol: Protocol::from_bits(protocol.try_into().unwrap()).ok_or_else(|| {
                 Error::new(
                     ErrorKind::InternalError,

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -214,13 +214,13 @@ impl WinScard for SystemScard {
         //     "SCardFreeMemory failed"
         // )?;
 
-        // let state_b = crate::winscard::pcsc_lite::State::from_bits(state);
-        // debug!(state, ?state_b);
+        let state_b = crate::winscard::pcsc_lite::State::from_bits(state);
+        debug!(state, ?state_b);
 
         let status = Status {
             readers,
-            // state: state_b.map(|s| s.into()).unwrap_or(winscard::winscard::State::Specific),
-            state: state.try_into()?,
+            state: state_b.map(|s| s.into()).unwrap_or(winscard::winscard::State::Specific),
+            // state: state.try_into()?,
             protocol: Protocol::from_bits(protocol.try_into().unwrap()).ok_or_else(|| {
                 Error::new(
                     ErrorKind::InternalError,

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::mem::size_of;
 use std::ptr::null_mut;
 use std::slice::from_raw_parts;
@@ -18,9 +19,9 @@ use super::parse_multi_string_owned;
 #[cfg(target_os = "windows")]
 use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 #[cfg(not(target_os = "windows"))]
-use crate::winscard::pcsc_lite::SCARD_AUTOALLOCATE;
-#[cfg(not(target_os = "windows"))]
 use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::SCARD_AUTOALLOCATE;
 #[cfg(not(target_os = "windows"))]
 use crate::winscard::pcsc_lite::{initialize_pcsc_lite_api, ScardContext, ScardHandle};
 
@@ -45,17 +46,6 @@ pub struct SystemScard {
     api: SCardApiFunctionTable,
     #[cfg(not(target_os = "windows"))]
     api: PcscLiteApiFunctionTable,
-}
-
-use std::fmt;
-
-impl fmt::Debug for SystemScard {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SystemScard")
-            .field("h_card", &self.h_card)
-            .field("h_card_context", &self.h_card_context)
-            .finish()
-    }
 }
 
 impl SystemScard {
@@ -110,6 +100,15 @@ impl Drop for SystemScard {
                 error!(?err, "Failed to disconnect the card");
             }
         }
+    }
+}
+
+impl fmt::Debug for SystemScard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SystemScard")
+            .field("h_card", &self.h_card)
+            .field("h_card_context", &self.h_card_context)
+            .finish()
     }
 }
 

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
+use std::io::Write;
 use std::mem::size_of;
 use std::ptr::null_mut;
 use std::slice::from_raw_parts;
-use std::io::Write;
 
 #[cfg(target_os = "windows")]
 use ffi_types::winscard::functions::SCardApiFunctionTable;
@@ -50,9 +50,9 @@ use std::fmt;
 impl fmt::Debug for SystemScard {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SystemScard")
-         .field("h_card", &self.h_card)
-         .field("h_card_context", &self.h_card_context)
-         .finish()
+            .field("h_card", &self.h_card)
+            .field("h_card_context", &self.h_card_context)
+            .finish()
     }
 }
 
@@ -338,8 +338,6 @@ impl WinScard for SystemScard {
     }
 
     fn begin_transaction(&mut self) -> WinScardResult<()> {
-        debug!("TBT: scardbt: {} - {}. {} - {}", self.h_card()?, std::mem::size_of::<ScardHandle>(), self.h_card_context, std::mem::size_of::<ScardContext>());
-
         try_execute!(
             // SAFETY: This function is safe to call because `self.h_card` is checked.
             unsafe { (self.api.SCardBeginTransaction)(self.h_card()?) },

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -126,7 +126,7 @@ impl WinScard for SystemScard {
         //
         // PCSC-lite docs do not specify that ATR buf should be 32 bytes long, but actually,
         // the ATR string can not be longer than 32 bytes.
-        let mut atr = [0; 32];
+        let mut atr = vec![0; 32];
         let mut atr_len = 32;
 
         #[cfg(not(target_os = "windows"))]
@@ -181,6 +181,8 @@ impl WinScard for SystemScard {
             ));
         };
 
+        atr.truncate(atr_len.try_into()?);
+
         let status = Status {
             readers,
             #[cfg(not(target_os = "windows"))]
@@ -197,7 +199,7 @@ impl WinScard for SystemScard {
                     format!("Invalid protocol value: {}", protocol),
                 )
             })?,
-            atr: atr[0..atr_len.try_into()?].to_vec().into(),
+            atr: atr.into(),
         };
 
         Ok(status)

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -114,8 +114,8 @@ impl WinScard for SystemScard {
     #[instrument(ret)]
     fn status(&self) -> WinScardResult<Status> {
         // macOS PC/SC framework doesn't support `SCARD_AUTOALLOCATE` option, so we use preallocated buffer for reader name.
-        let mut reader_name = vec![0; 256];
-        let mut reader_name_len = 256;
+        let mut reader_name = vec![0; 1024];
+        let mut reader_name_len = 1024;
 
         let mut state = 0;
         let mut protocol = 0;

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -18,9 +18,9 @@ use super::parse_multi_string_owned;
 #[cfg(target_os = "windows")]
 use crate::winscard::buf_alloc::SCARD_AUTOALLOCATE;
 #[cfg(not(target_os = "windows"))]
-use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
-#[cfg(not(target_os = "windows"))]
 use crate::winscard::pcsc_lite::SCARD_AUTOALLOCATE;
+#[cfg(not(target_os = "windows"))]
+use crate::winscard::pcsc_lite::functions::PcscLiteApiFunctionTable;
 #[cfg(not(target_os = "windows"))]
 use crate::winscard::pcsc_lite::{initialize_pcsc_lite_api, ScardContext, ScardHandle};
 
@@ -214,7 +214,7 @@ impl WinScard for SystemScard {
             },
             #[cfg(target_os = "windows")]
             state: state.try_into()?,
-            protocol: Protocol::from_bits(protocol.try_into().unwrap()).ok_or_else(|| {
+            protocol: Protocol::from_bits(protocol.try_into()?).ok_or_else(|| {
                 Error::new(
                     ErrorKind::InternalError,
                     format!("Invalid protocol value: {}", protocol),

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -33,6 +33,16 @@ pub struct SystemScardContext {
     cache: BTreeMap<String, Vec<u8>>,
 }
 
+use std::fmt;
+
+impl fmt::Debug for SystemScardContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SystemScardContext")
+            .field("h_context", &self.h_context)
+            .finish()
+    }
+}
+
 impl SystemScardContext {
     #[allow(dead_code)]
     pub fn establish(scope: ScardScope) -> WinScardResult<Self> {
@@ -61,260 +71,262 @@ impl SystemScardContext {
 
         // initialize scard cache
 
-        use winscard::SmartCardInfo;
-        let smart_card_info = SmartCardInfo::try_from_env().unwrap();
+        // use winscard::SmartCardInfo;
+        // let smart_card_info = SmartCardInfo::try_from_env().unwrap();
 
-        // Freshness values may vary at different points in time.
-        // We do not need to change them in runtime, so we hardcode them here.
-        // Those values do not mean anything special. They are just extracted from the real TPM smart card.
-        const PIN_FRESHNESS: [u8; 2] = [0x00, 0x00];
-        const CONTAINER_FRESHNESS: [u8; 2] = [0x01, 0x00];
-        const FILE_FRESHNESS: [u8; 2] = [0x0b, 0x00];
+        // // Freshness values may vary at different points in time.
+        // // We do not need to change them in runtime, so we hardcode them here.
+        // // Those values do not mean anything special. They are just extracted from the real TPM smart card.
+        // const PIN_FRESHNESS: [u8; 2] = [0x00, 0x00];
+        // const CONTAINER_FRESHNESS: [u8; 2] = [0x01, 0x00];
+        // const FILE_FRESHNESS: [u8; 2] = [0x0b, 0x00];
 
-        // The following header is formed based on the extracted information from the Windows Smart Card Minidriver (`msclmd.dll`).
-        // Do not change it unless you know what you are doing.
-        // A broken cache will break the entire authentication.
-        const CACHE_ITEM_HEADER: [u8; 6] = {
-            let mut header = [0; 6];
+        // // The following header is formed based on the extracted information from the Windows Smart Card Minidriver (`msclmd.dll`).
+        // // Do not change it unless you know what you are doing.
+        // // A broken cache will break the entire authentication.
+        // const CACHE_ITEM_HEADER: [u8; 6] = {
+        //     let mut header = [0; 6];
 
-            // reference: msclmd!I_GetPIVCache
-            header[0] = 1;
-            header[1] = PIN_FRESHNESS[1];
-            header[2] = CONTAINER_FRESHNESS[0] + 1;
-            header[3] = CONTAINER_FRESHNESS[1];
-            header[4] = FILE_FRESHNESS[0] + 1;
-            header[5] = FILE_FRESHNESS[1];
+        //     // reference: msclmd!I_GetPIVCache
+        //     header[0] = 1;
+        //     header[1] = PIN_FRESHNESS[1];
+        //     header[2] = CONTAINER_FRESHNESS[0] + 1;
+        //     header[3] = CONTAINER_FRESHNESS[1];
+        //     header[4] = FILE_FRESHNESS[0] + 1;
+        //     header[5] = FILE_FRESHNESS[1];
 
-            header
-        };
+        //     header
+        // };
 
-        let mut cache = BTreeMap::new();
-        cache.insert("Cached_CardProperty_Read Only Mode_0".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&4_u32.to_le_bytes());
-            // false
-            value.extend_from_slice(&0_u32.to_le_bytes());
+        // let mut cache = BTreeMap::new();
+        // cache.insert("Cached_CardProperty_Read Only Mode_0".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&4_u32.to_le_bytes());
+        //     // false
+        //     value.extend_from_slice(&0_u32.to_le_bytes());
 
-            value
-        });
-        cache.insert("Cached_CardProperty_Cache Mode_0".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&4_u32.to_le_bytes());
-            // true
-            value.extend_from_slice(&1_u32.to_le_bytes());
+        //     value
+        // });
+        // cache.insert("Cached_CardProperty_Cache Mode_0".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&4_u32.to_le_bytes());
+        //     // true
+        //     value.extend_from_slice(&1_u32.to_le_bytes());
 
-            value
-        });
-        cache.insert("Cached_CardProperty_Supports Windows x.509 Enrollment_0".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&4_u32.to_le_bytes());
-            // true
-            value.extend_from_slice(&1_u32.to_le_bytes());
+        //     value
+        // });
+        // cache.insert("Cached_CardProperty_Supports Windows x.509 Enrollment_0".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&4_u32.to_le_bytes());
+        //     // true
+        //     value.extend_from_slice(&1_u32.to_le_bytes());
 
-            value
-        });
-        cache.insert("Cached_GeneralFile/mscp/cmapfile".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len: size_of<CONTAINER_MAP_RECORD>()
-            // https://github.com/selfrender/Windows-Server-2003/blob/5c6fe3db626b63a384230a1aa6b92ac416b0765f/ds/security/csps/wfsccsp/inc/basecsp.h#L104-L110
-            value.extend_from_slice(&86_u32.to_le_bytes());
-            // CONTAINER_MAP_RECORD:
-            let container = smart_card_info
-                .container_name
-                .as_ref()
-                .encode_utf16()
-                .chain(core::iter::once(0))
-                .flat_map(|v| v.to_le_bytes())
-                .collect::<Vec<_>>();
-            value.extend_from_slice(&container); // wszGuid
-            value.extend_from_slice(&[3, 0]); // bFlags
-            value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
-            value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
+        //     value
+        // });
+        // cache.insert("Cached_GeneralFile/mscp/cmapfile".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len: size_of<CONTAINER_MAP_RECORD>()
+        //     // https://github.com/selfrender/Windows-Server-2003/blob/5c6fe3db626b63a384230a1aa6b92ac416b0765f/ds/security/csps/wfsccsp/inc/basecsp.h#L104-L110
+        //     value.extend_from_slice(&86_u32.to_le_bytes());
+        //     // CONTAINER_MAP_RECORD:
+        //     let container = smart_card_info
+        //         .container_name
+        //         .as_ref()
+        //         .encode_utf16()
+        //         .chain(core::iter::once(0))
+        //         .flat_map(|v| v.to_le_bytes())
+        //         .collect::<Vec<_>>();
+        //     value.extend_from_slice(&container); // wszGuid
+        //     value.extend_from_slice(&[3, 0]); // bFlags
+        //     value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
+        //     value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
 
-            value
-        });
-        cache.insert("Cached_CardmodFile\\Cached_CMAPFile".into(), {
-            // CONTAINER_MAP_RECORD:
-            let mut value = smart_card_info
-                .container_name
-                .as_ref()
-                .encode_utf16()
-                .chain(core::iter::once(0))
-                .flat_map(|v| v.to_le_bytes())
-                .collect::<Vec<_>>(); // wszGuid
-            value.extend_from_slice(&[3, 0]); // bFlags
-            value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
-            value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
+        //     value
+        // });
+        // cache.insert("Cached_CardmodFile\\Cached_CMAPFile".into(), {
+        //     // CONTAINER_MAP_RECORD:
+        //     let mut value = smart_card_info
+        //         .container_name
+        //         .as_ref()
+        //         .encode_utf16()
+        //         .chain(core::iter::once(0))
+        //         .flat_map(|v| v.to_le_bytes())
+        //         .collect::<Vec<_>>(); // wszGuid
+        //     value.extend_from_slice(&[3, 0]); // bFlags
+        //     value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
+        //     value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
 
-            value
-        });
-        cache.insert("Cached_ContainerProperty_PIN Identifier_0".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&4_u32.to_le_bytes());
-            // PIN identifier
-            value.extend_from_slice(&1_u32.to_le_bytes());
+        //     value
+        // });
+        // cache.insert("Cached_ContainerProperty_PIN Identifier_0".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&4_u32.to_le_bytes());
+        //     // PIN identifier
+        //     value.extend_from_slice(&1_u32.to_le_bytes());
 
-            value
-        });
-        cache.insert("Cached_ContainerInfo_00".into(), {
-            // Note. We can hardcode lengths values in this cache item because we support only 2048 RSA keys.
-            // RSA 4096 is not defined in the specification so we don't support it.
-            // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=34
-            // 5.3 Cryptographic Mechanism Identifiers
-            // '07' - RSA 2048
+        //     value
+        // });
+        // cache.insert("Cached_ContainerInfo_00".into(), {
+        //     // Note. We can hardcode lengths values in this cache item because we support only 2048 RSA keys.
+        //     // RSA 4096 is not defined in the specification so we don't support it.
+        //     // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=34
+        //     // 5.3 Cryptographic Mechanism Identifiers
+        //     // '07' - RSA 2048
 
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len (precalculated)
-            value.extend_from_slice(&292_u32.to_le_bytes());
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len (precalculated)
+        //     value.extend_from_slice(&292_u32.to_le_bytes());
 
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x01, 0x00, 0x00]); // container info header
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x01, 0x00, 0x00]); // container info header
 
-            // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-publickeystruc
-            // PUBLICKEYSTRUC
-            value.push(0x06); // bType = PUBLICKEYBLOB
-            value.push(0x02); // bVersion = 0x2
-            value.extend_from_slice(&[0x00, 0x00]); // reserved
-            value.extend_from_slice(&[0x00, 0xa4, 0x00, 0x00]); // aiKeyAlg = CALG_RSA_KEYX
+        //     // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-publickeystruc
+        //     // PUBLICKEYSTRUC
+        //     value.push(0x06); // bType = PUBLICKEYBLOB
+        //     value.push(0x02); // bVersion = 0x2
+        //     value.extend_from_slice(&[0x00, 0x00]); // reserved
+        //     value.extend_from_slice(&[0x00, 0xa4, 0x00, 0x00]); // aiKeyAlg = CALG_RSA_KEYX
 
-            // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-rsapubkey
-            // RSAPUBKEY
-            value.extend_from_slice(b"RSA1"); // magic = RSA1
-            value.extend_from_slice(&2048_u32.to_le_bytes()); // bitlen = 2048
+        //     // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-rsapubkey
+        //     // RSAPUBKEY
+        //     value.extend_from_slice(b"RSA1"); // magic = RSA1
+        //     value.extend_from_slice(&2048_u32.to_le_bytes()); // bitlen = 2048
 
-            // let pub_key = smart_cards_info.
-            let public_key = smart_card_info
-                .auth_pk
-                .to_public_key()
-                .expect("rsa private key to public key");
-            let public_key: &SubjectPublicKeyInfo = public_key.as_ref();
-            let (modulus, public_exponent) = match &public_key.subject_public_key {
-                PublicKey::Rsa(rsa) => (
-                    {
-                        let mut modulus = rsa.0.modulus.to_vec();
-                        modulus.reverse();
-                        modulus.resize(256, 0);
-                        modulus
-                    },
-                    {
-                        let mut pub_exp = rsa.0.public_exponent.to_vec();
-                        pub_exp.reverse();
-                        pub_exp.resize(4, 0);
-                        pub_exp
-                    },
-                ),
-                _ => {
-                    return Err(Error::new(
-                        ErrorKind::UnsupportedFeature,
-                        "only RSA 2048 keys are supported",
-                    ))
-                }
-            };
+        //     // let pub_key = smart_cards_info.
+        //     let public_key = smart_card_info
+        //         .auth_pk
+        //         .to_public_key()
+        //         .expect("rsa private key to public key");
+        //     let public_key: &SubjectPublicKeyInfo = public_key.as_ref();
+        //     let (modulus, public_exponent) = match &public_key.subject_public_key {
+        //         PublicKey::Rsa(rsa) => (
+        //             {
+        //                 let mut modulus = rsa.0.modulus.to_vec();
+        //                 modulus.reverse();
+        //                 modulus.resize(256, 0);
+        //                 modulus
+        //             },
+        //             {
+        //                 let mut pub_exp = rsa.0.public_exponent.to_vec();
+        //                 pub_exp.reverse();
+        //                 pub_exp.resize(4, 0);
+        //                 pub_exp
+        //             },
+        //         ),
+        //         _ => {
+        //             return Err(Error::new(
+        //                 ErrorKind::UnsupportedFeature,
+        //                 "only RSA 2048 keys are supported",
+        //             ))
+        //         }
+        //     };
 
-            value.extend_from_slice(&public_exponent); // pubexp
-            value.extend_from_slice(&modulus); // public key
+        //     value.extend_from_slice(&public_exponent); // pubexp
+        //     value.extend_from_slice(&modulus); // public key
 
-            value
-        });
-        cache.insert("Cached_GeneralFile/mscp/kxc00".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     value
+        // });
+        // cache.insert("Cached_GeneralFile/mscp/kxc00".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
 
-            let mut compressed_cert = vec![0; smart_card_info.auth_cert_der.len()];
-            let compressed = winscard::compression::compress_cert(&smart_card_info.auth_cert_der, &mut compressed_cert)?;
+        //     let mut compressed_cert = vec![0; smart_card_info.auth_cert_der.len()];
+        //     let compressed = winscard::compression::compress_cert(&smart_card_info.auth_cert_der, &mut compressed_cert)?;
 
-            let total_value_len =
-                (compressed.len() + 2 /* unknown flags */ + 2/* uncompressed certificate len */) as u32;
-            value.extend_from_slice(&total_value_len.to_le_bytes());
+        //     let total_value_len =
+        //         (compressed.len() + 2 /* unknown flags */ + 2/* uncompressed certificate len */) as u32;
+        //     value.extend_from_slice(&total_value_len.to_le_bytes());
 
-            value.extend_from_slice(&[0x01, 0x00]); // unknown flags
-            value.extend_from_slice(&(smart_card_info.auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
-            value.extend_from_slice(&compressed_cert);
+        //     value.extend_from_slice(&[0x01, 0x00]); // unknown flags
+        //     value.extend_from_slice(&(smart_card_info.auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
+        //     value.extend_from_slice(&compressed_cert);
 
-            value
-        });
-        cache.insert("Cached_CardProperty_Capabilities_0".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&12_u32.to_le_bytes());
-            // Here should be the CARD_CAPABILITIES struct but the actual extracted data is different.
-            // So, we just insert the extracted data from a real smart card.
-            // Card capabilities:
-            value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
+        //     value
+        // });
+        // cache.insert("Cached_CardProperty_Capabilities_0".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&12_u32.to_le_bytes());
+        //     // Here should be the CARD_CAPABILITIES struct but the actual extracted data is different.
+        //     // So, we just insert the extracted data from a real smart card.
+        //     // Card capabilities:
+        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
 
-            value
-        });
+        //     value
+        // });
 
-        cache.insert("Cached_CardProperty_Key Sizes_2".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&20_u32.to_le_bytes());
-            // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
-            value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
-            value.extend_from_slice(&[
-                1, 0, 0, 0, // dwVersion = 1
-                0, 4, 0, 0, // dwMinimumBitlen = 1024
-                0, 4, 0, 0, // dwDefaultBitlen = 1048
-                0, 8, 0, 0, // dwMaximumBitlen = 2048
-                0, 4, 0, 0, // dwIncrementalBitlen = 1024
-            ]);
+        // cache.insert("Cached_CardProperty_Key Sizes_2".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&20_u32.to_le_bytes());
+        //     // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
+        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
+        //     value.extend_from_slice(&[
+        //         1, 0, 0, 0, // dwVersion = 1
+        //         0, 4, 0, 0, // dwMinimumBitlen = 1024
+        //         0, 4, 0, 0, // dwDefaultBitlen = 1048
+        //         0, 8, 0, 0, // dwMaximumBitlen = 2048
+        //         0, 4, 0, 0, // dwIncrementalBitlen = 1024
+        //     ]);
 
-            value
-        });
+        //     value
+        // });
 
-        cache.insert("Cached_CardProperty_Key Sizes_1".into(), {
-            let mut value = CACHE_ITEM_HEADER.to_vec();
-            // unkown flags
-            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-            // actual data len
-            value.extend_from_slice(&20_u32.to_le_bytes());
-            // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
-            value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
-            value.extend_from_slice(&[
-                1, 0, 0, 0, // dwVersion = 1
-                0, 4, 0, 0, // dwMinimumBitlen = 1024
-                0, 4, 0, 0, // dwDefaultBitlen = 1048
-                0, 8, 0, 0, // dwMaximumBitlen = 2048
-                0, 4, 0, 0, // dwIncrementalBitlen = 1024
-            ]);
+        // cache.insert("Cached_CardProperty_Key Sizes_1".into(), {
+        //     let mut value = CACHE_ITEM_HEADER.to_vec();
+        //     // unkown flags
+        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        //     // actual data len
+        //     value.extend_from_slice(&20_u32.to_le_bytes());
+        //     // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
+        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
+        //     value.extend_from_slice(&[
+        //         1, 0, 0, 0, // dwVersion = 1
+        //         0, 4, 0, 0, // dwMinimumBitlen = 1024
+        //         0, 4, 0, 0, // dwDefaultBitlen = 1048
+        //         0, 8, 0, 0, // dwMaximumBitlen = 2048
+        //         0, 4, 0, 0, // dwIncrementalBitlen = 1024
+        //     ]);
 
-            value
-        });
+        //     value
+        // });
 
-        cache.insert(
-            "Cached_CardmodFile\\Cached_Pin_Freshness".into(),
-            PIN_FRESHNESS.to_vec(),
-        );
-        cache.insert(
-            "Cached_CardmodFile\\Cached_File_Freshness".into(),
-            FILE_FRESHNESS.to_vec(),
-        );
-        cache.insert(
-            "Cached_CardmodFile\\Cached_Container_Freshness".into(),
-            CONTAINER_FRESHNESS.to_vec(),
-        );
+        // cache.insert(
+        //     "Cached_CardmodFile\\Cached_Pin_Freshness".into(),
+        //     PIN_FRESHNESS.to_vec(),
+        // );
+        // cache.insert(
+        //     "Cached_CardmodFile\\Cached_File_Freshness".into(),
+        //     FILE_FRESHNESS.to_vec(),
+        // );
+        // cache.insert(
+        //     "Cached_CardmodFile\\Cached_Container_Freshness".into(),
+        //     CONTAINER_FRESHNESS.to_vec(),
+        // );
 
-        Ok(Self { h_context, api, cache })
+        Ok(Self { h_context, api,
+            // cache
+        })
     }
 }
 
@@ -545,6 +557,7 @@ impl WinScardContext for SystemScardContext {
         .is_ok()
     }
 
+    #[instrument]
     fn read_cache(&self, _card_id: Uuid, _freshness_counter: u32, key: &str) -> WinScardResult<Cow<[u8]>> {
         #[cfg(not(target_os = "windows"))]
         {

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -59,13 +59,11 @@ impl SystemScardContext {
         #[cfg(not(target_os = "windows"))]
         let api = initialize_pcsc_lite_api()?;
 
-        debug!("h_context size: {}", std::mem::size_of_val(&h_context));
-
         try_execute!(
             // SAFETY: This function is safe to call because the `scope` parameter value is type checked
             // and `*mut h_context` can't be `null`.
             unsafe { (api.SCardEstablishContext)(scope.into(), null_mut(), null_mut(), &mut h_context) },
-            "SCardEstablishContext failed :("
+            "SCardEstablishContext failed"
         )?;
 
         if h_context == 0 {
@@ -366,7 +364,7 @@ impl WinScardContext for SystemScardContext {
                 // SAFETY: This function is safe to call because the `self.h_context` is always a valid handle
                 // and other parameters are type checked.
                 unsafe { (self.api.SCardListReaders)(self.h_context, null(), null_mut(), &mut readers_buf_len) },
-                "SCardListReaders failed 1"
+                "SCardListReaders failed"
             )?;
         }
         #[cfg(target_os = "windows")]
@@ -394,7 +392,7 @@ impl WinScardContext for SystemScardContext {
                 unsafe {
                     (self.api.SCardListReaders)(self.h_context, null(), readers.as_mut_ptr(), &mut readers_buf_len)
                 },
-                "SCardListReaders failed 2"
+                "SCardListReaders failed"
             )?;
         }
         #[cfg(target_os = "windows")]
@@ -576,7 +574,6 @@ impl WinScardContext for SystemScardContext {
         }
     }
 
-    #[instrument(ret)]
     fn write_cache(
         &mut self,
         _card_id: Uuid,

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -347,7 +347,11 @@ impl WinScardContext for SystemScardContext {
 
         Ok(ScardConnectData {
             handle,
-            protocol: Protocol::from_bits(active_protocol.try_into()?).unwrap_or_default(),
+            protocol: Protocol::from_bits(
+                #[allow(clippy::useless_conversion)]
+                active_protocol.try_into()?,
+            )
+            .unwrap_or_default(),
         })
     }
 

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -39,10 +39,6 @@ pub struct SystemScardContext {
     // pcsc-lite API does not have function for the cache reading/writing. So, we emulate the smart card cache by ourselves.
     #[cfg(not(target_os = "windows"))]
     cache: BTreeMap<String, Vec<u8>>,
-    // pcsc-lite API does not have the `SCardGetStatusChangeW` function. We need the ATR string value to emulate it. We query the ATR
-    // string once using the pcsc-lite API, save it, and then use it every time we need it.
-    #[cfg(not(target_os = "windows"))]
-    atr: Option<Vec<u8>>,
 }
 
 impl fmt::Debug for SystemScardContext {
@@ -89,8 +85,6 @@ impl SystemScardContext {
 
                 init_scard_cache(&winscard::env::container_name()?, auth_cert, &auth_cert_der)?
             },
-            #[cfg(not(target_os = "windows"))]
-            atr: None,
         })
     }
 }

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -70,262 +70,172 @@ impl SystemScardContext {
         debug!("foierjfoirefj: {} - {}", h_context, std::mem::size_of::<ScardContext>());
 
         // initialize scard cache
+        use picky::x509::Cert;
 
-        // use winscard::SmartCardInfo;
-        // let smart_card_info = SmartCardInfo::try_from_env().unwrap();
+        let auth_cert = {
+            let cert_path = std::env::var("WINSCARD_CERTIFICATE_FILE_PATH").unwrap();
+            let raw_certificate = std::fs::read_to_string(cert_path).unwrap();
+            Cert::from_pem_str(&raw_certificate).unwrap()
+        };
+        let auth_cert_der = auth_cert.to_der().unwrap();
 
-        // // Freshness values may vary at different points in time.
-        // // We do not need to change them in runtime, so we hardcode them here.
-        // // Those values do not mean anything special. They are just extracted from the real TPM smart card.
-        // const PIN_FRESHNESS: [u8; 2] = [0x00, 0x00];
-        // const CONTAINER_FRESHNESS: [u8; 2] = [0x01, 0x00];
-        // const FILE_FRESHNESS: [u8; 2] = [0x0b, 0x00];
+        let mut cache = BTreeMap::new();
+        cache.insert("Cached_CardProperty_Read Only Mode_0".into(), {
+            let mut value = [1, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len
+            value.extend_from_slice(&4_u32.to_le_bytes());
+            // true
+            value.extend_from_slice(&1_u32.to_le_bytes());
 
-        // // The following header is formed based on the extracted information from the Windows Smart Card Minidriver (`msclmd.dll`).
-        // // Do not change it unless you know what you are doing.
-        // // A broken cache will break the entire authentication.
-        // const CACHE_ITEM_HEADER: [u8; 6] = {
-        //     let mut header = [0; 6];
+            value
+        });
+        cache.insert("Cached_CardProperty_Cache Mode_0".into(), {
+            let mut value = [1, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len
+            value.extend_from_slice(&4_u32.to_le_bytes());
+            // true
+            value.extend_from_slice(&1_u32.to_le_bytes());
 
-        //     // reference: msclmd!I_GetPIVCache
-        //     header[0] = 1;
-        //     header[1] = PIN_FRESHNESS[1];
-        //     header[2] = CONTAINER_FRESHNESS[0] + 1;
-        //     header[3] = CONTAINER_FRESHNESS[1];
-        //     header[4] = FILE_FRESHNESS[0] + 1;
-        //     header[5] = FILE_FRESHNESS[1];
+            value
+        });
+        cache.insert("Cached_CardProperty_Supports Windows x.509 Enrollment_0".into(), {
+            let mut value = [1, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len
+            value.extend_from_slice(&4_u32.to_le_bytes());
+            // false
+            value.extend_from_slice(&0_u32.to_le_bytes());
 
-        //     header
-        // };
+            value
+        });
+        cache.insert("Cached_GeneralFile/mscp/cmapfile".into(), {
+            let mut value = [1, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len: size_of<CONTAINER_MAP_RECORD>()
+            // https://github.com/selfrender/Windows-Server-2003/blob/5c6fe3db626b63a384230a1aa6b92ac416b0765f/ds/security/csps/wfsccsp/inc/basecsp.h#L104-L110
+            value.extend_from_slice(&86_u32.to_le_bytes());
+            // CONTAINER_MAP_RECORD:
+            // let container = smart_card_info
+            //     .container_name
+            //     .as_ref()
+            //     .encode_utf16()
+            //     .chain(core::iter::once(0))
+            //     .flat_map(|v| v.to_le_bytes())
+            //     .collect::<Vec<_>>();
+            let container = [49, 0, 100, 0, 56, 0, 97, 0, 99, 0, 54, 0, 53, 0, 56, 0, 45, 0, 101, 0, 48, 0, 54, 0, 53, 0, 45, 0, 57, 0, 50, 0, 97, 0, 48, 0, 45, 0, 56, 0, 53, 0, 97, 0, 102, 0, 45, 0, 48, 0, 57, 0, 48, 0, 98, 0, 48, 0, 55, 0, 53, 0, 102, 0, 99, 0, 49, 0, 48, 0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+            value.extend_from_slice(&container); // wszGuid
+            value.extend_from_slice(&[3, 0]); // bFlags
+            value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
+            value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
 
-        // let mut cache = BTreeMap::new();
-        // cache.insert("Cached_CardProperty_Read Only Mode_0".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&4_u32.to_le_bytes());
-        //     // false
-        //     value.extend_from_slice(&0_u32.to_le_bytes());
+            value
+        });
+        cache.insert("Cached_ContainerProperty_PIN Identifier_0".into(), {
+            let mut value = [1, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len
+            value.extend_from_slice(&4_u32.to_le_bytes());
+            // PIN identifier
+            value.extend_from_slice(&1_u32.to_le_bytes());
 
-        //     value
-        // });
-        // cache.insert("Cached_CardProperty_Cache Mode_0".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&4_u32.to_le_bytes());
-        //     // true
-        //     value.extend_from_slice(&1_u32.to_le_bytes());
+            value
+        });
+        cache.insert("Cached_ContainerInfo_00".into(), {
+            // Note. We can hardcode lengths values in this cache item because we support only 2048 RSA keys.
+            // RSA 4096 is not defined in the specification so we don't support it.
+            // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=34
+            // 5.3 Cryptographic Mechanism Identifiers
+            // '07' - RSA 2048
 
-        //     value
-        // });
-        // cache.insert("Cached_CardProperty_Supports Windows x.509 Enrollment_0".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&4_u32.to_le_bytes());
-        //     // true
-        //     value.extend_from_slice(&1_u32.to_le_bytes());
+            let mut value = [1_u8, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len (precalculated)
+            value.extend_from_slice(&292_u32.to_le_bytes());
 
-        //     value
-        // });
-        // cache.insert("Cached_GeneralFile/mscp/cmapfile".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len: size_of<CONTAINER_MAP_RECORD>()
-        //     // https://github.com/selfrender/Windows-Server-2003/blob/5c6fe3db626b63a384230a1aa6b92ac416b0765f/ds/security/csps/wfsccsp/inc/basecsp.h#L104-L110
-        //     value.extend_from_slice(&86_u32.to_le_bytes());
-        //     // CONTAINER_MAP_RECORD:
-        //     let container = smart_card_info
-        //         .container_name
-        //         .as_ref()
-        //         .encode_utf16()
-        //         .chain(core::iter::once(0))
-        //         .flat_map(|v| v.to_le_bytes())
-        //         .collect::<Vec<_>>();
-        //     value.extend_from_slice(&container); // wszGuid
-        //     value.extend_from_slice(&[3, 0]); // bFlags
-        //     value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
-        //     value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x01, 0x00, 0x00]); // container info header
 
-        //     value
-        // });
-        // cache.insert("Cached_CardmodFile\\Cached_CMAPFile".into(), {
-        //     // CONTAINER_MAP_RECORD:
-        //     let mut value = smart_card_info
-        //         .container_name
-        //         .as_ref()
-        //         .encode_utf16()
-        //         .chain(core::iter::once(0))
-        //         .flat_map(|v| v.to_le_bytes())
-        //         .collect::<Vec<_>>(); // wszGuid
-        //     value.extend_from_slice(&[3, 0]); // bFlags
-        //     value.extend_from_slice(&[0, 0]); // wSigKeySizeBits
-        //     value.extend_from_slice(&[0, 8]); // wKeyExchangeKeySizeBits
+            // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-publickeystruc
+            // PUBLICKEYSTRUC
+            value.push(0x06); // bType = PUBLICKEYBLOB
+            value.push(0x02); // bVersion = 0x2
+            value.extend_from_slice(&[0x00, 0x00]); // reserved
+            value.extend_from_slice(&[0x00, 0xa4, 0x00, 0x00]); // aiKeyAlg = CALG_RSA_KEYX
 
-        //     value
-        // });
-        // cache.insert("Cached_ContainerProperty_PIN Identifier_0".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&4_u32.to_le_bytes());
-        //     // PIN identifier
-        //     value.extend_from_slice(&1_u32.to_le_bytes());
+            // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-rsapubkey
+            // RSAPUBKEY
+            value.extend_from_slice(b"RSA1"); // magic = RSA1
+            value.extend_from_slice(&2048_u32.to_le_bytes()); // bitlen = 2048
 
-        //     value
-        // });
-        // cache.insert("Cached_ContainerInfo_00".into(), {
-        //     // Note. We can hardcode lengths values in this cache item because we support only 2048 RSA keys.
-        //     // RSA 4096 is not defined in the specification so we don't support it.
-        //     // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=34
-        //     // 5.3 Cryptographic Mechanism Identifiers
-        //     // '07' - RSA 2048
+            let public_key = auth_cert
+                .public_key();
+            let public_key: &SubjectPublicKeyInfo = public_key.as_ref();
+            let (modulus, public_exponent) = match &public_key.subject_public_key {
+                PublicKey::Rsa(rsa) => (
+                    {
+                        let mut modulus = rsa.0.modulus.to_vec();
+                        modulus.reverse();
+                        modulus.resize(256, 0);
+                        modulus
+                    },
+                    {
+                        let mut pub_exp = rsa.0.public_exponent.to_vec();
+                        pub_exp.reverse();
+                        pub_exp.resize(4, 0);
+                        pub_exp
+                    },
+                ),
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::UnsupportedFeature,
+                        "only RSA 2048 keys are supported",
+                    ))
+                }
+            };
 
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len (precalculated)
-        //     value.extend_from_slice(&292_u32.to_le_bytes());
+            value.extend_from_slice(&public_exponent); // pubexp
+            value.extend_from_slice(&modulus); // public key
 
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x14, 0x01, 0x00, 0x00]); // container info header
+            value
+        });
+        cache.insert("Cached_GeneralFile/mscp/kxc00".into(), {
+            let mut value = [1_u8, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
 
-        //     // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-publickeystruc
-        //     // PUBLICKEYSTRUC
-        //     value.push(0x06); // bType = PUBLICKEYBLOB
-        //     value.push(0x02); // bVersion = 0x2
-        //     value.extend_from_slice(&[0x00, 0x00]); // reserved
-        //     value.extend_from_slice(&[0x00, 0xa4, 0x00, 0x00]); // aiKeyAlg = CALG_RSA_KEYX
+            value.extend_from_slice(&(auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
+            value.extend_from_slice(&[0x00, 0x00]); // unknown flags
+            value.extend_from_slice(&auth_cert_der);
 
-        //     // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-rsapubkey
-        //     // RSAPUBKEY
-        //     value.extend_from_slice(b"RSA1"); // magic = RSA1
-        //     value.extend_from_slice(&2048_u32.to_le_bytes()); // bitlen = 2048
+            value
+        });
+        cache.insert("Cached_CardProperty_Capabilities_0".into(), {
+            let mut value = [1_u8, 0, 1, 0, 1, 0].to_vec();
+            // unkown flags
+            value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+            // actual data len
+            value.extend_from_slice(&12_u32.to_le_bytes());
+            // Here should be the CARD_CAPABILITIES struct but the actual extracted data is different.
+            // So, we just insert the extracted data from a real smart card.
+            // Card capabilities:
+            value.extend_from_slice(&[1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]);
 
-        //     // let pub_key = smart_cards_info.
-        //     let public_key = smart_card_info
-        //         .auth_pk
-        //         .to_public_key()
-        //         .expect("rsa private key to public key");
-        //     let public_key: &SubjectPublicKeyInfo = public_key.as_ref();
-        //     let (modulus, public_exponent) = match &public_key.subject_public_key {
-        //         PublicKey::Rsa(rsa) => (
-        //             {
-        //                 let mut modulus = rsa.0.modulus.to_vec();
-        //                 modulus.reverse();
-        //                 modulus.resize(256, 0);
-        //                 modulus
-        //             },
-        //             {
-        //                 let mut pub_exp = rsa.0.public_exponent.to_vec();
-        //                 pub_exp.reverse();
-        //                 pub_exp.resize(4, 0);
-        //                 pub_exp
-        //             },
-        //         ),
-        //         _ => {
-        //             return Err(Error::new(
-        //                 ErrorKind::UnsupportedFeature,
-        //                 "only RSA 2048 keys are supported",
-        //             ))
-        //         }
-        //     };
+            value
+        });
 
-        //     value.extend_from_slice(&public_exponent); // pubexp
-        //     value.extend_from_slice(&modulus); // public key
-
-        //     value
-        // });
-        // cache.insert("Cached_GeneralFile/mscp/kxc00".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-
-        //     let mut compressed_cert = vec![0; smart_card_info.auth_cert_der.len()];
-        //     let compressed = winscard::compression::compress_cert(&smart_card_info.auth_cert_der, &mut compressed_cert)?;
-
-        //     let total_value_len =
-        //         (compressed.len() + 2 /* unknown flags */ + 2/* uncompressed certificate len */) as u32;
-        //     value.extend_from_slice(&total_value_len.to_le_bytes());
-
-        //     value.extend_from_slice(&[0x01, 0x00]); // unknown flags
-        //     value.extend_from_slice(&(smart_card_info.auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
-        //     value.extend_from_slice(&compressed_cert);
-
-        //     value
-        // });
-        // cache.insert("Cached_CardProperty_Capabilities_0".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&12_u32.to_le_bytes());
-        //     // Here should be the CARD_CAPABILITIES struct but the actual extracted data is different.
-        //     // So, we just insert the extracted data from a real smart card.
-        //     // Card capabilities:
-        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
-
-        //     value
-        // });
-
-        // cache.insert("Cached_CardProperty_Key Sizes_2".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&20_u32.to_le_bytes());
-        //     // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
-        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
-        //     value.extend_from_slice(&[
-        //         1, 0, 0, 0, // dwVersion = 1
-        //         0, 4, 0, 0, // dwMinimumBitlen = 1024
-        //         0, 4, 0, 0, // dwDefaultBitlen = 1048
-        //         0, 8, 0, 0, // dwMaximumBitlen = 2048
-        //         0, 4, 0, 0, // dwIncrementalBitlen = 1024
-        //     ]);
-
-        //     value
-        // });
-
-        // cache.insert("Cached_CardProperty_Key Sizes_1".into(), {
-        //     let mut value = CACHE_ITEM_HEADER.to_vec();
-        //     // unkown flags
-        //     value.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
-        //     // actual data len
-        //     value.extend_from_slice(&20_u32.to_le_bytes());
-        //     // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/secsmart/card-key-sizes
-        //     value.extend_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]);
-        //     value.extend_from_slice(&[
-        //         1, 0, 0, 0, // dwVersion = 1
-        //         0, 4, 0, 0, // dwMinimumBitlen = 1024
-        //         0, 4, 0, 0, // dwDefaultBitlen = 1048
-        //         0, 8, 0, 0, // dwMaximumBitlen = 2048
-        //         0, 4, 0, 0, // dwIncrementalBitlen = 1024
-        //     ]);
-
-        //     value
-        // });
-
-        // cache.insert(
-        //     "Cached_CardmodFile\\Cached_Pin_Freshness".into(),
-        //     PIN_FRESHNESS.to_vec(),
-        // );
-        // cache.insert(
-        //     "Cached_CardmodFile\\Cached_File_Freshness".into(),
-        //     FILE_FRESHNESS.to_vec(),
-        // );
-        // cache.insert(
-        //     "Cached_CardmodFile\\Cached_Container_Freshness".into(),
-        //     CONTAINER_FRESHNESS.to_vec(),
-        // );
-
-        Ok(Self { h_context, api,
-            // cache
+        Ok(Self {
+            h_context,
+            api,
+            #[cfg(not(target_os = "windows"))]
+            cache,
         })
     }
 }

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -6,6 +6,9 @@ macro_rules! try_execute {
         let error_kind = ErrorKind::from_u32(
             // In pcsc-lite API, the status code has 8-byte width. But the Windows WinSCard uses 4-byte width status code.
             #[allow(clippy::useless_conversion)]
+            // `pcsc-lite` status codes has 8-byte width, but the values always fit 4-byte number:
+            // https://pcsclite.apdu.fr/api/group__ErrorCodes.html#details
+            // This `.unwrap` will never panic.
             $x.try_into().unwrap()
         ).unwrap_or(ErrorKind::InternalError);
         if error_kind == ErrorKind::Success {

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -3,7 +3,11 @@ macro_rules! try_execute {
         use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
-        let error_kind = ErrorKind::from_u32($x as u32).unwrap_or(ErrorKind::InternalError);
+        let error_kind = ErrorKind::from_u32(
+            // In pcsc-lite API, the status code has 8-byte width. But the Windows WinSCard uses 4-byte width status code.
+            #[allow(clippy::useless_conversion)]
+            $x.try_into().unwrap()
+        ).unwrap_or(ErrorKind::InternalError);
         if error_kind == ErrorKind::Success {
             Ok(())
         } else {

--- a/ffi/src/winscard/system_scard/macros.rs
+++ b/ffi/src/winscard/system_scard/macros.rs
@@ -3,7 +3,7 @@ macro_rules! try_execute {
         use num_traits::FromPrimitive;
         use winscard::{Error, ErrorKind};
 
-        let error_kind = ErrorKind::from_u32($x).unwrap_or(ErrorKind::InternalError);
+        let error_kind = ErrorKind::from_u32($x as u32).unwrap_or(ErrorKind::InternalError);
         if error_kind == ErrorKind::Success {
             Ok(())
         } else {


### PR DESCRIPTION
Hi,
In this PR I've fixed the smart card auth for Linux and macOS. Now we can use smart card auth with FreeRDP on Linux and macOS.

## Implementation notes

Originally, we planned to link with `pcsc-lite` on Linux and macOS. But it turned out that the `pcsc-lite` doesn't work well on macOS. We have tried to overcome it in a few ways but failed. After all tries we decided to link with the `PCSC.framework`. We adjusted the bindings and managed to make it work.

## Configuration

To use the smart card auth you need to perform some configurations.

1. **Kerberos.** You need to write your own `krb.conf` or ask your sysadmin to provide you with one. It should look like this (replace domain, CA cert file path, and realm with your ones):
```conf
[libdefaults]
        default_realm = TBT.COM

[realms]
        TBT.COM = {
                admin_server = WIN-956CQOSSJTF.tbt.com
                kdc = WIN-956CQOSSJTF.tbt.com
                pkinit_anchors = FILE:/Users/tbt/Documents/ca_cert.cer
                pkinit_kdc_hostname = WIN-956CQOSSJTF.tbt.com
                pkinit_cert_match = <SAN>.*@tbt.com

                # The option below is important and required. The MIT KRB5 can reject the CA certificate without it. More info:
                # https://web.mit.edu/kerberos/krb5-latest/doc/admin/pkinit.html#configuring-the-clients
                # > A commercially issued server certificate will usually not have the standard PKINIT principal name or Extended Key Usage extensions
                pkinit_eku_checking = kpServerAuth
        }

[domain_realm]
        tbt.com = TBT.COM
        tbt = TBT

[logging]
        kdc = CONSOLE
```
2. **Smart card.** Insert the smart card into the Windows domain-joined machine and enroll the certificate or generate the certificate manually and import it on the smart card.
3. **Environment variables.** Some of them are optional, and some of them are required. See the table below:

| Env variable name | Meaning | Example | Required? |
| --- | --- | --- | --- |
| `WLOG_LEVEL` | `FreeRDP` logging level | trace | optional |
| `KRB5_TRACE` | log internal krb5 library operations. [docs](https://web.mit.edu/kerberos/krb5-latest/doc/admin/troubleshoot.html). | `/dev/stdout` | optional |
| `KRB5_CONFIG` | Path to the `krb.conf`. [docs](https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html). | `~/.config/kerberos/krb5.conf` | optional |
| `SSPI_LOG_PATH` | Path to the `sspi-rs` log file | `~/Documents/sspi/sspi.log` | required |
| `SSPI_LOG_LEVEL` | `sspi-rs` log level | trace | optional |
| `WINSCARD_USE_SYSTEM_SCARD` | Tell `sspi-rs` to use the system-provided smart card instead of emulated one | true | required |
| `WINSCARD_SMARTCARD_CONTAINER_NAME` | Smart card container name | `1d8ac658-e065-92a0-85af-090b075fc105` | required |
| `PCSC_LITE_LIB_PATH` | Path to the pcsc library | `/System/Library/Frameworks/PCSC.framework/PCSC` | optional (unless you want to overwrite the default value) |
| `WINSCARD_CERTIFICATE_FILE_PATH` | Path to the user certificate imported on the smart card | `/Users/tbt/Documents/new_t2@tbt.com.cer` | required |

The `FreeRDP` command template I used to connect:

```bash
./xfreerdp /v:<host> /u:<UPN> /p:<scard PIN code> /smartcard-logon /sec:nla /kerberos:pkcs11-module:<PKCS11 mosule> /auth-pkg-list:\!ntlm,kerberos /winscard-module:libsspi.dylib
```

## Demo

The [Yubikey 5 Nano](https://www.yubico.com/ua/product/yubikey-5-nano) was used for testing. The full `FreeRDP` command I used to connect:

```bash
./xfreerdp /v:DESKTOP-8F33RFH.tbt.com /u:t2@tbt.com /p:123456 /smartcard-logon /sec:nla /kerberos:pkcs11-module:libykcs11.2.6.0.dylib /auth-pkg-list:\!ntlm,kerberos /winscard-module:libsspi.dylib
```

Don't worry about the smart card PIN. This scard is used only for testing.

https://github.com/user-attachments/assets/8a470289-b607-4253-ad73-d5023d09d515

Please get in touch with me if you need more details about `FreeRDP`/smart card configuration.

## **_Note_**

Only the _winscard_ part of the `sspi-rs` is modified. Currently, our CredSSP implementation can use only the emulated smart card. We plan to improve the CredSSP module in the next `sspi-rs`-related iterations.

## Docs & references:

* [`winscard.h`](https://learn.microsoft.com/en-us/windows/win32/api/winscard/).
* [`PCSC Lite`](https://pcsclite.apdu.fr/).
* [`FreeRDP`](https://github.com/FreeRDP/FreeRDP).
* [`MIT Kerberos V5`](https://web.mit.edu/kerberos/krb5-latest/doc/).

cc @awakecoding 