### PR TITLE
fix(ffi): compilation with `scard` feature on macOS

### DIFF
--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -187,7 +187,7 @@ impl WinScard for SystemScard {
             readers,
             #[cfg(not(target_os = "windows"))]
             state: crate::winscard::pcsc_lite::State::from_bits(state)
-                .unwrap_or(State::Specific)
+                .unwrap_or(crate::winscard::pcsc_lite::State::Specific)
                 .into(),
             #[cfg(target_os = "windows")]
             state: state.try_into()?,


### PR DESCRIPTION
This problem was added in #294 . I don't know why CI didn't cache it. Maybe the `--scard` feature wasn't turned on during compilation on macOS/Linux