### PR TITLE
Fix memory corruption in the `AcquireCredentialsHandleA/W` functions

### DIFF
--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Response {
 }
 
 impl Response {
-    /// Creates a new [Response] based on the [status] and [data].
+    /// Creates a new [Response] based on the `status` and `data`.
     pub fn new(status: Status, data: Option<Vec<u8>>) -> Self {
         Response { status, data }
     }
@@ -91,7 +91,7 @@ pub struct Error {
 }
 
 impl Error {
-    /// Creates a new [Error] based on the [error_kind] and [description].
+    /// Creates a new [Error] based on the `error_kind` and `description`.
     pub fn new(error_kind: ErrorKind, description: impl Into<String>) -> Self {
         Error {
             error_kind,

--- a/crates/winscard/src/scard.rs
+++ b/crates/winscard/src/scard.rs
@@ -50,7 +50,7 @@ const IO_CTL: u32 = 0x00313520;
 
 /// The original winscard ATR is not suitable because it contains AID bytes.
 /// So we need to construct our own. Read more about our constructed ATR string:
-/// https://smartcard-atr.apdu.fr/parse?ATR=3B+8D+01+80+FB+A0+00+00+03+08+00+00+10+00+01+00+4D
+/// <https://smartcard-atr.apdu.fr/parse?ATR=3B+8D+01+80+FB+A0+00+00+03+08+00+00+10+00+01+00+4D>
 #[rustfmt::skip]
 pub const ATR: [u8; 17] = [
     // TS. Direct Convention

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -75,7 +75,7 @@ impl From<ReaderAction> for u64 {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, FromPrimitive, ToPrimitive)]
 #[repr(u32)]
 pub enum AttributeId {
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a2e87e6925548b9fcca3fa0026b82500d
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a2e87e6925548b9fcca3fa0026b82500d>
     AsyncProtocolTypes = 0x0120,
     /// Answer to reset (ATR) string.
     AtrString = 0x0303,
@@ -101,7 +101,7 @@ pub enum AttributeId {
     CurrentIfsc = 0x0207,
     /// Current byte size for information field size device.
     CurrentIfsd = 0x0208,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a9c6ee3dccc23e924907e3dc2e29a50f6
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a9c6ee3dccc23e924907e3dc2e29a50f6>
     CurrentIoState = 0x0302,
     /// Current guard time.
     CurrentN = 0x0205,
@@ -129,13 +129,13 @@ pub enum AttributeId {
     /// the next will be unit 1 (if it is the same brand of reader) and so on. Two different brands of readers
     /// will both have zero for this value.
     DeviceUnit = 0x0001,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a1a1d31628ec9f49f79d2dda6651658d6
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a1a1d31628ec9f49f79d2dda6651658d6>
     EscAuhRequest = 0xA005,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a69d8dd84f5f433efbfa6e0fce2a95528
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a69d8dd84f5f433efbfa6e0fce2a95528>
     EscCancel = 0xA003,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a55df7896fb65a2a942780d383d815071
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a55df7896fb65a2a942780d383d815071>
     EscReset = 0xA000,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a5fcd5c979018130c164a64c728f0716d
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a5fcd5c979018130c164a64c728f0716d>
     ExtendedBt = 0x020c,
     /// Single byte. Zero if smart card electrical contact is not active; nonzero if contact is active.
     IccInterfaceStatus = 0x0301,
@@ -149,19 +149,19 @@ pub enum AttributeId {
     MaxDataRate = 0x0124,
     /// Maximum bytes for information file size device.
     MaxIfsd = 0x0125,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a42ea634deb1ec51e10722b661aa73d01
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a42ea634deb1ec51e10722b661aa73d01>
     MaxInput = 0xA007,
     /// Zero if device does not support power down while smart card is inserted. Nonzero otherwise.
     PowerMgmtSupport = 0x0131,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a62d09db2a45663ea726239aeafaac747
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a62d09db2a45663ea726239aeafaac747>
     SupresT1IfsRequest = 0x0007,
     /// DWORD encoded as 0x0rrrpppp where rrr is RFU and should be 0x000. pppp encodes the supported
     /// protocol types. A '1' in a given bit position indicates support for the associated ISO protocol,
     /// so if bits zero and one are set, both T=0 and T=1 protocols are supported.
     SyncProtocolTypes = 0x0126,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a86eb3bba6a8a463aa0eac4ada7704785
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a86eb3bba6a8a463aa0eac4ada7704785>
     UserAuthInputDevice = 0x0142,
-    /// https://pcsclite.apdu.fr/api/reader_8h.html#a60bf2dbb950d448099314aa86c14b2aa
+    /// <https://pcsclite.apdu.fr/api/reader_8h.html#a60bf2dbb950d448099314aa86c14b2aa>
     UserToCardAuthDevice = 0x0140,
     /// Vendor-supplied interface device serial number.
     VendorIfdSerialNo = 0x0103,

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -514,11 +514,11 @@ mod tests {
         );
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn kerberos_encryption_decryption() {
-        // This test simulates decryption and decryption. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let plain_message = b"some plain message";
 
         let kerberos_client = sspi::kerberos::test_data::fake_client();

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1253,11 +1253,11 @@ mod tests {
 
     extern "system" fn dummy(_: *mut c_void, _: *mut c_void, _: u32, _: *mut *mut c_void, _: *mut i32) {}
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn initialize_security_context_w() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0".encode_utf16().collect::<Vec<_>>();
         let mut pkg_info: PSecPkgInfoW = null_mut::<SecPkgInfoW>();
 
@@ -1379,11 +1379,11 @@ mod tests {
         assert_eq!(status, 0);
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn initialize_security_context_a() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0";
         let mut pkg_info: PSecPkgInfoA = null_mut::<SecPkgInfoA>();
 
@@ -1505,11 +1505,11 @@ mod tests {
         assert_eq!(status, 0);
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn acquire_credentials_handle_w_null_credentials() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0".encode_utf16().collect::<Vec<_>>();
 
         let user = "user".encode_utf16().collect::<Vec<_>>();
@@ -1572,11 +1572,11 @@ mod tests {
         }
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn acquire_credentials_handle_w_empty_credentials() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0".encode_utf16().collect::<Vec<_>>();
 
         let user = "".encode_utf16().collect::<Vec<_>>();
@@ -1617,11 +1617,11 @@ mod tests {
         assert_eq!(status, 0);
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn acquire_credentials_handle_a_null_credentials() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0";
 
         let user = "user";
@@ -1684,11 +1684,11 @@ mod tests {
         }
     }
 
+    /// This test simulates initialize security context function call. It's better to run it using Miri
+    /// https://github.com/rust-lang/miri
+    /// cargo +nightly miri test
     #[test]
     fn acquire_credentials_handle_a_empty_credentials() {
-        // This test simulates initialize security context function call. It's better to run it using Miri
-        // https://github.com/rust-lang/miri
-        // cargo +nightly miri test
         let pkg_name = "NTLM\0";
 
         let user = "";

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -312,6 +312,10 @@ fn verify_security_package(package_name: &str) -> Result<()> {
     }
 }
 
+/// AcquireCredentialsHandleA function acquires a handle to preexisting credentials of a security principal.
+///
+/// NOTE: Although in the original Windows SSPI, `p_auth_data` parameter can be NULL, in our implementation it must be non-NULL.
+/// That's because we cannot get the default credentials handle for security package, like Windows can.
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_AcquireCredentialsHandleA"))]
 #[no_mangle]
@@ -363,6 +367,10 @@ pub type AcquireCredentialsHandleFnA = unsafe extern "system" fn(
     PTimeStamp,
 ) -> SecurityStatus;
 
+/// AcquireCredentialsHandleW function acquires a handle to preexisting credentials of a security principal.
+///
+/// NOTE: Although in the original Windows SSPI, `p_auth_data` parameter can be NULL, in our implementation it must be non-NULL.
+/// That's because we cannot get the default credentials handle for security package, like Windows can.
 #[instrument(skip_all)]
 #[cfg_attr(windows, rename_symbol(to = "Rust_AcquireCredentialsHandleW"))]
 #[no_mangle]

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1246,7 +1246,9 @@ mod tests {
         EnumerateSecurityPackagesA, EnumerateSecurityPackagesW, PSecPkgInfoA, PSecPkgInfoW, QuerySecurityPackageInfoA,
         QuerySecurityPackageInfoW, SecPkgInfoA, SecPkgInfoW,
     };
-    use crate::sspi::sec_winnt_auth_identity::{SecWinntAuthIdentityA, SecWinntAuthIdentityW};
+    use crate::sspi::sec_winnt_auth_identity::{
+        SecWinntAuthIdentityA, SecWinntAuthIdentityW, SEC_WINNT_AUTH_IDENTITY_ANSI, SEC_WINNT_AUTH_IDENTITY_UNICODE,
+    };
     use crate::utils::c_w_str_to_string;
 
     extern "system" fn dummy(_: *mut c_void, _: *mut c_void, _: u32, _: *mut *mut c_void, _: *mut i32) {}
@@ -1522,7 +1524,7 @@ mod tests {
                 domain_length: domain.len() as u32,
                 password: password.as_ptr(),
                 password_length: password.len() as u32,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             },
             SecWinntAuthIdentityW {
                 user: user.as_ptr(),
@@ -1531,7 +1533,7 @@ mod tests {
                 domain_length: 0,
                 password: password.as_ptr(),
                 password_length: password.len() as u32,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             },
             SecWinntAuthIdentityW {
                 user: user.as_ptr(),
@@ -1540,7 +1542,7 @@ mod tests {
                 domain_length: domain.len() as u32,
                 password: null(),
                 password_length: 0,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             },
         ];
 
@@ -1588,7 +1590,7 @@ mod tests {
             domain_length: domain.len() as u32,
             password: password.as_ptr(),
             password_length: password.len() as u32,
-            flags: 1,
+            flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
         };
 
         let mut cred_handle = SecHandle {
@@ -1634,7 +1636,7 @@ mod tests {
                 domain_length: domain.len() as u32,
                 password: password.as_ptr() as *const _,
                 password_length: password.len() as u32,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
             },
             SecWinntAuthIdentityA {
                 user: user.as_ptr() as *const _,
@@ -1643,7 +1645,7 @@ mod tests {
                 domain_length: 0,
                 password: password.as_ptr() as *const _,
                 password_length: password.len() as u32,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
             },
             SecWinntAuthIdentityA {
                 user: user.as_ptr() as *const _,
@@ -1652,7 +1654,7 @@ mod tests {
                 domain_length: domain.len() as u32,
                 password: null(),
                 password_length: 0,
-                flags: 1,
+                flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
             },
         ];
 
@@ -1700,7 +1702,7 @@ mod tests {
             domain_length: domain.len() as u32,
             password: password.as_ptr() as *const _,
             password_length: password.len() as u32,
-            flags: 1,
+            flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
         };
 
         let mut cred_handle = SecHandle {

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -314,7 +314,7 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         // Only marshaled smart card creds starts with '@' char.
         #[cfg(all(feature = "scard", target_os = "windows"))]
-        if CredIsMarshaledCredentialW(user.as_ptr() as *const _) != 0 {
+        if !user.is_empty() && CredIsMarshaledCredentialW(user.as_ptr() as *const _) != 0 {
             return handle_smart_card_creds(user, password);
         }
 
@@ -337,7 +337,7 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         // Only marshaled smart card creds starts with '@' char.
         #[cfg(all(feature = "scard", target_os = "windows"))]
-        if CredIsMarshaledCredentialW(user.as_ptr() as *const _) != 0 {
+        if !user.is_empty() && CredIsMarshaledCredentialW(user.as_ptr() as *const _) != 0 {
             return handle_smart_card_creds(user, password);
         }
 
@@ -664,7 +664,7 @@ pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w_sized(
 
     // Only marshaled smart card creds starts with '@' char.
     #[cfg(feature = "scard")]
-    if CredIsMarshaledCredentialW(username.as_ptr() as *const _) != 0 {
+    if !username.is_empty() && CredIsMarshaledCredentialW(username.as_ptr() as *const _) != 0 {
         // The `handle_smart_card_creds` function expects credentials in a form of raw wide strings without NULL-terminator bytes.
         // The `CredUnPackAuthenticationBufferW` function always returns credentials as strings.
         // So, password data is a wide C string and we need to delete the NULL terminator.

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -17,7 +17,7 @@ use windows_sys::Win32::Security::Credentials::CredIsMarshaledCredentialW;
 use windows_sys::Win32::Security::Credentials::{CredUIPromptForWindowsCredentialsW, CREDUI_INFOW};
 
 use super::sspi_data_types::{SecWChar, SecurityStatus};
-use crate::utils::{into_raw_ptr, raw_str_into_bytes, w_str_len};
+use crate::utils::{credentials_str_into_bytes, into_raw_ptr, w_str_len};
 
 pub const SEC_WINNT_AUTH_IDENTITY_ANSI: u32 = 0x1;
 pub const SEC_WINNT_AUTH_IDENTITY_UNICODE: u32 = 0x2;
@@ -277,16 +277,16 @@ pub unsafe fn auth_data_to_identity_buffers_a(
             );
         }
         Ok(CredentialsBuffers::AuthIdentity(AuthIdentityBuffers {
-            user: raw_str_into_bytes((*auth_data).user, (*auth_data).user_length as usize),
-            domain: raw_str_into_bytes((*auth_data).domain, (*auth_data).domain_length as usize),
-            password: raw_str_into_bytes((*auth_data).password, (*auth_data).password_length as usize).into(),
+            user: credentials_str_into_bytes((*auth_data).user, (*auth_data).user_length as usize),
+            domain: credentials_str_into_bytes((*auth_data).domain, (*auth_data).domain_length as usize),
+            password: credentials_str_into_bytes((*auth_data).password, (*auth_data).password_length as usize).into(),
         }))
     } else {
         let auth_data = p_auth_data.cast::<SecWinntAuthIdentityA>();
         Ok(CredentialsBuffers::AuthIdentity(AuthIdentityBuffers {
-            user: raw_str_into_bytes((*auth_data).user, (*auth_data).user_length as usize),
-            domain: raw_str_into_bytes((*auth_data).domain, (*auth_data).domain_length as usize),
-            password: raw_str_into_bytes((*auth_data).password, (*auth_data).password_length as usize).into(),
+            user: credentials_str_into_bytes((*auth_data).user, (*auth_data).user_length as usize),
+            domain: credentials_str_into_bytes((*auth_data).domain, (*auth_data).domain_length as usize),
+            password: credentials_str_into_bytes((*auth_data).password, (*auth_data).password_length as usize).into(),
         }))
     }
 }
@@ -305,8 +305,8 @@ pub unsafe fn auth_data_to_identity_buffers_w(
                 usize::try_from((*auth_data).package_list_length).unwrap(),
             )));
         }
-        let user = raw_str_into_bytes((*auth_data).user as *const _, (*auth_data).user_length as usize * 2);
-        let password = raw_str_into_bytes(
+        let user = credentials_str_into_bytes((*auth_data).user as *const _, (*auth_data).user_length as usize * 2);
+        let password = credentials_str_into_bytes(
             (*auth_data).password as *const _,
             (*auth_data).password_length as usize * 2,
         )
@@ -320,13 +320,16 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         Ok(CredentialsBuffers::AuthIdentity(AuthIdentityBuffers {
             user,
-            domain: raw_str_into_bytes((*auth_data).domain as *const _, (*auth_data).domain_length as usize * 2),
+            domain: credentials_str_into_bytes(
+                (*auth_data).domain as *const _,
+                (*auth_data).domain_length as usize * 2,
+            ),
             password,
         }))
     } else {
         let auth_data = p_auth_data.cast::<SecWinntAuthIdentityW>();
-        let user = raw_str_into_bytes((*auth_data).user as *const _, (*auth_data).user_length as usize * 2);
-        let password = raw_str_into_bytes(
+        let user = credentials_str_into_bytes((*auth_data).user as *const _, (*auth_data).user_length as usize * 2);
+        let password = credentials_str_into_bytes(
             (*auth_data).password as *const _,
             (*auth_data).password_length as usize * 2,
         )
@@ -346,7 +349,10 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         Ok(CredentialsBuffers::AuthIdentity(AuthIdentityBuffers {
             user,
-            domain: raw_str_into_bytes((*auth_data).domain as *const _, (*auth_data).domain_length as usize * 2),
+            domain: credentials_str_into_bytes(
+                (*auth_data).domain as *const _,
+                (*auth_data).domain_length as usize * 2,
+            ),
             password,
         }))
     }

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -26,7 +26,13 @@ pub unsafe fn w_str_len(s: *const u16) -> usize {
     len
 }
 
-pub unsafe fn raw_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
+/// Converts raw credentials string into [Vec] of bytes.
+///
+/// Credentials are often represented as strings. For example, username, domain, password.
+/// It is OK for Windows SSPI to accept `null` or empty credential strings. The `AcquireCredentialsHandle`
+/// function will return successful status code is we pass the `null` username value. Thus, this function
+/// will return an empty [Vec] in such a case. It is done on purpose to follow the Windows SSPI behaviour.
+pub unsafe fn credentials_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
     if !raw_buffer.is_null() {
         unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
     } else {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -27,7 +27,11 @@ pub unsafe fn w_str_len(s: *const u16) -> usize {
 }
 
 pub unsafe fn raw_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
-    unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
+    if !raw_buffer.is_null() {
+        unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
+    } else {
+        Vec::new()
+    }
 }
 
 pub fn str_to_w_buff(data: &str) -> Vec<u16> {

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -32,8 +32,16 @@ pub unsafe fn w_str_len(s: *const u16) -> usize {
 /// It is OK for Windows SSPI to accept `null` or empty credential strings. The `AcquireCredentialsHandle`
 /// function will return successful status code is we pass the `null` username value. Thus, this function
 /// will return an empty [Vec] in such a case. It is done on purpose to follow the Windows SSPI behaviour.
+///
+/// # Safety
+///
+/// * `raw_buffer` must be [valid] for reads for `len` many bytes, and it must be properly aligned.
+/// * The total size `len` of the slice must be no larger than `isize::MAX`, and adding that size to `data`
+///   must not "wrap around" the address space.
 pub unsafe fn credentials_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {
     if !raw_buffer.is_null() {
+        // SAFETY:
+        // `raw_buffer` is not null: checked above. All other guarantees should be upheld by the caller.
         unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
     } else {
         Vec::new()

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -35,7 +35,7 @@ pub unsafe fn w_str_len(s: *const u16) -> usize {
 ///
 /// # Safety
 ///
-/// * `raw_buffer` must be [valid] for reads for `len` many bytes, and it must be properly aligned.
+/// * `raw_buffer` must be valid for reads for `len` many bytes, and it must be properly aligned.
 /// * The total size `len` of the slice must be no larger than `isize::MAX`, and adding that size to `data`
 ///   must not "wrap around" the address space.
 pub unsafe fn credentials_str_into_bytes(raw_buffer: *const c_char, len: usize) -> Vec<u8> {

--- a/src/kerberos/config.rs
+++ b/src/kerberos/config.rs
@@ -13,7 +13,7 @@ pub struct KerberosConfig {
     ///
     /// Depending on the scheme it is expected to be either:
     /// - a (Kerberos) KDC address (e.g.: tcp://domain:88, udp://domain:88), or
-    /// - a KDC _Proxy_ URL (e.g.: https://gateway.devolutions.net/jet/KdcProxy?token=<…>)
+    /// - a KDC _Proxy_ URL (e.g.: <https://gateway.devolutions.net/jet/KdcProxy?token=…>)
     ///
     /// That is, when the scheme is `http` or `https`, the KDC Proxy Protocol ([KKDCP]) will be
     /// used on top of the Kerberos protocol, wrapping the messages.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub use utils::string_to_utf16;
 
 pub use self::auth_identity::{
     AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, SmartCardIdentity, SmartCardIdentityBuffers,
-    Username,
+    UserNameFormat, Username,
 };
 pub use self::builders::{
     AcceptSecurityContextResult, AcquireCredentialsHandleResult, InitializeSecurityContextResult,

--- a/src/security_buffer.rs
+++ b/src/security_buffer.rs
@@ -4,12 +4,12 @@ use std::mem::take;
 use crate::{Error, ErrorKind, Result, SecurityBufferType};
 
 /// A special security buffer type is used for the data decryption. Basically, it's almost the same
-/// as [OwnedSecurityBuffer] but for decryption.
+/// as `OwnedSecurityBuffer` but for decryption.
 ///
 /// [DecryptMessage](https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--general)
 /// "The encrypted message is decrypted in place, overwriting the original contents of its buffer."
 ///
-/// So, the already defined [OwnedSecurityBuffer] is not suitable for decryption because it uses [Vec] inside.
+/// So, the already defined `OwnedSecurityBuffer` is not suitable for decryption because it uses [Vec] inside.
 /// We use reference in the [SecurityBuffer] structure to avoid data cloning as much as possible.
 /// Decryption/encryption input buffers can be very large. Even up to 32 KiB if we are using this crate as a TSSSP(CREDSSP)
 /// security package.


### PR DESCRIPTION
Hi,
In this PR I've fixed the memory corruption error in the `AcquireCredentialsHandleA/W` functions. The user can safely pass the `null`/empty credentials strings.
Also, I covered such cases with tests.