### PR TITLE
ci: do not enable dns_resolver feature for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             additional-args: --features network_client,dns_resolver,scard,tsssp
           - os: osx
             manifest: Cargo.toml
-            additional-args: --features network_client,dns_resolver,scard
+            additional-args: --features network_client,scard
           - os: linux
             manifest: Cargo.toml
             additional-args: --features network_client,dns_resolver,scard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "sspi"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-dnssd",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sspi"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ windows-sys = { workspace = true, features = ["Win32_Security_Cryptography", "Wi
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-dnssd = "0.5"
 futures = "0.3"
-tokio.workspace = true
+tokio = { workspace = true, features = ["time", "rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 base64.workspace = true

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -32,7 +32,7 @@ tracing = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "local-time", "env-filter"] }
 
 libc = "0.2"
-sspi = { path = "..", default-features = false, features = ["network_client", "dns_resolver"] }
+sspi = { path = "..", default-features = false, features = ["network_client"] }
 
 [target.'cfg(windows)'.dependencies]
 symbol-rename-macro = { path = "./symbol-rename-macro" }
@@ -43,5 +43,8 @@ bitflags = { workspace = true, optional = true }
 picky-asn1-x509 = { workspace = true, optional = true }
 picky = { workspace = true, features = ["x509"], optional = true }
 
+[target.'cfg(not(any(target_os="macos", target_os="ios", windows)))'.dependencies]
+sspi = { path = "..", default-features = false, features = ["dns_resolver"] }
+
 [dev-dependencies]
-sspi = { path = "..", features = ["network_client", "dns_resolver", "__test-data"] }
+sspi = { path = "..", features = ["__test-data"] }


### PR DESCRIPTION
We have a special logic for DNS resolving when targetting macOS.

This PR is also fixing a problem in our feature set causing the compilation to fail on macOS when the `dns_resolver` feature is not enabled on macOS.