### PR TITLE
ci: update macos-12 runners to macos-14

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -39,11 +39,11 @@ jobs:
           - os: win
             runner: windows-2022
           - os: osx
-            runner: macos-12
+            runner: macos-14
           - os: linux
             runner: ubuntu-20.04
           - os: ios
-            runner: macos-12
+            runner: macos-14
           - os: android
             runner: ubuntu-20.04
         exclude:
@@ -123,6 +123,10 @@ jobs:
 
           # Install Visual Studio Developer PowerShell Module for cmdlets such as Enter-VsDevShell
           Install-Module VsDevShell -Force
+
+      - name: Install dependencies
+        if: matrix.os == 'ios'
+        run: cargo install --force --locked bindgen-cli
 
       - name: Setup build environment
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             runner: windows-2022
             additional-args: --features tsssp
           - os: osx
-            runner: macos-12
+            runner: macos-14
           - os: linux
             runner: ubuntu-20.04
 
@@ -71,7 +71,7 @@ jobs:
           - os: win
             runner: windows-2022
           - os: osx
-            runner: macos-12
+            runner: macos-14
           - os: linux
             runner: ubuntu-20.04
 


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024