### PR TITLE
Fix domain realm mapping

### DIFF
--- a/src/krb.rs
+++ b/src/krb.rs
@@ -85,6 +85,23 @@ impl Krb5Conf {
         None
     }
 
+    pub fn get_values_in_section(&self, path: &[&str]) -> Option<Vec<(&str, &str)>> {
+        let mut values = Vec::new();
+
+        let path = path.join("|").to_ascii_lowercase();
+        for (key, val) in self.values.iter() {
+            if key.to_ascii_lowercase().contains(&path) {
+                values.push((&key[path.len() + 1..], val.as_str()));
+            }
+        }
+
+        if values.is_empty() {
+            None
+        } else {
+            Some(values)
+        }
+    }
+
     fn enter_section(&mut self, name: &str) {
         self.path = vec![name.to_owned()];
     }

--- a/test_assets/krb5.conf
+++ b/test_assets/krb5.conf
@@ -1,0 +1,37 @@
+[libdefaults]
+        default_realm = TBT.COM
+
+# The following krb5.conf variables are only for MIT Kerberos.
+        kdc_timesync = 1
+        ccache_type = 4
+        forwardable = true
+        proxiable = true
+
+# The following encryption type specification will be used by MIT Kerberos
+# if uncommented.  In general, the defaults in the MIT Kerberos code are
+# correct and overriding these specifications only serves to disable new
+# encryption types as they are added, creating interoperability problems.
+#
+# The only time when you might need to uncomment these lines and change
+# the enctypes is if you have local software that will break on ticket
+# caches containing ticket encryption types it doesn't know about (such as
+# old versions of Sun Java).
+
+#       default_tgs_enctypes = des3-hmac-sha1
+#       default_tkt_enctypes = des3-hmac-sha1
+#       permitted_enctypes = des3-hmac-sha1
+
+# The following libdefaults parameters are only for Heimdal Kerberos.
+        fcc-mit-ticketflags = true
+
+[realms]
+        TBT.COM = {
+                kdc = WIN-956CQOSSJTF.tbt.com
+                kdc = tbt.com
+                admin_server = WIN-956CQOSSJTF.tbt.com
+                default_domain = WIN-956CQOSSJTF.tbt.com
+        }
+
+[domain_realm]
+        .tbt.com = TBT.COM
+        tbt.com = TBT.COM


### PR DESCRIPTION
Hi,
I've improved the domain realm mapping in this PR. Previously, we used to derive realm from the domain, but this approach sometimes results in an invalid realm.
I changed this behavior, and we are first trying to read the `krb5.conf` file `domain_realm` section. If the appropriate domain realm mapping is not found, it will continue with the default behavior which is basically `domain.to_upper_case()`.

Additionally, I wrote some tests to check it. If you have some unusual Kerberos configurations, let me know and I will add them to the tests.

closes #323 