### PR TITLE
fix: store session key when using Ntlm as a server

### DIFF
--- a/src/ntlm/messages/server/complete_authenticate.rs
+++ b/src/ntlm/messages/server/complete_authenticate.rs
@@ -52,6 +52,7 @@ pub fn complete_authenticate(context: &mut Ntlm) -> crate::Result<SecurityStatus
         session_key.as_ref(),
     )?;
 
+    context.session_key = Some(session_key);
     context.state = NtlmState::Final;
 
     Ok(SecurityStatus::Ok)


### PR DESCRIPTION
Fixes #349 by storing session key when `fn complete_authenticate` is called