### PR TITLE
fix(dpapi): AES IV extraction during decryption;

### DIFF
--- a/crates/dpapi/src/crypto/mod.rs
+++ b/crates/dpapi/src/crypto/mod.rs
@@ -126,6 +126,8 @@ fn extract_iv(parameters: &AlgorithmIdentifierParameters) -> CryptoResult<&[u8]>
     if let AlgorithmIdentifierParameters::Aes(aes_parameters) = parameters {
         if let AesParameters::InitializationVector(iv) = aes_parameters {
             Ok(iv.0.as_slice())
+        } else if let AesParameters::AuthenticatedEncryptionParameters(enc_params) = aes_parameters {
+            Ok(enc_params.nonce())
         } else {
             Err(CryptoError::InvalidAesParams {
                 reason: "expected AES initialization vector",


### PR DESCRIPTION
Hi,
I fixed DPAPI blob decryption in this PR.

Previously, we assumed that the AES IV is always encoded as `AesParameters::InitializationVector`. But recently we discovered that it also can be encoded as `AesParameters::AuthenticatedEncryptionParameters`. It depends on the blob creation process.