### PR TITLE
feat(dpapi): use Negotiate module instead of hardcoded Kerberos

### DIFF
--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,6 +1,5 @@
-use std::env;
-use std::fs;
 use std::path::PathBuf;
+use std::{env, fs};
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2148,6 +2148,12 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<auth_identity::UsernameError> for Error {
+    fn from(value: auth_identity::UsernameError) -> Self {
+        Error::new(ErrorKind::UnknownCredentials, value)
+    }
+}
+
 impl From<rsa::Error> for Error {
     fn from(value: rsa::Error) -> Self {
         Error::new(

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -236,6 +236,10 @@ impl Negotiate {
         Ok(filtered_protocol)
     }
 
+    pub fn negotiated_protocol(&self) -> &NegotiatedProtocol {
+        &self.protocol
+    }
+
     fn is_protocol_ntlm(&self) -> bool {
         matches!(&self.protocol, NegotiatedProtocol::Ntlm(_))
     }


### PR DESCRIPTION
Hi,
I refactored the DPAPI implementation a bit: now it uses Negotiate module instead of hardcoded Kerberos configuration. I added corresponding comments in the code.