### PR TITLE
fix(kerberos): set correct seq number in MIC token

### DIFF
--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -1147,6 +1147,7 @@ impl<'a> Kerberos {
                         validate_mic_token(&token.0 .0, ACCEPTOR_SIGN, &self.encryption_params)?;
                     }
 
+                    self.next_seq_number();
                     self.prepare_final_neg_token(builder)?;
                     self.state = KerberosState::PubKeyAuth;
                     SecurityStatus::Ok


### PR DESCRIPTION
Hi,
I fixed Kerberos LDAP auth in this PR. The problem was in the invalid sequence number in MIC token. The most surprising thing is that the RDP authentication worked even without this fix.