### PR TITLE
fix(dpapi): NTLM RPC auth

### DIFF
--- a/crates/dpapi/src/rpc/auth.rs
+++ b/crates/dpapi/src/rpc/auth.rs
@@ -53,6 +53,22 @@ impl AuthProvider {
         })
     }
 
+    /// Determines if the selected authorization protocol needs negotiation.
+    ///
+    /// If the returned value is positive, then the client needs to call the `initialize_security_context` method
+    /// twice in order to skip the negotiation phase.
+    pub fn needs_negotication(&self) -> bool {
+        // The first `initialize_security_context` call is Negotiation in our Kerberos implementation.
+        // We don't need its result during the RPC authentication.
+        match &self.security_context {
+            SspiContext::Kerberos(_) => true,
+            SspiContext::Negotiate(negotiate) => {
+                matches!(negotiate.negotiated_protocol(), NegotiatedProtocol::Kerberos(_))
+            }
+            _ => false,
+        }
+    }
+
     /// Returns [SecurityProvider] type in use.
     ///
     /// We determine [SecurityProvider] every time we need to construct [SecurityTrailer].


### PR DESCRIPTION
Hi,
I fixed the NTLM RPC auth in this PR. Explanation:

Our Kerberos implementation has parts of SPNEGO and GSS API tokens inside. The first phase of the Kerberos implementation is called `Negotiate`: https://github.com/Devolutions/sspi-rs/blob/bda97ded7807e15f92ad796f881f85ef27839d96/src/kerberos/mod.rs#L109 + https://github.com/Devolutions/sspi-rs/blob/bda97ded7807e15f92ad796f881f85ef27839d96/src/kerberos/mod.rs#L800-L832. And we don't need it during the RPC auth. So, we just decided to call the `initialize_security_context` method twice and just ignore the first call result: https://github.com/Devolutions/sspi-rs/blob/bda97ded7807e15f92ad796f881f85ef27839d96/crates/dpapi/src/rpc/client.rs#L350-L354.
But it works only when `Kerberos` or `Negotiate(Kerberos)` security package is used. When we tried to authorize using NTLM we got an error. Because we don't need to call the `initialize_security_context` method twice. My fix is pretty straightforward: I check for the security type in use and call the `initialize_security_context` method second time only when needed.

The second problem was in the last returned token from the `initialize_security_context` method. We don't need to return _the final neg token_ in the case of RPC Kerberos auth: https://github.com/Devolutions/sspi-rs/blob/bda97ded7807e15f92ad796f881f85ef27839d96/src/kerberos/mod.rs#L249-L267. So, I just removed it.

I retested the DPAPI implementation with NTLM and Kerberos auth. Everything works great.