### PR TITLE
test(sspi): network_client is only required for a subset of the tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,10 +155,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 proptest.workspace = true
 cfg-if.workspace = true
 
-[[test]]
-name = "sspi"
-required-features = ["network_client"]
-
 [[example]]
 name = "kerberos"
 required-features = ["network_client"]

--- a/tests/sspi/client_server/mod.rs
+++ b/tests/sspi/client_server/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "network_client")] // The network_client feature is required for the client_server tests.
+
 mod credssp;
 mod ntlm;
 


### PR DESCRIPTION
The other tests can be run even without the network_client feature enabled.