### PR TITLE
refactor(ffi): sspi: enable lints for unsafe code

### DIFF
--- a/ffi/src/dpapi/mod.rs
+++ b/ffi/src/dpapi/mod.rs
@@ -182,7 +182,7 @@ pub unsafe extern "system" fn DpapiProtectSecret(
             return NTE_INTERNAL_ERROR;
         }
 
-        // SAFETY: Memory allocation should be safe. Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
         let blob_buf = unsafe { libc::malloc(blob_data.len()) as *mut u8 };
         if blob_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL");
@@ -327,7 +327,7 @@ pub unsafe extern "system" fn DpapiUnprotectSecret(
             return NTE_INTERNAL_ERROR;
         }
 
-        // SAFETY: Memory allocation should be safe. Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
         let secret_buf = unsafe { libc::malloc(secret_data.as_ref().len()) as *mut u8 };
         if secret_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL.");

--- a/ffi/src/dpapi/mod.rs
+++ b/ffi/src/dpapi/mod.rs
@@ -182,7 +182,7 @@ pub unsafe extern "system" fn DpapiProtectSecret(
             return NTE_INTERNAL_ERROR;
         }
 
-        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe. Moreover, we check for the null value below.
         let blob_buf = unsafe { libc::malloc(blob_data.len()) as *mut u8 };
         if blob_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL");
@@ -327,7 +327,7 @@ pub unsafe extern "system" fn DpapiUnprotectSecret(
             return NTE_INTERNAL_ERROR;
         }
 
-        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe. Moreover, we check for the null value below.
         let secret_buf = unsafe { libc::malloc(secret_data.as_ref().len()) as *mut u8 };
         if secret_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL.");

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -10,6 +10,8 @@ extern crate tracing;
 #[warn(clippy::undocumented_unsafe_blocks)]
 pub mod dpapi;
 pub mod logging;
+#[deny(unsafe_op_in_unsafe_fn)]
+#[warn(clippy::undocumented_unsafe_blocks)]
 pub mod sspi;
 mod utils;
 #[cfg(feature = "scard")]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::print_stdout)]
 #![allow(non_snake_case)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 #[macro_use]
 extern crate tracing;
@@ -10,11 +12,7 @@ extern crate tracing;
 #[warn(clippy::undocumented_unsafe_blocks)]
 pub mod dpapi;
 pub mod logging;
-#[deny(unsafe_op_in_unsafe_fn)]
-#[warn(clippy::undocumented_unsafe_blocks)]
 pub mod sspi;
 mod utils;
 #[cfg(feature = "scard")]
-#[deny(unsafe_op_in_unsafe_fn)]
-#[warn(clippy::undocumented_unsafe_blocks)]
 pub mod winscard;

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -265,7 +265,6 @@ pub type VerifySignatureFn = extern "system" fn(PCtxtHandle, PSecBufferDesc, u32
 #[no_mangle]
 pub unsafe extern "system" fn FreeContextBuffer(pv_context_buffer: *mut c_void) -> SecurityStatus {
     // NOTE: see https://github.com/Devolutions/sspi-rs/pull/141 for rationale behind libc usage.
-    check_null!(pv_context_buffer);
     // SAFETY: Memory deallocation should be safe.
     unsafe {
         libc::free(pv_context_buffer);

--- a/ffi/src/sspi/sec_buffer.rs
+++ b/ffi/src/sspi/sec_buffer.rs
@@ -1,7 +1,7 @@
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 use libc::c_char;
-use sspi::{SecurityBuffer, SecurityBufferType};
+use sspi::{Error, ErrorKind, Result, SecurityBuffer, SecurityBufferType};
 
 #[derive(Debug)]
 #[repr(C)]
@@ -31,27 +31,53 @@ pub(crate) unsafe fn p_sec_buffers_to_security_buffers(raw_buffers: &[SecBuffer]
             buffer: if raw_buffer.pv_buffer.is_null() {
                 Vec::new()
             } else {
-                from_raw_parts(raw_buffer.pv_buffer, raw_buffer.cb_buffer as usize)
-                    .iter()
-                    .map(|v| *v as u8)
-                    .collect()
+                // SAFETY: `pv_buffer` is not null (checked above). All other guarantees must be provided by the user.
+                unsafe {
+                    from_raw_parts(raw_buffer.pv_buffer, raw_buffer.cb_buffer as usize)
+                        .iter()
+                        .map(|v| *v as u8)
+                        .collect()
+                }
             },
             buffer_type: SecurityBufferType::try_from(u32::try_from(raw_buffer.buffer_type).unwrap()).unwrap(),
         })
         .collect()
 }
 
-pub(crate) unsafe fn copy_to_c_sec_buffer(to_buffers: PSecBuffer, from_buffers: &[SecurityBuffer], allocate: bool) {
-    let to_buffers = from_raw_parts_mut(to_buffers, from_buffers.len());
+pub(crate) unsafe fn copy_to_c_sec_buffer(
+    to_buffers: PSecBuffer,
+    from_buffers: &[SecurityBuffer],
+    allocate: bool,
+) -> Result<()> {
+    if to_buffers.is_null() {
+        return Err(Error::new(ErrorKind::InvalidParameter, "to_buffers cannot be null"));
+    }
+
+    // SAFETY: `to_buffers` is not null. We've checked for this above.
+    let to_buffers = unsafe { from_raw_parts_mut(to_buffers, from_buffers.len()) };
     for i in 0..from_buffers.len() {
         let buffer = &from_buffers[i];
         let buffer_size = buffer.buffer.len();
         to_buffers[i].cb_buffer = buffer_size.try_into().unwrap();
         to_buffers[i].buffer_type = buffer.buffer_type.into();
         if allocate || to_buffers[i].pv_buffer.is_null() {
-            to_buffers[i].pv_buffer = libc::malloc(buffer_size) as *mut c_char;
+            // SAFETY: Memory allocation should be safe. Also, we check `pv_buffer` for the null below.
+            to_buffers[i].pv_buffer = unsafe { libc::malloc(buffer_size) as *mut c_char };
         }
-        let to_buffer = from_raw_parts_mut(to_buffers[i].pv_buffer, buffer_size);
-        to_buffer.copy_from_slice(from_raw_parts(buffer.buffer.as_ptr() as *const c_char, buffer_size));
+
+        if to_buffers[i].pv_buffer.is_null() {
+            return Err(Error::new(
+                ErrorKind::InsufficientMemory,
+                format!("cannot allocate {buffer_size} bytes"),
+            ));
+        }
+
+        // SAFETY: `pv_buffer` is not null. We've checked for this above.
+        let to_buffer = unsafe { from_raw_parts_mut(to_buffers[i].pv_buffer, buffer_size) };
+
+        // SAFETY: We create a valid pointer, so it's safe to call the function.
+        to_buffer.copy_from_slice(unsafe { from_raw_parts(buffer.buffer.as_ptr() as *const c_char, buffer_size) });
     }
+
+    Ok(())
 }

--- a/ffi/src/sspi/sec_buffer.rs
+++ b/ffi/src/sspi/sec_buffer.rs
@@ -63,13 +63,13 @@ pub(crate) unsafe fn copy_to_c_sec_buffer(
         if allocate || to_buffers[i].pv_buffer.is_null() {
             // SAFETY: Memory allocation should be safe. Also, we check `pv_buffer` for the null below.
             to_buffers[i].pv_buffer = unsafe { libc::malloc(buffer_size) as *mut c_char };
-        }
 
-        if to_buffers[i].pv_buffer.is_null() {
-            return Err(Error::new(
-                ErrorKind::InsufficientMemory,
-                format!("cannot allocate {buffer_size} bytes"),
-            ));
+            if to_buffers[i].pv_buffer.is_null() {
+                return Err(Error::new(
+                    ErrorKind::InsufficientMemory,
+                    format!("cannot allocate {buffer_size} bytes"),
+                ));
+            }
         }
 
         // SAFETY: `pv_buffer` is not null. We've checked for this above.

--- a/ffi/src/sspi/sec_pkg_info.rs
+++ b/ffi/src/sspi/sec_pkg_info.rs
@@ -207,7 +207,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
             size += package.name.as_ref().len() + 1 /* null byte */ + package.comment.len() + 1 /* null byte */;
         }
 
-        // SAFETY: Memory allocation should be safe.
+        // SAFETY: Memory allocation is safe
         let raw_packages = unsafe { libc::malloc(size) };
 
         if raw_packages.is_null() {
@@ -301,7 +301,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
             comments.push(comment);
         }
 
-        // SAFETY: Memory allocation should be safe.
+        // SAFETY: Memory allocation is safe
         let raw_packages = unsafe { libc::malloc(size) };
 
         if raw_packages.is_null() {

--- a/ffi/src/sspi/sec_pkg_info.rs
+++ b/ffi/src/sspi/sec_pkg_info.rs
@@ -207,7 +207,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
             size += package.name.as_ref().len() + 1 /* null byte */ + package.comment.len() + 1 /* null byte */;
         }
 
-        // SAFETY: Memory allocation is safe
+        // SAFETY: Memory allocation is safe.
         let raw_packages = unsafe { libc::malloc(size) };
 
         if raw_packages.is_null() {
@@ -301,7 +301,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
             comments.push(comment);
         }
 
-        // SAFETY: Memory allocation is safe
+        // SAFETY: Memory allocation is safe.
         let raw_packages = unsafe { libc::malloc(size) };
 
         if raw_packages.is_null() {

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -387,9 +387,9 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         // Only marshaled smart card creds starts with '@' char.
         #[cfg(all(feature = "scard", target_os = "windows"))]
+        // SAFETY: This function is safe to call because argument is validated.
         if !user.is_empty() && unsafe { CredIsMarshaledCredentialW(user.as_ptr() as *const _) } != 0 {
-            // SAFETY:
-            // `user` and `password` are Rust vectors which is safe to read.
+            // SAFETY: This function is safe to call because arguments are validated.
             return unsafe { handle_smart_card_creds(user, password) };
         }
 
@@ -426,9 +426,9 @@ pub unsafe fn auth_data_to_identity_buffers_w(
 
         // Only marshaled smart card creds starts with '@' char.
         #[cfg(all(feature = "scard", target_os = "windows"))]
+        // SAFETY: This function is safe to call because argument is validated.
         if !user.is_empty() && unsafe { CredIsMarshaledCredentialW(user.as_ptr() as *const _) } != 0 {
-            // SAFETY:
-            // `user` and `password` are Rust vectors which is safe to read.
+            // SAFETY: This function is safe to call because arguments are validated.
             return unsafe { handle_smart_card_creds(user, password) };
         }
 
@@ -643,6 +643,7 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
     // So, we need add the NULL terminator.
     username.extend_from_slice(&[0, 0]);
 
+    // SAFETY: This function is safe to call because the arguments are type-checked.
     if unsafe { CredUnmarshalCredentialW(username.as_ptr() as *const _, &mut cred_type, &mut credential) } == 0 {
         return Err(Error::new(
             ErrorKind::NoCredentials,
@@ -659,10 +660,12 @@ unsafe fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8
 
     let cert_credential = credential.cast::<CERT_CREDENTIAL_INFO>();
 
+    // SAFETY: This function is safe to call because `cert_credential` is validated.
     let (raw_certificate, certificate) =
         unsafe { sspi::cert_utils::extract_certificate_by_thumbprint(&(*cert_credential).rgbHashOfCert)? };
 
     let username = string_to_utf16(sspi::cert_utils::extract_user_name_from_certificate(&certificate)?);
+    // SAFETY: This function is safe to call because argument is type-checked.
     let SmartCardInfo {
         key_container_name,
         reader_name,

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -158,7 +158,7 @@ pub struct CredSspCred {
 ///
 /// # Safety:
 ///
-/// * The auth identity pointer should not be null.
+/// * The auth identity pointer must not be null.
 pub unsafe fn get_auth_data_identity_version_and_flags(p_auth_data: *const c_void) -> (u32, u32) {
     // SAFETY: the safety contract [p_auth_data] must be upheld by the caller.
     let auth_version = unsafe { *p_auth_data.cast::<u32>() };

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -154,6 +154,11 @@ pub struct CredSspCred {
     pub p_spnego_cred: *const c_void,
 }
 
+/// Returns auth identity version and flags.
+///
+/// # Safety:
+///
+/// * The auth identity pointer should not be null.
 pub unsafe fn get_auth_data_identity_version_and_flags(p_auth_data: *const c_void) -> (u32, u32) {
     // SAFETY: the safety contract [p_auth_data] must be upheld by the caller.
     let auth_version = unsafe { *p_auth_data.cast::<u32>() };
@@ -719,7 +724,7 @@ fn handle_smart_card_creds(mut username: Vec<u8>, password: Secret<Vec<u8>>) -> 
         certificate: _,
         csp_name,
         private_key_file_index,
-    } = unsafe { finalize_smart_card_info(&certificate.tbs_certificate.serial_number.0)? };
+    } = finalize_smart_card_info(&certificate.tbs_certificate.serial_number.0)?;
 
     let creds = CredentialsBuffers::SmartCard(SmartCardIdentityBuffers {
         certificate: raw_certificate,
@@ -915,7 +920,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
             return ErrorKind::InvalidParameter.to_u32().unwrap();
         }
 
-        // SAFETY: Memory allocation should be safe.
+        // SAFETY: Memory allocation is safe
         let user = unsafe { libc::malloc(user_length * 2) as *mut SecWChar };
         if user.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
@@ -923,7 +928,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         // SAFETY: This function is safe to call because `psz_user_name` and `user` are not null. We've checked this above.
         unsafe { copy_nonoverlapping(psz_user_name, user, user_length) };
 
-        // SAFETY: Memory allocation should be safe.
+        // SAFETY: Memory allocation is safe
         let domain = unsafe { libc::malloc(domain_length * 2) as *mut SecWChar };
         if domain.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
@@ -931,7 +936,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         // SAFETY: This function is safe to call because `psz_domain_name` and `domain` are not null. We've checked this above.
         unsafe { copy_nonoverlapping(psz_domain_name, domain, domain_length) };
 
-        // SAFETY: Memory allocation should be safe.
+        // SAFETY: Memory allocation is safe
         let password = unsafe { libc::malloc(password_length * 2) as *mut SecWChar };
         if password.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -920,7 +920,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
             return ErrorKind::InvalidParameter.to_u32().unwrap();
         }
 
-        // SAFETY: Memory allocation is safe
+        // SAFETY: Memory allocation is safe.
         let user = unsafe { libc::malloc(user_length * 2) as *mut SecWChar };
         if user.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
@@ -928,7 +928,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         // SAFETY: This function is safe to call because `psz_user_name` and `user` are not null. We've checked this above.
         unsafe { copy_nonoverlapping(psz_user_name, user, user_length) };
 
-        // SAFETY: Memory allocation is safe
+        // SAFETY: Memory allocation is safe.
         let domain = unsafe { libc::malloc(domain_length * 2) as *mut SecWChar };
         if domain.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
@@ -936,7 +936,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         // SAFETY: This function is safe to call because `psz_domain_name` and `domain` are not null. We've checked this above.
         unsafe { copy_nonoverlapping(psz_domain_name, domain, domain_length) };
 
-        // SAFETY: Memory allocation is safe
+        // SAFETY: Memory allocation is safe.
         let password = unsafe { libc::malloc(password_length * 2) as *mut SecWChar };
         if password.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();

--- a/ffi/src/sspi/utils.rs
+++ b/ffi/src/sspi/utils.rs
@@ -3,20 +3,23 @@ use sspi::{CredentialsBuffers, Result};
 use super::credentials_attributes::CredentialsAttributes;
 use super::sec_handle::CredentialsHandle;
 
+/// Transforms a passed pointer to the credentials handle into a triplet of [CredentialsBuffers],
+/// security package name, and [CredentialsAttributes].
+///
+/// # Safety:
+///
+/// The caller have to ensure that either the pointer is null or the pointer is [convertible to a reference](https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion).
 pub unsafe fn transform_credentials_handle<'a>(
     credentials_handle: *mut CredentialsHandle,
 ) -> Option<(CredentialsBuffers, &'a str, &'a CredentialsAttributes)> {
-    if credentials_handle.is_null() {
-        None
-    } else {
-        // SAFETY: `credentials_handle` is not null. We've checked this above.
-        let cred_handle = unsafe { credentials_handle.as_mut().unwrap() };
-        Some((
+    // SAFETY: `credentials_handle` is not null. We've checked this above.
+    unsafe { credentials_handle.as_mut() }.map(|cred_handle| {
+        (
             cred_handle.credentials.clone(),
             cred_handle.security_package_name.as_str(),
             &cred_handle.attributes,
-        ))
-    }
+        )
+    })
 }
 
 // When encoding a UTF-16 character using two code units, the 16-bit values are chosen from

--- a/ffi/src/sspi/utils.rs
+++ b/ffi/src/sspi/utils.rs
@@ -9,7 +9,8 @@ pub unsafe fn transform_credentials_handle<'a>(
     if credentials_handle.is_null() {
         None
     } else {
-        let cred_handle = credentials_handle.as_mut().unwrap();
+        // SAFETY: `credentials_handle` is not null. We've checked this above.
+        let cred_handle = unsafe { credentials_handle.as_mut().unwrap() };
         Some((
             cred_handle.credentials.clone(),
             cred_handle.security_package_name.as_str(),

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -8,30 +8,32 @@ pub fn into_raw_ptr<T>(value: T) -> *mut T {
 
 /// # Safety
 ///
+/// *Note*: the resulting [String] will contain a null-terminator char at the end.
 /// Behavior is undefined is any of the following conditions are violated:
 ///
-/// * `s` must be [valid] C string.
+/// * `s` must be a [valid] C string.
 pub unsafe fn c_w_str_to_string(s: *const u16) -> String {
     let mut len = 0;
 
-    // SAFETY: The user must provide guarantees that `s` is valid C string.
+    // SAFETY: The user must provide guarantees that `s` is a valid C string.
     while unsafe { *(s.add(len)) } != 0 {
         len += 1;
     }
 
-    // SAFETY: The user must provide guarantees that `s` is valid C string.
+    // SAFETY: The user must provide guarantees that `s` is a valid C string.
     String::from_utf16_lossy(unsafe { from_raw_parts(s, len) })
 }
 
 /// # Safety
 ///
+/// The returned length includes the null terminator char.
 /// Behavior is undefined is any of the following conditions are violated:
 ///
-/// * `s` must be [valid] C string.
+/// * `s` must be a [valid] C string.
 pub unsafe fn w_str_len(s: *const u16) -> usize {
     let mut len = 0;
 
-    // SAFETY: The user must provide guarantees that `s` is valid C string.
+    // SAFETY: The user must provide guarantees that `s` is a valid C string.
     while unsafe { *(s.add(len)) } != 0 {
         len += 1;
     }

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -6,19 +6,32 @@ pub fn into_raw_ptr<T>(value: T) -> *mut T {
     Box::into_raw(Box::new(value))
 }
 
+/// # Safety
+///
+/// Behavior is undefined is any of the following conditions are violated:
+///
+/// * `s` must be [valid] C string.
 pub unsafe fn c_w_str_to_string(s: *const u16) -> String {
     let mut len = 0;
 
+    // SAFETY: The user must provide guarantees that `s` is valid C string.
     while unsafe { *(s.add(len)) } != 0 {
         len += 1;
     }
 
+    // SAFETY: The user must provide guarantees that `s` is valid C string.
     String::from_utf16_lossy(unsafe { from_raw_parts(s, len) })
 }
 
+/// # Safety
+///
+/// Behavior is undefined is any of the following conditions are violated:
+///
+/// * `s` must be [valid] C string.
 pub unsafe fn w_str_len(s: *const u16) -> usize {
     let mut len = 0;
 
+    // SAFETY: The user must provide guarantees that `s` is valid C string.
     while unsafe { *(s.add(len)) } != 0 {
         len += 1;
     }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -74,7 +74,7 @@ impl WinScardContextHandle {
     /// Allocated a new buffer inside the scard context.
     #[instrument(level = "debug", ret)]
     pub fn allocate_buffer(&mut self, size: usize) -> WinScardResult<*mut u8> {
-        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe. Moreover, we check for the null value below.
         let buff = unsafe { libc::malloc(size) as *mut u8 };
         if buff.is_null() {
             return Err(Error::new(

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -74,7 +74,7 @@ impl WinScardContextHandle {
     /// Allocated a new buffer inside the scard context.
     #[instrument(level = "debug", ret)]
     pub fn allocate_buffer(&mut self, size: usize) -> WinScardResult<*mut u8> {
-        // SAFETY: Memory allocation should be safe. Moreover, we check for the null value below.
+        // SAFETY: Memory allocation is safe Moreover, we check for the null value below.
         let buff = unsafe { libc::malloc(size) as *mut u8 };
         if buff.is_null() {
             return Err(Error::new(

--- a/src/cert_utils.rs
+++ b/src/cert_utils.rs
@@ -91,8 +91,11 @@ pub fn extract_raw_certificate_by_thumbprint(thumbprint: &[u8]) -> Result<Vec<u8
     let cert = unsafe { find_raw_cert_by_thumbprint(thumbprint, cert_store)? };
 
     // SAFETY: `open_user_cert_store` returns valid store handle that needs to be closed.
-    unsafe {
-        CertCloseStore(cert_store, 0);
+    if unsafe { CertCloseStore(cert_store, 0) } == 0 {
+        return Err(Error::new(
+            ErrorKind::InternalError,
+            "could not close the certificate store",
+        ));
     }
 
     Ok(cert)
@@ -204,15 +207,21 @@ pub struct SmartCardInfo {
 // The similar approach is implemented in the FreeRDP for the smart card information gathering:
 // https://github.com/FreeRDP/FreeRDP/blob/56324906a2d5b2538675e2f10b9f1ffe4a27de79/libfreerdp/core/smartcardlogon.c#L616
 #[instrument(level = "trace", ret)]
-pub unsafe fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<SmartCardInfo> {
+pub fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<SmartCardInfo> {
     let mut crypt_context_handle = HCRYPTPROV::default();
-    if CryptAcquireContextW(
-        &mut crypt_context_handle,
-        null(),
-        CSP_NAME_W.as_ptr() as *const _,
-        PROV_RSA_FULL,
-        CRYPT_SILENT,
-    ) == 0
+    // SAFETY:
+    // * `phProv` is constructed using Rust references. This it is valid.
+    // * `szContainer` can be null according to the documentation.
+    // * all other parameters are hardcoded constants that are valid.
+    if unsafe {
+        CryptAcquireContextW(
+            &mut crypt_context_handle,
+            null(),
+            CSP_NAME_W.as_ptr() as *const _,
+            PROV_RSA_FULL,
+            CRYPT_SILENT,
+        )
+    } == 0
     {
         return Err(Error::new(
             ErrorKind::InternalError,
@@ -224,26 +233,40 @@ pub unsafe fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<Smar
     let mut is_first = true;
     let mut index = 1;
     loop {
-        if CryptGetProvParam(
-            crypt_context_handle,
-            PP_ENUMCONTAINERS,
-            null_mut(),
-            &mut key_container_name_len,
-            if is_first { CRYPT_FIRST } else { CRYPT_NEXT },
-        ) == 0
+        // SAFETY:
+        // * `crypt_context_handle` is obtained from the successful `CryptAcquireContextW` function call.
+        // * `pbData` can be null according to the documentation.
+        // * `key_container_name_len` is constructed using Rust references. This it is valid.
+        // * all other parameters are hardcoded constants that are valid.
+        if unsafe {
+            CryptGetProvParam(
+                crypt_context_handle,
+                PP_ENUMCONTAINERS,
+                null_mut(),
+                &mut key_container_name_len,
+                if is_first { CRYPT_FIRST } else { CRYPT_NEXT },
+            )
+        } == 0
         {
             break;
         }
 
         let mut key_container_name = vec![0; key_container_name_len as usize];
 
-        if CryptGetProvParam(
-            crypt_context_handle,
-            PP_ENUMCONTAINERS,
-            key_container_name.as_mut_ptr(),
-            &mut key_container_name_len,
-            if is_first { CRYPT_FIRST } else { CRYPT_NEXT },
-        ) == 0
+        // SAFETY:
+        // * `crypt_context_handle` is obtained from the successful `CryptAcquireContextW` function call.
+        // * `key_container_name` is a Rust vector buffer of valid length. Its len was previously obtained using `CryptGetProvParam`.
+        // * `key_container_name_len` is constructed using Rust references. This it is valid.
+        // * all other parameters are hardcoded constants that are valid.
+        if unsafe {
+            CryptGetProvParam(
+                crypt_context_handle,
+                PP_ENUMCONTAINERS,
+                key_container_name.as_mut_ptr(),
+                &mut key_container_name_len,
+                if is_first { CRYPT_FIRST } else { CRYPT_NEXT },
+            )
+        } == 0
         {
             break;
         }
@@ -251,18 +274,25 @@ pub unsafe fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<Smar
         // remove null char
         key_container_name.pop();
 
-        let context = if let Ok(context) = acquire_key_container_context(&key_container_name) {
+        let context = if let Ok(context) = unsafe { acquire_key_container_context(&key_container_name) } {
             context
         } else {
             index += 1;
             continue;
         };
 
-        if let Ok(certificate) = get_key_container_certificate(context) {
+        if let Ok(certificate) = unsafe { get_key_container_certificate(context) } {
             if certificate.tbs_certificate.serial_number.0 == cert_serial_number {
-                let reader_name = get_reader_name(crypt_context_handle);
+                let reader_name = unsafe { get_reader_name(crypt_context_handle) };
 
-                CryptReleaseContext(crypt_context_handle, 0);
+                // SAFETY: the `crypt_context_handle` was obtained using successful `CryptAcquireContextW` function call.
+                // `dwFlags` parameter is reserved for future use and must be zero.
+                if unsafe { CryptReleaseContext(crypt_context_handle, 0) } == 0 {
+                    return Err(Error::new(
+                        ErrorKind::InternalError,
+                        "could not release the crypto context",
+                    ));
+                }
 
                 let reader_name = match reader_name {
                     Ok(reader_name) => reader_name,
@@ -286,7 +316,14 @@ pub unsafe fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<Smar
         is_first = false;
     }
 
-    CryptReleaseContext(crypt_context_handle, 0);
+    // SAFETY: the `crypt_context_handle` was obtained using successful `CryptAcquireContextW` function call.
+    // `dwFlags` parameter is reserved for future use and must be zero.
+    if unsafe { CryptReleaseContext(crypt_context_handle, 0) } == 0 {
+        return Err(Error::new(
+            ErrorKind::InternalError,
+            "could not release the crypto context",
+        ));
+    }
 
     Err(Error::new(ErrorKind::InternalError, "Cannot get smart card info"))
 }


### PR DESCRIPTION
Hi,
I refactored FFI code in this PR:

* Enabled `unsafe_op_in_unsafe_fn` and `clippy::undocumented_unsafe_blocks` lints for all modules in the FFI crate.
* Fixed warnings and compilation errors.

Do not be scared of big number of lines changed. They are mostly `SAFETY` comments 🙂 