### PR TITLE
fix: do not log at info-level return values

### DIFF
--- a/crates/dpapi/src/client.rs
+++ b/crates/dpapi/src/client.rs
@@ -132,7 +132,7 @@ fn process_get_key_result(response: &Response, security_trailer: Option<Security
     unpack_response(data)
 }
 
-#[instrument(ret)]
+#[instrument(ret, level = "debug")]
 fn decrypt_blob(blob: &DpapiBlob, key: &GroupKeyEnvelope) -> Result<Vec<u8>> {
     let kek = get_kek(key, &blob.key_identifier)?;
 
@@ -147,7 +147,7 @@ fn decrypt_blob(blob: &DpapiBlob, key: &GroupKeyEnvelope) -> Result<Vec<u8>> {
     )?)
 }
 
-#[instrument(ret)]
+#[instrument(ret, level = "debug")]
 fn encrypt_blob(
     data: &[u8],
     key: &GroupKeyEnvelope,

--- a/crates/dpapi/src/rpc/auth.rs
+++ b/crates/dpapi/src/rpc/auth.rs
@@ -135,7 +135,7 @@ impl<'a> AuthProvider<'a> {
     /// * `security_trailer_data`: RPC PDU security trailer `auth_value`. Basically, it's a Kerberos Wrap Token.
     ///
     /// All encryption is performed in-place.
-    #[instrument(ret, skip(self))]
+    #[instrument(ret, level = "debug", skip(self))]
     pub fn wrap_with_header_sign(
         &mut self,
         header: &mut [u8],
@@ -189,7 +189,7 @@ impl<'a> AuthProvider<'a> {
     /// * `security_trailer_data`: `auth_value` of the RPC PDU security trailer. Basically, it's a Kerberos Wrap Token.
     ///
     /// All decryption is performed in-place.
-    #[instrument(ret, skip(self))]
+    #[instrument(ret, level = "debug", skip(self))]
     pub fn unwrap_with_header_sign(
         &mut self,
         header: &mut [u8],
@@ -219,7 +219,7 @@ impl<'a> AuthProvider<'a> {
     /// * `security_trailer_data`: `auth_value` of the RPC PDU security trailer. Basically, it's a Kerberos Wrap Token.
     ///
     /// All decryption is performed in-place.
-    #[instrument(ret, skip(self))]
+    #[instrument(ret, level = "debug", skip(self))]
     pub fn unwrap(&mut self, body: &mut [u8], security_trailer_data: &mut [u8]) -> AuthResult<Vec<u8>> {
         let mut message = vec![
             SecurityBufferRef::data_buf(body),
@@ -234,7 +234,7 @@ impl<'a> AuthProvider<'a> {
     /// Performs one step in authorization process.
     ///
     /// The client should call this method until `self.is_finished()` is `true`.
-    #[instrument(ret, fields(state = ?self.is_finished), skip(self))]
+    #[instrument(ret, level = "debug", fields(state = ?self.is_finished), skip(self))]
     pub async fn initialize_security_context(&mut self, in_token: Vec<u8>) -> AuthResult<SecurityTrailer> {
         let mut input_token = [SecurityBuffer::new(in_token, BufferType::Token)];
         let mut output_token = vec![SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];

--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -634,7 +634,7 @@ impl SspiImpl for SspiContext {
     type CredentialsHandle = Option<CredentialsBuffers>;
     type AuthenticationData = Credentials;
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip_all)]
     fn acquire_credentials_handle_impl(
         &mut self,
         builder: FilledAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData>,
@@ -681,7 +681,7 @@ impl SspiImpl for SspiContext {
         })
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip_all)]
     fn accept_security_context_impl(
         &mut self,
         builder: FilledAcceptSecurityContext<'_, Self::CredentialsHandle>,
@@ -736,7 +736,7 @@ impl SspiImpl for SspiContext {
 }
 
 impl<'a> SspiContext {
-    #[instrument(ret, fields(security_package = self.package_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip_all)]
     async fn change_password_impl(
         &mut self,
         yield_point: &mut YieldPointLocal,
@@ -769,7 +769,7 @@ impl<'a> SspiContext {
             .resolve_with_default_network_client()
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip_all)]
     async fn initialize_security_context_impl(
         &'a mut self,
         yield_point: &mut YieldPointLocal,
@@ -807,7 +807,7 @@ impl<'a> SspiContext {
 }
 
 impl Sspi for SspiContext {
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn complete_auth_token(&mut self, token: &mut [SecurityBuffer]) -> crate::Result<SecurityStatus> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.complete_auth_token(token),
@@ -819,7 +819,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn encrypt_message(
         &mut self,
         flags: EncryptionFlags,
@@ -836,7 +836,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn decrypt_message(
         &mut self,
         message: &mut [SecurityBufferRef],
@@ -852,7 +852,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_sizes(&mut self) -> crate::Result<ContextSizes> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_sizes(),
@@ -864,7 +864,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_names(&mut self) -> crate::Result<ContextNames> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_names(),
@@ -876,7 +876,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_stream_sizes(&mut self) -> crate::Result<StreamSizes> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_stream_sizes(),
@@ -888,7 +888,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_package_info(&mut self) -> crate::Result<PackageInfo> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_package_info(),
@@ -900,7 +900,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_cert_trust_status(&mut self) -> crate::Result<CertTrustStatus> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_cert_trust_status(),
@@ -912,7 +912,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_remote_cert(&mut self) -> crate::Result<CertContext> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_remote_cert(),
@@ -924,7 +924,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_negotiation_package(&mut self) -> crate::Result<PackageInfo> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_negotiation_package(),
@@ -936,7 +936,7 @@ impl Sspi for SspiContext {
         }
     }
 
-    #[instrument(ret, fields(security_package = self.package_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(security_package = self.package_name()), skip(self))]
     fn query_context_connection_info(&mut self) -> crate::Result<ConnectionInfo> {
         match self {
             SspiContext::Ntlm(ntlm) => ntlm.query_context_connection_info(),

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -365,7 +365,7 @@ impl SspiImpl for SspiCredSsp {
 }
 
 impl SspiCredSsp {
-    #[instrument(ret, fields(state = ?self.state), skip_all)]
+    #[instrument(ret, level = "debug", fields(state = ?self.state), skip_all)]
     #[async_recursion]
     pub(crate) async fn initialize_security_context_impl<'a>(
         &mut self,

--- a/src/credssp/ts_request/mod.rs
+++ b/src/credssp/ts_request/mod.rs
@@ -251,7 +251,7 @@ impl TsRequest {
     }
 }
 
-#[instrument(ret)]
+#[instrument(ret, level = "debug")]
 fn write_smart_card_credentials(credentials: &SmartCardIdentityBuffers) -> crate::Result<Vec<u8>> {
     let smart_card_creds = TsSmartCardCreds {
         pin: ExplicitContextTag0::from(OctetStringAsn1::from(credentials.pin.as_ref().to_vec())),
@@ -300,7 +300,7 @@ pub fn write_ts_credentials(credentials: &CredentialsBuffers, cred_ssp_mode: Cre
     Ok(picky_asn1_der::to_vec(&ts_creds)?)
 }
 
-#[instrument(ret)]
+#[instrument(ret, level = "debug")]
 fn write_password_credentials(credentials: &AuthIdentityBuffers, cred_ssp_mode: CredSspMode) -> io::Result<Vec<u8>> {
     let empty_identity = AuthIdentityBuffers::default();
     let identity = match cred_ssp_mode {

--- a/src/kdc.rs
+++ b/src/kdc.rs
@@ -53,7 +53,7 @@ pub fn detect_kdc_hosts_from_system(domain: &str) -> Vec<String> {
     Vec::new()
 }
 
-#[instrument(ret)]
+#[instrument(ret, level = "debug")]
 pub fn detect_kdc_hosts(domain: &str) -> Vec<String> {
     if let Ok(kdc_url) = env::var(format!("SSPI_KDC_URL_{}", domain)) {
         return vec![kdc_url];

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -130,7 +130,7 @@ impl Negotiate {
     // 3) if the provided username is FQDN and we can resolve KDC then it'll use Kerberos
     // 4) if SSPI_KDC_URL_ENV is set then it'll also use Kerberos
     // 5) in any other cases, it'll use NTLM
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip(self))]
     fn negotiate_protocol(&mut self, username: &str, domain: &str) -> Result<()> {
         if let NegotiatedProtocol::Ntlm(_) = &self.protocol {
             #[cfg(target_os = "windows")]
@@ -266,7 +266,7 @@ impl Negotiate {
 }
 
 impl SspiEx for Negotiate {
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) -> Result<()> {
         self.auth_identity = Some(identity.clone().try_into().unwrap());
 
@@ -293,7 +293,7 @@ impl SspiEx for Negotiate {
 }
 
 impl Sspi for Negotiate {
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip(self))]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip(self))]
     fn complete_auth_token(&mut self, token: &mut [SecurityBuffer]) -> Result<SecurityStatus> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.complete_auth_token(token),
@@ -302,7 +302,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn encrypt_message(
         &mut self,
         flags: crate::EncryptionFlags,
@@ -316,7 +316,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn decrypt_message<'data>(
         &mut self,
         message: &mut [SecurityBufferRef<'data>],
@@ -329,7 +329,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn query_context_sizes(&mut self) -> Result<ContextSizes> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_sizes(),
@@ -338,7 +338,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn query_context_names(&mut self) -> Result<ContextNames> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_names(),
@@ -347,12 +347,12 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn query_context_package_info(&mut self) -> Result<PackageInfo> {
         crate::query_security_package_info(SecurityPackageType::Negotiate)
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn query_context_negotiation_package(&mut self) -> Result<PackageInfo> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_package_info(),
@@ -361,7 +361,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn query_context_cert_trust_status(&mut self) -> Result<CertTrustStatus> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_cert_trust_status(),
@@ -414,7 +414,7 @@ impl SspiImpl for Negotiate {
     type CredentialsHandle = Option<CredentialsBuffers>;
     type AuthenticationData = Credentials;
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn acquire_credentials_handle_impl(
         &mut self,
         builder: builders::FilledAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData>,
@@ -478,7 +478,7 @@ impl SspiImpl for Negotiate {
         })
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn accept_security_context_impl(
         &mut self,
         builder: builders::FilledAcceptSecurityContext<'_, Self::CredentialsHandle>,
@@ -517,7 +517,7 @@ impl SspiImpl for Negotiate {
 }
 
 impl<'a> Negotiate {
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     pub(crate) async fn change_password(
         &'a mut self,
         yield_point: &mut YieldPointLocal,
@@ -534,7 +534,7 @@ impl<'a> Negotiate {
         }
     }
 
-    #[instrument(ret, fields(protocol = self.protocol.protocol_name()), skip_all)]
+    #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     pub(crate) async fn initialize_security_context_impl(
         &'a mut self,
         yield_point: &mut YieldPointLocal,

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -286,7 +286,7 @@ impl SspiImpl for Ntlm {
         })
     }
 
-    #[instrument(ret, fields(state = ?self.state), skip_all)]
+    #[instrument(ret, level = "debug", fields(state = ?self.state), skip_all)]
     fn initialize_security_context_impl(
         &mut self,
         builder: &mut FilledInitializeSecurityContext<'_, Self::CredentialsHandle>,

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -414,7 +414,7 @@ impl SspiImpl for Pku2u {
 }
 
 impl Pku2u {
-    #[instrument(ret, fields(state = ?self.state), skip_all)]
+    #[instrument(ret, level = "debug", fields(state = ?self.state), skip_all)]
     pub(crate) fn initialize_security_context_impl(
         &mut self,
         builder: &mut crate::builders::FilledInitializeSecurityContext<'_, <Self as SspiImpl>::CredentialsHandle>,


### PR DESCRIPTION
cc @TheBestTvarynka 
I missed this pattern. It’s also possible to change the event level without changing the span level, but it makes sense to not create info-level spans since we are not supposed to log at info-level (although this can be useful for warnings that will inherit the info-level span.