### PR TITLE
ci(dependabot): remove `winreg` from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       windows:
         patterns:
           - "windows*"
-          - "winreg"
           - "winapi"
       patch:
         dependency-type: "production"


### PR DESCRIPTION
more context: https://github.com/Devolutions/sspi-rs/pull/441#discussion_r2128800079 