### PR TITLE
fix: invalid Kerberos token DER encoding

### DIFF
--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -13,7 +13,6 @@ use picky_asn1::wrapper::{
     ExplicitContextTag8, ExplicitContextTag9, GeneralizedTimeAsn1, IntegerAsn1, ObjectIdentifierAsn1, OctetStringAsn1,
     Optional,
 };
-use picky_asn1_der::application_tag::ApplicationTag;
 use picky_asn1_der::Asn1RawDer;
 use picky_asn1_x509::oids;
 use picky_krb::constants::gss_api::{
@@ -723,7 +722,7 @@ pub fn get_mech_list() -> MechTypeList {
 }
 
 pub fn generate_neg_token_init(username: &str, service_name: &str) -> Result<ApplicationTag0<GssApiNegInit>> {
-    let krb5_neg_token_init: ApplicationTag<_, 0> = ApplicationTag::from(KrbMessage {
+    let krb5_neg_token_init = ApplicationTag0(KrbMessage {
         krb5_oid: ObjectIdentifierAsn1::from(oids::krb5_user_to_user()),
         krb5_token_id: TGT_REQ_TOKEN_ID,
         krb_msg: TgtReq {
@@ -753,7 +752,7 @@ pub fn generate_neg_token_init(username: &str, service_name: &str) -> Result<App
 }
 
 pub fn generate_neg_ap_req(ap_req: ApReq, mech_id: oid::ObjectIdentifier) -> Result<ExplicitContextTag1<NegTokenTarg>> {
-    let krb_blob: ApplicationTag<_, 0> = ApplicationTag(KrbMessage {
+    let krb_blob = ApplicationTag0(KrbMessage {
         krb5_oid: ObjectIdentifierAsn1::from(mech_id),
         krb5_token_id: AP_REQ_TOKEN_ID,
         krb_msg: ap_req,


### PR DESCRIPTION
I have upgraded `sspi` to version 0.15.11 after the merge of my [last PR](https://github.com/Devolutions/sspi-rs/pull/447).

Testing the new code today against my Active Directory setup, I had a general DER error:
```
SspiError(Error { error_type: InvalidToken, description: "ASN1 DER error: InvalidData", nstatus: None })
```
Sniffing the session, and more specifically, taking a look at the token from `sspi`:
<img width="2286" alt="image" src="https://github.com/user-attachments/assets/1d3ce3eb-3d79-4aa5-8e63-1ca3d82bd19d" />

Seems like the error originates in an invalid DER-encoded kerberos token, that later causes the server to respond with a generic kerberos error.

I have checked out an earlier revision of my code, and it was working properly. A Quick Look at my `sspi` usage seemed very similar to the up-to-date one, so I tried reverting package versions and it was all working.

From there, I narrowed down the issue to upgrading `sspi` to it's latest version.

I compared the valid kerberos token from the earlier version to the newer one, and the difference was 2 bytes in the beginning:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/628aa584-3137-4387-8239-360ccbdec2e7" />
It seemed like sspi, in it's *newer* version, is encoding the Kerberos token as: `ApplicationTag=0 { Sequence { ...fields } }`, but in the older version, it is encoded as `ApplicationTag=0 { ...fields }`.

Technically, I believe the issue originates in the upgrade of `picky-krb` to a newer version in [this PR](https://github.com/Devolutions/sspi-rs/pull/448). Specifically, the default behavior of serializing a `KrbMessage<T>` changed -- it was wrapped with the `Container` [here](https://github.com/Devolutions/picky-rs/blob/302df9912d6f038f21b64fc916bd82836944c382/picky-krb/src/gss_api.rs#L167), to add the Sequence tag, as opposed to how it went before, which just [encoded the data right away](https://github.com/Devolutions/picky-rs/blob/picky-krb-v0.9.4/picky-krb/src/gss_api.rs#L123).

The solution is quite easy -- the same module `gss_api.rs` provides the `ApplicationTag0` which encodes the inner value without adding the sequence TLV wrapping, so it just works,

This patch uses this structure instead of the `ApplicationTag`, and worked right away.
Perhaps I am missing some use case that this works properly for, but currently, this seems to resolve the issue for SMB.

LMK if I can help with anything further -- Thanks!
