### PR TITLE
feat(ntlm): add method to set the channel bindings for a session

### DIFF
--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -351,12 +351,6 @@ impl Ntlm {
                 let input_token = SecurityBuffer::find_buffer(input, BufferType::Token)?;
                 let output_token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
 
-                if let Ok(sec_buffer) =
-                    SecurityBuffer::find_buffer(builder.input.as_ref().unwrap(), BufferType::ChannelBindings)
-                {
-                    self.channel_bindings = Some(ChannelBindings::from_bytes(&sec_buffer.buffer)?);
-                }
-
                 client::read_challenge(self, input_token.buffer.as_slice())?;
 
                 client::write_authenticate(


### PR DESCRIPTION
A while ago I opened #240, but didn't have time to thoroughly analyze the code and the spec in order to address the questions raised in the discussion. Now I've done the analysis. The principal question was:

> About the suggested change, however, my guess is that it was not intended for the `channel_bindings` field to be overridden by the user, as-is.

On the contrary, the user is the only party that can meaningfully set the channel bindings, since the point is to let the server know the user's idea of the server's identity, transmitted in a tamper-proof way, so that any discrepancy, indicative of an attempt of a relaying attack, can be detected and the session terminated.

Setting and sending the CBs is described in Sec. 3.1.5.2.1 of the NTLM spec, admittedly in a slightly confusing way, which may seem to suggest that the bindings are somehow part of the CHALLENGE message, but they are not: knowledge of CBs is strictly local to the client, therefore the client should send them in AUTHENTICATE.

Accordingly, the second commit in this PR removes the check for CBs in the CHALLENGE token, since it can't be there. The other check for CBs, on the server side (L287 in 78345a1fd875eac1b128cbcca1cefce81b339b26), is valid and should stay.