### PR TITLE
fix(winscard): incorrect `SCARD_IO_REQUEST` usage

### DIFF
--- a/crates/ffi-types/src/winscard/functions.rs
+++ b/crates/ffi-types/src/winscard/functions.rs
@@ -1,9 +1,11 @@
 use std::ffi::c_void;
 
 use super::{
-    LpOpenCardNameA, LpOpenCardNameExA, LpOpenCardNameExW, LpOpenCardNameW, LpScardAtrMask, LpScardContext,
-    LpScardHandle, LpScardIoRequest, LpScardReaderStateA, LpScardReaderStateW, ScardContext, ScardHandle, ScardStatus,
+    LpCScardIoRequest, LpOpenCardNameA, LpOpenCardNameExA, LpOpenCardNameExW, LpOpenCardNameW, LpScardAtrMask,
+    LpScardContext, LpScardHandle, LpScardIoRequest, LpScardReaderStateA, LpScardReaderStateW, ScardContext,
+    ScardHandle, ScardStatus,
 };
+use crate::winscard::ScardIoRequest;
 use crate::{
     Handle, LpByte, LpCByte, LpCGuid, LpCStr, LpCVoid, LpCWStr, LpDword, LpGuid, LpStr, LpUuid, LpVoid, LpWStr,
 };
@@ -99,7 +101,7 @@ pub type SCardStatusWFn =
     unsafe extern "system" fn(ScardHandle, LpWStr, LpDword, LpDword, LpDword, LpByte, LpDword) -> ScardStatus;
 pub type SCardTransmitFn = unsafe extern "system" fn(
     ScardHandle,
-    LpScardIoRequest,
+    LpCScardIoRequest,
     LpCByte,
     u32,
     LpScardIoRequest,
@@ -199,6 +201,10 @@ pub struct SCardApiFunctionTable {
     pub SCardListReadersWithDeviceInstanceIdA: SCardListReadersWithDeviceInstanceIdAFn,
     pub SCardListReadersWithDeviceInstanceIdW: SCardListReadersWithDeviceInstanceIdWFn,
     pub SCardAudit: SCardAuditFn,
+
+    pub g_rgSCardT0Pci: &'static ScardIoRequest,
+    pub g_rgSCardT1Pci: &'static ScardIoRequest,
+    pub g_rgSCardRawPci: &'static ScardIoRequest,
 }
 
 pub type PSCardApiFunctionTable = *mut SCardApiFunctionTable;

--- a/crates/ffi-types/src/winscard/mod.rs
+++ b/crates/ffi-types/src/winscard/mod.rs
@@ -97,6 +97,7 @@ pub type LpScardAtrMask = *mut ScardAtrMask;
 ///   DWORD cbPciLength;
 /// } SCARD_IO_REQUEST;
 /// ```
+#[derive(Debug)]
 #[repr(C)]
 pub struct ScardIoRequest {
     pub dw_protocol: u32,
@@ -104,6 +105,7 @@ pub struct ScardIoRequest {
 }
 
 pub type LpScardIoRequest = *mut ScardIoRequest;
+pub type LpCScardIoRequest = *const ScardIoRequest;
 
 /// [OPENCARD_SEARCH_CRITERIAA](https://learn.microsoft.com/en-us/windows/win32/api/winscard/ns-winscard-opencard_search_criteriaa)
 ///

--- a/crates/winscard/src/scard.rs
+++ b/crates/winscard/src/scard.rs
@@ -14,9 +14,7 @@ use sha1::Sha1;
 use crate::card_capability_container::build_ccc;
 use crate::chuid::{build_chuid, CHUID_LENGTH};
 use crate::piv_cert::build_auth_cert;
-use crate::winscard::{
-    AttributeId, ControlCode, IoRequest, Protocol, ReaderAction, ShareMode, TransmitOutData, WinScard,
-};
+use crate::winscard::{AttributeId, ControlCode, Protocol, ReaderAction, ShareMode, TransmitOutData, WinScard};
 use crate::{tlv_tags, winscard, Error, ErrorKind, Response, Status, WinScardResult};
 
 /// [NIST.SP.800-73-4, part 1, section 2.2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=16).
@@ -509,7 +507,7 @@ impl WinScard for SmartCard<'_> {
         Ok(0)
     }
 
-    fn transmit(&mut self, _send_pci: IoRequest, input_apdu: &[u8]) -> WinScardResult<TransmitOutData> {
+    fn transmit(&mut self, input_apdu: &[u8]) -> WinScardResult<TransmitOutData> {
         let Response { status, data } = self.handle_command(input_apdu)?;
 
         let mut output_apdu = data.unwrap_or_default();

--- a/crates/winscard/src/tlv_tags.rs
+++ b/crates/winscard/src/tlv_tags.rs
@@ -1,4 +1,4 @@
-/// BER-TLV with the tag `53` containing in the value field of the
+/// BER-TLV with the tag `0x53` containing in the value field of the
 /// requested data object.
 pub const DATA: u8 = 0x53;
 /// [FASC-N](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf#page=36).

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -630,7 +630,7 @@ pub trait WinScard {
     /// [SCardTransmit](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardtransmit)
     ///
     /// The SCardTransmit function sends a service request to the smart card and expects to receive data back from the card.
-    fn transmit(&mut self, send_pci: IoRequest, input_apdu: &[u8]) -> WinScardResult<TransmitOutData>;
+    fn transmit(&mut self, input_apdu: &[u8]) -> WinScardResult<TransmitOutData>;
 
     /// [SCardBeginTransaction](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardbegintransaction)
     ///

--- a/ffi/src/winscard/mod.rs
+++ b/ffi/src/winscard/mod.rs
@@ -115,5 +115,9 @@ pub extern "system" fn GetSCardApiFunctionTable() -> PSCardApiFunctionTable {
         SCardListReadersWithDeviceInstanceIdA,
         SCardListReadersWithDeviceInstanceIdW,
         SCardAudit,
+
+        g_rgSCardT0Pci: &Rust_g_rgSCardT0Pci,
+        g_rgSCardT1Pci: &Rust_g_rgSCardT1Pci,
+        g_rgSCardRawPci: &Rust_g_rgSCardRawPci,
     })
 }

--- a/ffi/src/winscard/pcsc_lite/functions.rs
+++ b/ffi/src/winscard/pcsc_lite/functions.rs
@@ -190,4 +190,8 @@ pub struct PcscLiteApiFunctionTable {
     pub SCardListReaderGroups: SCardListReaderGroupsFn,
     pub SCardCancel: SCardCancelFn,
     pub SCardIsValidContext: SCardIsValidContextFn,
+
+    pub g_rgSCardT0Pci: *const ScardIoRequest,
+    pub g_rgSCardT1Pci: *const ScardIoRequest,
+    pub g_rgSCardRawPci: *const ScardIoRequest,
 }


### PR DESCRIPTION
Hi,
I this PR I fixed incorrect [`SCARD_IO_REQUEST`](https://learn.microsoft.com/en-us/windows/win32/secauthn/scard-io-request) usage.

The `SCARD_IO_REQUEST` structure contains protocol-specific information. The active smart card communication protocol is negotiated during [`SCardConnect`](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardconnectw) (see `pdwActiveProtocol` parameter).

All `SCARD_IO_REQUEST`s are predefined in WinSCard/PCSC-lite and we can obtain handle to them using the following names `g_rgSCardT0Pci`/`g_rgSCardT1Pci`/`g_rgSCardRawPci`.

So, when calling system provided smart card API via WinSCard/PCSC, we should use the predefined `SCARD_IO_REQUEST` based on the negotiated active protocol.