### PR TITLE
refactor(sspi): fix lifetime anti-pattern in initialize_security_cont…

### DIFF
--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -116,10 +116,14 @@ impl SspiImpl for SspiHandle {
         context.acquire_credentials_handle_impl(builder)
     }
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut sspi::builders::FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
-    ) -> Result<sspi::generator::GeneratorInitSecurityContext<'a>> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut sspi::builders::FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<sspi::generator::GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         let mut context = self.sspi_context.lock()?;
         Ok(context.initialize_security_context_sync(builder).into())
     }

--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -724,10 +724,14 @@ impl SspiImpl for SspiContext {
         }))
     }
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
-    ) -> crate::Result<GeneratorInitSecurityContext<'a>> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> crate::Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         Ok(Generator::new(move |mut yield_point| async move {
             self.initialize_security_context_impl(&mut yield_point, builder).await
         }))

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -345,10 +345,14 @@ impl SspiImpl for SspiCredSsp {
         })
     }
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut builders::FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
-    ) -> Result<GeneratorInitSecurityContext<'a>> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut builders::FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         Ok(GeneratorInitSecurityContext::new(move |mut yield_point| async move {
             self.initialize_security_context_impl(&mut yield_point, builder).await
         }))

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -615,10 +615,14 @@ impl SspiImpl for Kerberos {
         }))
     }
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut crate::builders::FilledInitializeSecurityContext<Self::CredentialsHandle>,
-    ) -> Result<GeneratorInitSecurityContext<'a>> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut crate::builders::FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'b,
+        'b: 'g,
+    {
         Ok(GeneratorInitSecurityContext::new(move |mut yield_point| async move {
             self.initialize_security_context_impl(&mut yield_point, builder).await
         }))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1272,10 +1272,13 @@ pub trait SspiImpl {
         builder: FilledAcquireCredentialsHandle<'_, Self::CredentialsHandle, Self::AuthenticationData>,
     ) -> Result<AcquireCredentialsHandleResult<Self::CredentialsHandle>>;
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut FilledInitializeSecurityContext<'a, Self::CredentialsHandle>,
-    ) -> Result<GeneratorInitSecurityContext<'a>>;
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g;
 
     fn accept_security_context_impl<'a>(
         &'a mut self,

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -532,10 +532,14 @@ impl SspiImpl for Negotiate {
         }))
     }
 
-    fn initialize_security_context_impl<'a>(
-        &'a mut self,
-        builder: &'a mut builders::FilledInitializeSecurityContext<Self::CredentialsHandle>,
-    ) -> Result<GeneratorInitSecurityContext<'a>> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut builders::FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         Ok(GeneratorInitSecurityContext::new(move |mut yield_point| async move {
             self.initialize_security_context_impl(&mut yield_point, builder).await
         }))

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -267,10 +267,14 @@ impl SspiImpl for Ntlm {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip_all)]
-    fn initialize_security_context_impl(
-        &mut self,
-        builder: &mut FilledInitializeSecurityContext<'_, Self::CredentialsHandle>,
-    ) -> crate::Result<GeneratorInitSecurityContext> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> crate::Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         Ok(self.initialize_security_context_impl(builder).into())
     }
 }

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -404,10 +404,14 @@ impl SspiImpl for Pku2u {
         }))
     }
 
-    fn initialize_security_context_impl(
-        &mut self,
-        builder: &mut crate::builders::FilledInitializeSecurityContext<'_, Self::CredentialsHandle>,
-    ) -> Result<GeneratorInitSecurityContext> {
+    fn initialize_security_context_impl<'ctx, 'b, 'g>(
+        &'ctx mut self,
+        builder: &'b mut crate::builders::FilledInitializeSecurityContext<'ctx, Self::CredentialsHandle>,
+    ) -> Result<GeneratorInitSecurityContext<'g>>
+    where
+        'ctx: 'g,
+        'b: 'g,
+    {
         Ok(self.initialize_security_context_impl(builder).into())
     }
 }


### PR DESCRIPTION
…ext_impl

Replace &'a mut Struct<'a> anti-pattern with separate lifetimes for better flexibility. The previous signature forced all lifetimes to be the same, preventing generators from outliving their initialization parameters.

Changes:
- Separate context lifetime ('ctx), builder lifetime ('b), and generator lifetime ('g)
- Add lifetime bounds 'ctx: 'g and 'b: 'g to ensure safety
- Apply changes across all SSPI implementations (NTLM, Kerberos, Negotiate, PKU2U, CredSSP)
- Update trait definition in SspiImpl and FFI wrappers

This allows async generators to be used more flexibly without keeping initialization parameters alive for their entire lifetime.