### PR TITLE
fix!: async network client returns `!Send` future

### DIFF
--- a/ffi/src/dpapi/network_client.rs
+++ b/ffi/src/dpapi/network_client.rs
@@ -9,10 +9,7 @@ use sspi::{Error, ErrorKind, NetworkRequest, Result};
 pub struct SyncNetworkClient;
 
 impl AsyncNetworkClient for SyncNetworkClient {
-    fn send<'a>(
-        &'a mut self,
-        request: &'a NetworkRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'a>> {
+    fn send<'a>(&'a mut self, request: &'a NetworkRequest) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + 'a>> {
         let request = request.clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || ReqwestNetworkClient.send(&request))

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -40,7 +40,7 @@ pub trait AsyncNetworkClient: Send + Sync {
     fn send<'a>(
         &'a mut self,
         network_request: &'a NetworkRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + 'a>>;
 }
 
 pub trait NetworkClient: Send + Sync {


### PR DESCRIPTION
Hi,

I broke the `dpapi-web` compilation in this PR: #457. I was trying to make the `AsyncNetworkClient` work with Devolutions-Gateway, but later I chose another approach. Now we can remove the `Send` bound safely (I checked it: the DG compiles well with this change in `sspi-rs`).

### Why haven't we caught it earlier?

I suppose it is because we do not check this crate on CI. I propose improving the `./tools/wasm-testcompile` to depend on `dpapi-web` and use any of its exported items. What do you think about it?