### PR TITLE
build: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "dpapi"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "aead",
  "aes",


### PR DESCRIPTION
This is preventing the crates from being published by release-plz.