### PR TITLE
chore: get rid of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "dpapi"
-version = "0.3.0"
+version = "0.0.0"
 dependencies = [
  "aead",
  "aes",
@@ -2932,7 +2932,6 @@ dependencies = [
  "getrandom 0.3.3",
  "hickory-resolver",
  "hmac",
- "lazy_static",
  "md-5",
  "md4",
  "num-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ url = "2.5"
 md-5 = "=0.11.0-rc.2"
 md4 = "0.10"
 crypto-mac = "0.11"
-lazy_static = "1.5"
 serde_derive = "1"
 oid = "0.2"
 


### PR DESCRIPTION
We still have it in the dependency tree because it's used in _num-bigint-dig_, which is still used by _picky-asn1-x509_. 