### PR TITLE
refactor: enable `elided_lifetimes_in_paths` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 # == Style, readability == #
 unreachable_pub = "warn"
 single_use_lifetimes = "warn"
+elided_lifetimes_in_paths = "warn"
 
 [workspace.dependencies]
 uuid = { version = "1.18", default-features = false }

--- a/crates/dpapi-core/src/str.rs
+++ b/crates/dpapi-core/src/str.rs
@@ -34,7 +34,7 @@ pub fn from_utf16_le(data: &[u8]) -> DecodeResult<String> {
 /// # Panics
 ///
 /// Panics when cursor's internal buffer doesn't have enough space.
-pub fn encode_utf16_le(data: &str, dst: &mut WriteCursor) {
+pub fn encode_utf16_le(data: &str, dst: &mut WriteCursor<'_>) {
     data.encode_utf16()
         .chain(core::iter::once(0))
         .for_each(|v| dst.write_u16(v));

--- a/crates/dpapi-pdu/src/rpc/bind.rs
+++ b/crates/dpapi-pdu/src/rpc/bind.rs
@@ -98,7 +98,7 @@ impl Encode for SyntaxId {
 }
 
 impl DecodeOwned for SyntaxId {
-    fn decode_owned(src: &mut ReadCursor) -> DecodeResult<Self> {
+    fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
 
         Ok(Self {

--- a/crates/winscard/src/scard.rs
+++ b/crates/winscard/src/scard.rs
@@ -93,7 +93,7 @@ pub struct SmartCard<'a> {
 impl SmartCard<'_> {
     /// Creates a smart card instance based on the provided data.
     pub fn new(
-        reader_name: Cow<str>,
+        reader_name: Cow<'_, str>,
         pin: Vec<u8>,
         auth_cert_der: Vec<u8>,
         auth_pk: PrivateKey,
@@ -486,7 +486,7 @@ enum SCardState {
 }
 
 impl WinScard for SmartCard<'_> {
-    fn status(&self) -> WinScardResult<winscard::Status> {
+    fn status(&self) -> WinScardResult<winscard::Status<'_>> {
         Ok(winscard::Status {
             readers: vec![self.reader_name.clone()],
             // The original winscard always returns SCARD_SPECIFIC for a working inserted card
@@ -551,7 +551,7 @@ impl WinScard for SmartCard<'_> {
         Ok(SUPPORTED_CONNECTION_PROTOCOL)
     }
 
-    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<'_, [u8]>> {
         let data = self.attributes.get(&attribute_id).map(AsRef::as_ref).ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidParameter,
@@ -665,7 +665,7 @@ JLqE3CeRAy9+50HbvOwHae9/K2aOFqddEFaluDodIulcD2zrywVesWoQdjwuj7Dg
     }
 
     // Helper function that calls the GET RESPONSE handler until there is no more data to read
-    fn get_all_available_data(mut response: Response, scard: &mut SmartCard) -> Vec<u8> {
+    fn get_all_available_data(mut response: Response, scard: &mut SmartCard<'_>) -> Vec<u8> {
         let mut complete_response = vec![];
         while let Status::MoreAvailable(bytes_left) = response.status {
             complete_response.extend_from_slice(&response.data.expect("Data should be present"));

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -419,7 +419,7 @@ impl WinScardContext for ScardContext<'_> {
         })
     }
 
-    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<'_, str>>> {
         Ok(vec![self.smart_card_info.reader.name.clone()])
     }
 
@@ -434,7 +434,7 @@ impl WinScardContext for ScardContext<'_> {
         Ok(self.smart_card_info.reader.device_type_id)
     }
 
-    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon> {
+    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon<'_>> {
         if self.smart_card_info.reader.name != reader_name {
             return Err(Error::new(
                 ErrorKind::UnknownReader,
@@ -449,7 +449,7 @@ impl WinScardContext for ScardContext<'_> {
         true
     }
 
-    fn read_cache(&self, _: Uuid, _: u32, key: &str) -> WinScardResult<Cow<[u8]>> {
+    fn read_cache(&self, _: Uuid, _: u32, key: &str) -> WinScardResult<Cow<'_, [u8]>> {
         self.cache
             .get(key)
             .map(|item| Cow::Borrowed(item.as_slice()))
@@ -462,7 +462,7 @@ impl WinScardContext for ScardContext<'_> {
         Ok(())
     }
 
-    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<'_, str>>> {
         // We don't support configuring or introducing reader groups. So, we just return hardcoded values.
         //
         // https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadergroupsw
@@ -479,7 +479,7 @@ impl WinScardContext for ScardContext<'_> {
         Ok(())
     }
 
-    fn get_status_change(&mut self, _timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()> {
+    fn get_status_change(&mut self, _timeout: u32, reader_states: &mut [ReaderState<'_>]) -> WinScardResult<()> {
         use crate::ATR;
 
         let supported_readers = self.list_readers()?;
@@ -502,12 +502,16 @@ impl WinScardContext for ScardContext<'_> {
         Ok(())
     }
 
-    fn list_cards(&self, _atr: Option<&[u8]>, _required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_cards(
+        &self,
+        _atr: Option<&[u8]>,
+        _required_interfaces: Option<&[Uuid]>,
+    ) -> WinScardResult<Vec<Cow<'_, str>>> {
         // we have only one smart card with only one default name
         Ok(vec![DEFAULT_CARD_NAME.into()])
     }
 
-    fn get_card_type_provider_name(&self, _card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<str>> {
+    fn get_card_type_provider_name(&self, _card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<'_, str>> {
         Ok(match provider_id {
             ProviderId::Primary => {
                 return Err(Error::new(

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -611,7 +611,7 @@ pub trait WinScard {
     /// The SCardStatus function provides the current status of a smart card in a reader.
     /// You can call it any time after a successful call to `SCardConnect` and before a successful
     /// call to `SCardDisconnect`. It does not affect the state of the reader or reader driver.
-    fn status(&self) -> WinScardResult<Status>;
+    fn status(&self) -> WinScardResult<Status<'_>>;
 
     /// [SCardControl](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcontrol)
     ///
@@ -660,7 +660,7 @@ pub trait WinScard {
     ///
     /// The SCardGetAttrib function retrieves the current reader attributes for the given handle.
     /// It does not affect the state of the reader, driver, or card.
-    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>>;
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<'_, [u8]>>;
 
     /// [SCardSetAttrib](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardsetattrib)
     ///
@@ -698,13 +698,14 @@ pub trait WinScardContext {
     /// [SCardListReadersW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadersw)
     ///
     /// Provides the list of readers within a set of named reader groups, eliminating duplicates.
-    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>>;
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<'_, str>>>;
 
     /// [SCardListCardsW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistcardsw)
     ///
     /// The SCardListCards function searches the smart card database and provides a list of named cards previously
     /// introduced to the system by the user.
-    fn list_cards(&self, atr: Option<&[u8]>, required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>>;
+    fn list_cards(&self, atr: Option<&[u8]>, required_interfaces: Option<&[Uuid]>)
+        -> WinScardResult<Vec<Cow<'_, str>>>;
 
     /// [SCardGetDeviceTypeIdW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetdevicetypeidw)
     ///
@@ -716,7 +717,7 @@ pub trait WinScardContext {
     ///
     /// The SCardGetReaderIcon function gets an icon of the smart card reader for a given reader's name.
     /// This function does not affect the state of the card reader.
-    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon>;
+    fn reader_icon(&self, reader_name: &str) -> WinScardResult<Icon<'_>>;
 
     /// [SCardIsValidContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardisvalidcontext)
     ///
@@ -726,7 +727,7 @@ pub trait WinScardContext {
     /// [SCardReadCacheW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreadcachew)
     ///
     /// The SCardReadCache function retrieves the value portion of a name-value pair from the global cache maintained by the Smart Card Resource Manager.
-    fn read_cache(&self, card_id: Uuid, freshness_counter: u32, key: &str) -> WinScardResult<Cow<[u8]>>;
+    fn read_cache(&self, card_id: Uuid, freshness_counter: u32, key: &str) -> WinScardResult<Cow<'_, [u8]>>;
 
     /// [SCardWriteCacheW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardwritecachew)
     ///
@@ -737,7 +738,7 @@ pub trait WinScardContext {
     /// [SCardListReaderGroupsW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardlistreadergroupsw)
     ///
     /// The SCardListReaderGroups function provides the list of reader groups that have previously been introduced to the system.
-    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>>;
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<'_, str>>>;
 
     /// [SCardCancel](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardcancel)
     ///
@@ -749,11 +750,11 @@ pub trait WinScardContext {
     /// [SCardGetStatusChangeW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetstatuschangew)
     ///
     /// The SCardGetStatusChange function blocks execution until the current availability of the cards in a specific set of readers changes.
-    fn get_status_change(&mut self, timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()>;
+    fn get_status_change(&mut self, timeout: u32, reader_states: &mut [ReaderState<'_>]) -> WinScardResult<()>;
 
     /// [SCardGetCardTypeProviderNameW](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardgetcardtypeprovidernamew)
     ///
     /// The SCardGetCardTypeProviderName function returns the name of the module (dynamic link library) that contains the provider for
     /// a given card name and provider type.
-    fn get_card_type_provider_name(&self, card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<str>>;
+    fn get_card_type_provider_name(&self, card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<'_, str>>;
 }

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -438,7 +438,7 @@ pub unsafe extern "system" fn DecryptMessage(
 /// *Attention*: after this function call, no one should touch [raw_buffers]. Otherwise, we can get UB.
 /// It's because this function creates exclusive (mutable) Rust references to the input buffers.
 #[allow(clippy::useless_conversion)]
-unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> sspi::Result<Vec<SecurityBufferRef>> {
+unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> sspi::Result<Vec<SecurityBufferRef<'_>>> {
     let mut buffers = Vec::with_capacity(raw_buffers.len());
 
     for raw_buffer in raw_buffers {
@@ -467,7 +467,7 @@ unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> sspi::R
 ///
 /// This function accepts owned [from_buffers] to avoid UB and other errors. Rust-buffers should
 /// not be used after the data is copied into C-buffers.
-unsafe fn copy_decrypted_buffers(to_buffers: PSecBuffer, from_buffers: Vec<SecurityBufferRef>) -> sspi::Result<()> {
+unsafe fn copy_decrypted_buffers(to_buffers: PSecBuffer, from_buffers: Vec<SecurityBufferRef<'_>>) -> sspi::Result<()> {
     // SAFETY: the safety contract [to_buffers] must be upheld by the caller.
     let to_buffers = unsafe { from_raw_parts_mut(to_buffers, from_buffers.len()) };
 

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -130,8 +130,8 @@ impl SspiImpl for SspiHandle {
 
     fn accept_security_context_impl(
         &mut self,
-        builder: sspi::builders::FilledAcceptSecurityContext<Self::CredentialsHandle>,
-    ) -> Result<sspi::generator::GeneratorAcceptSecurityContext> {
+        builder: sspi::builders::FilledAcceptSecurityContext<'_, Self::CredentialsHandle>,
+    ) -> Result<sspi::generator::GeneratorAcceptSecurityContext<'_>> {
         let mut context = self.sspi_context.lock()?;
         Ok(context.accept_security_context_sync(builder).into())
     }
@@ -145,7 +145,7 @@ impl Sspi for SspiHandle {
     fn encrypt_message(
         &mut self,
         flags: sspi::EncryptionFlags,
-        message: &mut [sspi::SecurityBufferRef],
+        message: &mut [sspi::SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> Result<sspi::SecurityStatus> {
         self.sspi_context
@@ -155,7 +155,7 @@ impl Sspi for SspiHandle {
 
     fn decrypt_message(
         &mut self,
-        message: &mut [sspi::SecurityBufferRef],
+        message: &mut [sspi::SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> Result<sspi::DecryptionFlags> {
         self.sspi_context.lock()?.decrypt_message(message, sequence_number)
@@ -208,7 +208,7 @@ impl Sspi for SspiHandle {
     fn make_signature(
         &mut self,
         _flags: u32,
-        _message: &mut [sspi::SecurityBufferRef],
+        _message: &mut [sspi::SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> Result<()> {
         Err(Error::new(
@@ -217,7 +217,7 @@ impl Sspi for SspiHandle {
         ))
     }
 
-    fn verify_signature(&mut self, _message: &mut [sspi::SecurityBufferRef], _sequence_number: u32) -> Result<u32> {
+    fn verify_signature(&mut self, _message: &mut [sspi::SecurityBufferRef<'_>], _sequence_number: u32) -> Result<u32> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "verify_signature is not supported",

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -74,7 +74,7 @@ pub(super) unsafe fn build_buf_request_type_wide<'data>(
 }
 
 /// Saves the resulting data after the [RequestedBufferType] processing.
-pub(super) unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
+pub(super) unsafe fn save_out_buf(out_buf: OutBuffer<'_>, p_buf: LpByte, pcb_buf: LpDword) -> WinScardResult<()> {
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }
@@ -120,7 +120,7 @@ pub(super) unsafe fn save_out_buf(out_buf: OutBuffer, p_buf: LpByte, pcb_buf: Lp
 /// This function behaves as the [save_out_buf] but here it expects a pointer
 /// to the `u16` buffer instead of `u8`. So, the buffer length is divided by two.
 #[instrument(level = "debug", ret)]
-pub(super) unsafe fn save_out_buf_wide(out_buf: OutBuffer, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
+pub(super) unsafe fn save_out_buf_wide(out_buf: OutBuffer<'_>, p_buf: LpWStr, pcb_buf: LpDword) -> WinScardResult<()> {
     if pcb_buf.is_null() {
         return Err(Error::new(ErrorKind::InvalidParameter, "pcb_buf cannot be null"));
     }

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -111,8 +111,8 @@ impl WinScardContextHandle {
     pub(super) fn get_reader_icon(
         &mut self,
         reader: &str,
-        buffer_type: RequestedBufferType,
-    ) -> WinScardResult<OutBuffer> {
+        buffer_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<OutBuffer<'_>> {
         let reader_icon = self.scard_context.reader_icon(reader)?.as_ref().to_vec();
 
         self.write_to_out_buf(&reader_icon, buffer_type)
@@ -120,7 +120,7 @@ impl WinScardContextHandle {
 
     /// Lists readers.
     #[instrument(level = "debug", ret)]
-    pub(super) fn list_readers(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
+    pub(super) fn list_readers(&mut self, buffer_type: RequestedBufferType<'_>) -> WinScardResult<OutBuffer<'_>> {
         let readers: Vec<_> = self
             .scard_context()
             .list_readers()?
@@ -133,7 +133,7 @@ impl WinScardContextHandle {
 
     /// Lists readers but the resulting buffers contain wide strings.
     #[instrument(level = "debug", ret)]
-    pub(super) fn list_readers_wide(&mut self, buffer_type: RequestedBufferType) -> WinScardResult<OutBuffer> {
+    pub(super) fn list_readers_wide(&mut self, buffer_type: RequestedBufferType<'_>) -> WinScardResult<OutBuffer<'_>> {
         let readers: Vec<_> = self
             .scard_context()
             .list_readers()?
@@ -150,8 +150,8 @@ impl WinScardContextHandle {
         &mut self,
         atr: Option<&[u8]>,
         required_interfaces: Option<&[Uuid]>,
-        buffer_type: RequestedBufferType,
-    ) -> WinScardResult<OutBuffer> {
+        buffer_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<OutBuffer<'_>> {
         let cards: Vec<_> = self
             .scard_context()
             .list_cards(atr, required_interfaces)?
@@ -168,8 +168,8 @@ impl WinScardContextHandle {
         &mut self,
         atr: Option<&[u8]>,
         required_interfaces: Option<&[Uuid]>,
-        buffer_type: RequestedBufferType,
-    ) -> WinScardResult<OutBuffer> {
+        buffer_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<OutBuffer<'_>> {
         let cards: Vec<_> = self
             .scard_context()
             .list_cards(atr, required_interfaces)?
@@ -187,8 +187,8 @@ impl WinScardContextHandle {
         card_id: Uuid,
         freshness_counter: u32,
         key: &str,
-        buffer_type: RequestedBufferType,
-    ) -> WinScardResult<OutBuffer> {
+        buffer_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<OutBuffer<'_>> {
         let cached_value = self
             .scard_context()
             .read_cache(card_id, freshness_counter, key)?
@@ -202,7 +202,7 @@ impl WinScardContextHandle {
     pub(super) fn write_multi_string(
         &mut self,
         values: &[String],
-        buffer_type: RequestedBufferType,
+        buffer_type: RequestedBufferType<'_>,
     ) -> WinScardResult<OutBuffer<'static>> {
         let data: Vec<_> = values
             .iter()
@@ -219,7 +219,7 @@ impl WinScardContextHandle {
     pub(super) fn write_multi_string_wide(
         &mut self,
         values: &[String],
-        buffer_type: RequestedBufferType,
+        buffer_type: RequestedBufferType<'_>,
     ) -> WinScardResult<OutBuffer<'static>> {
         let data: Vec<_> = values
             .iter()
@@ -234,7 +234,7 @@ impl WinScardContextHandle {
     pub(super) fn write_to_out_buf(
         &mut self,
         data: &[u8],
-        buffer_type: RequestedBufferType,
+        buffer_type: RequestedBufferType<'_>,
     ) -> WinScardResult<OutBuffer<'static>> {
         Ok(match buffer_type {
             RequestedBufferType::Buf(buf) => {
@@ -380,8 +380,8 @@ impl WinScardHandle {
     pub(super) fn get_attribute(
         &self,
         attribute_id: AttributeId,
-        buffer_type: RequestedBufferType,
-    ) -> WinScardResult<OutBuffer> {
+        buffer_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<OutBuffer<'_>> {
         let data = self.scard().get_attribute(attribute_id)?;
 
         self.context()?.write_to_out_buf(data.as_ref(), buffer_type)
@@ -391,9 +391,9 @@ impl WinScardHandle {
     #[instrument(level = "debug", ret)]
     pub(super) fn status(
         &mut self,
-        readers_buf_type: RequestedBufferType,
-        atr_but_type: RequestedBufferType,
-    ) -> WinScardResult<FfiScardStatus> {
+        readers_buf_type: RequestedBufferType<'_>,
+        atr_but_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<FfiScardStatus<'_>> {
         let status = self.scard().status()?;
         let readers: Vec<_> = status.readers.into_iter().map(|r| r.to_string()).collect();
         let context = self.context()?;
@@ -413,9 +413,9 @@ impl WinScardHandle {
     #[instrument(level = "debug", ret)]
     pub(super) fn status_wide(
         &mut self,
-        readers_buf_type: RequestedBufferType,
-        atr_but_type: RequestedBufferType,
-    ) -> WinScardResult<FfiScardStatus> {
+        readers_buf_type: RequestedBufferType<'_>,
+        atr_but_type: RequestedBufferType<'_>,
+    ) -> WinScardResult<FfiScardStatus<'_>> {
         let status = self.scard().status()?;
         let readers: Vec<_> = status.readers.into_iter().map(|r| r.to_string()).collect();
         let context = self.context()?;

--- a/ffi/src/winscard/system_scard/card.rs
+++ b/ffi/src/winscard/system_scard/card.rs
@@ -111,7 +111,7 @@ impl fmt::Debug for SystemScard {
 
 impl WinScard for SystemScard {
     #[instrument(ret)]
-    fn status(&self) -> WinScardResult<Status> {
+    fn status(&self) -> WinScardResult<Status<'_>> {
         // macOS PC/SC framework doesn't support `SCARD_AUTOALLOCATE` option, so we use preallocated buffer for reader name.
         let mut reader_name = vec![0; 1024];
         let mut reader_name_len = 1024;
@@ -352,7 +352,7 @@ impl WinScard for SystemScard {
         .unwrap_or_default())
     }
 
-    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<[u8]>> {
+    fn get_attribute(&self, attribute_id: AttributeId) -> WinScardResult<Cow<'_, [u8]>> {
         let attr_id = attribute_id
             .to_u32()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "cannot convert AttributeId -> u32"))?;

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -518,7 +518,7 @@ impl WinScardContext for SystemScardContext {
         Ok(ScardConnectData { handle, protocol })
     }
 
-    fn list_readers(&self) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_readers(&self) -> WinScardResult<Vec<Cow<'_, str>>> {
         let mut readers_buf_len = 0;
 
         #[cfg(not(target_os = "windows"))]
@@ -612,7 +612,7 @@ impl WinScardContext for SystemScardContext {
         }
     }
 
-    fn reader_icon(&self, _reader_name: &str) -> WinScardResult<Icon> {
+    fn reader_icon(&self, _reader_name: &str) -> WinScardResult<Icon<'_>> {
         #[cfg(not(target_os = "windows"))]
         {
             use winscard::SmartCardInfo;
@@ -674,7 +674,7 @@ impl WinScardContext for SystemScardContext {
     }
 
     #[instrument(ret)]
-    fn read_cache(&self, _card_id: Uuid, _freshness_counter: u32, key: &str) -> WinScardResult<Cow<[u8]>> {
+    fn read_cache(&self, _card_id: Uuid, _freshness_counter: u32, key: &str) -> WinScardResult<Cow<'_, [u8]>> {
         #[cfg(not(target_os = "windows"))]
         {
             self.cache
@@ -779,7 +779,7 @@ impl WinScardContext for SystemScardContext {
         }
     }
 
-    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_reader_groups(&self) -> WinScardResult<Vec<Cow<'_, str>>> {
         let mut reader_groups_buf_len = 0;
 
         #[cfg(not(target_os = "windows"))]
@@ -851,7 +851,7 @@ impl WinScardContext for SystemScardContext {
     }
 
     #[instrument(ret)]
-    fn get_status_change(&mut self, timeout: u32, reader_states: &mut [ReaderState]) -> WinScardResult<()> {
+    fn get_status_change(&mut self, timeout: u32, reader_states: &mut [ReaderState<'_>]) -> WinScardResult<()> {
         use std::ffi::NulError;
 
         #[cfg(target_os = "windows")]
@@ -923,7 +923,11 @@ impl WinScardContext for SystemScardContext {
         Ok(())
     }
 
-    fn list_cards(&self, _atr: Option<&[u8]>, _required_interfaces: Option<&[Uuid]>) -> WinScardResult<Vec<Cow<str>>> {
+    fn list_cards(
+        &self,
+        _atr: Option<&[u8]>,
+        _required_interfaces: Option<&[Uuid]>,
+    ) -> WinScardResult<Vec<Cow<'_, str>>> {
         #[cfg(not(target_os = "windows"))]
         {
             Ok(vec![Cow::Borrowed(DEFAULT_CARD_NAME)])
@@ -979,7 +983,7 @@ impl WinScardContext for SystemScardContext {
         }
     }
 
-    fn get_card_type_provider_name(&self, _card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<str>> {
+    fn get_card_type_provider_name(&self, _card_name: &str, provider_id: ProviderId) -> WinScardResult<Cow<'_, str>> {
         #[cfg(not(target_os = "windows"))]
         {
             Ok(match provider_id {

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -155,7 +155,7 @@ impl Sspi for SspiCredSsp {
     fn encrypt_message(
         &mut self,
         _flags: EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> Result<SecurityStatus> {
         // CredSsp decrypt_message function just calls corresponding function from the Schannel
@@ -189,7 +189,11 @@ impl Sspi for SspiCredSsp {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self, _sequence_number))]
-    fn decrypt_message(&mut self, message: &mut [SecurityBufferRef], _sequence_number: u32) -> Result<DecryptionFlags> {
+    fn decrypt_message(
+        &mut self,
+        message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> Result<DecryptionFlags> {
         // CredSsp decrypt_message function just calls corresponding function from the Schannel
         // MSDN: message must contain four buffers
         // https://learn.microsoft.com/en-us/windows/win32/secauthn/decryptmessage--schannel
@@ -293,7 +297,10 @@ impl Sspi for SspiCredSsp {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip_all)]
-    fn change_password(&mut self, _change_password: builders::ChangePassword) -> Result<GeneratorChangePassword> {
+    fn change_password(
+        &mut self,
+        _change_password: builders::ChangePassword<'_>,
+    ) -> Result<GeneratorChangePassword<'_>> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "ChangePassword is not supported in SspiCredSsp context",
@@ -304,7 +311,7 @@ impl Sspi for SspiCredSsp {
     fn make_signature(
         &mut self,
         _flags: u32,
-        _message: &mut [SecurityBufferRef],
+        _message: &mut [SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> crate::Result<()> {
         Err(Error::new(
@@ -314,7 +321,11 @@ impl Sspi for SspiCredSsp {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip_all)]
-    fn verify_signature(&mut self, _message: &mut [SecurityBufferRef], _sequence_number: u32) -> crate::Result<u32> {
+    fn verify_signature(
+        &mut self,
+        _message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> crate::Result<u32> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "verify_signature is not supported",

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -121,7 +121,7 @@ where
     }
 }
 
-fn execute_one_step<OutTy>(task: &mut PinnedFuture<OutTy>) -> Option<OutTy> {
+fn execute_one_step<OutTy>(task: &mut PinnedFuture<'_, OutTy>) -> Option<OutTy> {
     struct NoopWake;
 
     impl Wake for NoopWake {

--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -156,7 +156,7 @@ pub struct GenerateAsPaDataOptions<'a> {
 }
 
 #[instrument(level = "trace", ret, skip_all, fields(options.salt, options.enc_params, options.with_pre_auth))]
-pub fn generate_pa_datas_for_as_req(options: &GenerateAsPaDataOptions) -> Result<Vec<PaData>> {
+pub fn generate_pa_datas_for_as_req(options: &GenerateAsPaDataOptions<'_>) -> Result<Vec<PaData>> {
     let GenerateAsPaDataOptions {
         password,
         salt,
@@ -227,7 +227,7 @@ pub struct GenerateAsReqOptions<'a> {
 }
 
 #[instrument(level = "trace", ret)]
-pub fn generate_as_req_kdc_body(options: &GenerateAsReqOptions) -> Result<KdcReqBody> {
+pub fn generate_as_req_kdc_body(options: &GenerateAsReqOptions<'_>) -> Result<KdcReqBody> {
     let GenerateAsReqOptions {
         realm,
         username,
@@ -318,7 +318,7 @@ pub struct GenerateTgsReqOptions<'a> {
 }
 
 #[instrument(level = "debug", ret)]
-pub fn generate_tgs_req(options: GenerateTgsReqOptions) -> Result<TgsReq> {
+pub fn generate_tgs_req(options: GenerateTgsReqOptions<'_>) -> Result<TgsReq> {
     let GenerateTgsReqOptions {
         realm,
         service_principal,
@@ -571,7 +571,7 @@ pub struct GenerateAuthenticatorOptions<'a> {
 
 /// Generated ApReq Authenticator.
 #[instrument(level = "trace", ret)]
-pub fn generate_authenticator(options: GenerateAuthenticatorOptions) -> Result<Authenticator> {
+pub fn generate_authenticator(options: GenerateAuthenticatorOptions<'_>) -> Result<Authenticator> {
     let GenerateAuthenticatorOptions {
         kdc_rep,
         seq_num,

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -258,7 +258,7 @@ impl Sspi for Kerberos {
     fn encrypt_message(
         &mut self,
         _flags: crate::EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> Result<SecurityStatus> {
         trace!(encryption_params = ?self.encryption_params);
@@ -381,7 +381,11 @@ impl Sspi for Kerberos {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self, _sequence_number))]
-    fn decrypt_message(&mut self, message: &mut [SecurityBufferRef], _sequence_number: u32) -> Result<DecryptionFlags> {
+    fn decrypt_message(
+        &mut self,
+        message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> Result<DecryptionFlags> {
         trace!(encryption_params = ?self.encryption_params);
 
         let encrypted = extract_encrypted_data(message)?;
@@ -568,7 +572,7 @@ impl Sspi for Kerberos {
     fn make_signature(
         &mut self,
         _flags: u32,
-        _message: &mut [SecurityBufferRef],
+        _message: &mut [SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> crate::Result<()> {
         Err(Error::new(
@@ -577,7 +581,11 @@ impl Sspi for Kerberos {
         ))
     }
 
-    fn verify_signature(&mut self, _message: &mut [SecurityBufferRef], _sequence_number: u32) -> crate::Result<u32> {
+    fn verify_signature(
+        &mut self,
+        _message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> crate::Result<u32> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "verify_signature is not supported. use decrypt_message to verify signatures instead",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,7 +607,7 @@ where
     fn encrypt_message(
         &mut self,
         flags: EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> Result<SecurityStatus>;
 
@@ -719,7 +719,7 @@ where
     fn make_signature(
         &mut self,
         flags: u32,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> crate::Result<()>;
 
@@ -835,7 +835,7 @@ where
     ///
     /// # MSDN
     /// * [VerifySignature function](https://learn.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-verifysignature)
-    fn verify_signature(&mut self, message: &mut [SecurityBufferRef], sequence_number: u32) -> crate::Result<u32>;
+    fn verify_signature(&mut self, message: &mut [SecurityBufferRef<'_>], sequence_number: u32) -> crate::Result<u32>;
 
     /// Decrypts a message. Some packages do not encrypt and decrypt messages but rather perform and check an integrity hash.
     ///
@@ -953,7 +953,11 @@ where
     /// # MSDN
     ///
     /// * [DecryptMessage function](https://docs.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-decryptmessage)
-    fn decrypt_message(&mut self, message: &mut [SecurityBufferRef], sequence_number: u32) -> Result<DecryptionFlags>;
+    fn decrypt_message(
+        &mut self,
+        message: &mut [SecurityBufferRef<'_>],
+        sequence_number: u32,
+    ) -> Result<DecryptionFlags>;
 
     /// Retrieves information about the bounds of sizes of authentication information of the current security principal.
     ///

--- a/src/negotiate.rs
+++ b/src/negotiate.rs
@@ -350,7 +350,7 @@ impl Sspi for Negotiate {
     fn encrypt_message(
         &mut self,
         flags: crate::EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> Result<SecurityStatus> {
         match &mut self.protocol {
@@ -435,7 +435,7 @@ impl Sspi for Negotiate {
     fn make_signature(
         &mut self,
         flags: u32,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> crate::Result<()> {
         match &mut self.protocol {
@@ -445,7 +445,7 @@ impl Sspi for Negotiate {
         }
     }
 
-    fn verify_signature(&mut self, message: &mut [SecurityBufferRef], sequence_number: u32) -> crate::Result<u32> {
+    fn verify_signature(&mut self, message: &mut [SecurityBufferRef<'_>], sequence_number: u32) -> crate::Result<u32> {
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => pku2u.verify_signature(message, sequence_number),
             NegotiatedProtocol::Kerberos(kerberos) => kerberos.verify_signature(message, sequence_number),

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -387,7 +387,7 @@ impl Ntlm {
 
     fn compute_checksum(
         &mut self,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
         digest: &[u8; 16],
     ) -> crate::Result<()> {
@@ -436,7 +436,7 @@ impl Sspi for Ntlm {
     fn encrypt_message(
         &mut self,
         _flags: EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> crate::Result<SecurityStatus> {
         if self.send_sealing_key.is_none() {
@@ -474,7 +474,7 @@ impl Sspi for Ntlm {
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self, sequence_number))]
     fn decrypt_message(
         &mut self,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> crate::Result<DecryptionFlags> {
         if self.recv_sealing_key.is_none() {
@@ -570,8 +570,8 @@ impl Sspi for Ntlm {
 
     fn change_password(
         &mut self,
-        _: crate::builders::ChangePassword,
-    ) -> crate::Result<crate::generator::GeneratorChangePassword> {
+        _: crate::builders::ChangePassword<'_>,
+    ) -> crate::Result<crate::generator::GeneratorChangePassword<'_>> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "NTLM does not support change pasword",
@@ -581,7 +581,7 @@ impl Sspi for Ntlm {
     fn make_signature(
         &mut self,
         _flags: u32,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> crate::Result<()> {
         if self.send_sealing_key.is_none() {
@@ -598,7 +598,7 @@ impl Sspi for Ntlm {
         Ok(())
     }
 
-    fn verify_signature(&mut self, message: &mut [SecurityBufferRef], sequence_number: u32) -> crate::Result<u32> {
+    fn verify_signature(&mut self, message: &mut [SecurityBufferRef<'_>], sequence_number: u32) -> crate::Result<u32> {
         if self.recv_sealing_key.is_none() {
             self.complete_auth_token(&mut [])?;
         }

--- a/src/pku2u/generators.rs
+++ b/src/pku2u/generators.rs
@@ -210,7 +210,7 @@ pub fn generate_authenticator_extension(key: &[u8], payload: &[u8]) -> Result<Au
 }
 
 #[instrument(level = "trace", ret)]
-pub fn generate_authenticator(options: GenerateAuthenticatorOptions) -> Result<Authenticator> {
+pub fn generate_authenticator(options: GenerateAuthenticatorOptions<'_>) -> Result<Authenticator> {
     let GenerateAuthenticatorOptions {
         kdc_rep,
         seq_num,

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -199,7 +199,7 @@ impl Sspi for Pku2u {
     fn encrypt_message(
         &mut self,
         _flags: EncryptionFlags,
-        message: &mut [SecurityBufferRef],
+        message: &mut [SecurityBufferRef<'_>],
         sequence_number: u32,
     ) -> Result<SecurityStatus> {
         trace!(encryption_params = ?self.encryption_params);
@@ -259,7 +259,11 @@ impl Sspi for Pku2u {
     }
 
     #[instrument(level = "debug", ret, fields(state = ?self.state), skip(self, _sequence_number))]
-    fn decrypt_message(&mut self, message: &mut [SecurityBufferRef], _sequence_number: u32) -> Result<DecryptionFlags> {
+    fn decrypt_message(
+        &mut self,
+        message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> Result<DecryptionFlags> {
         trace!(encryption_params = ?self.encryption_params);
 
         let encrypted = extract_encrypted_data(message)?;
@@ -346,7 +350,7 @@ impl Sspi for Pku2u {
         })
     }
 
-    fn change_password(&mut self, _: ChangePassword) -> Result<crate::generator::GeneratorChangePassword> {
+    fn change_password(&mut self, _: ChangePassword<'_>) -> Result<crate::generator::GeneratorChangePassword<'_>> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "Pku2u does not support change pasword",
@@ -356,7 +360,7 @@ impl Sspi for Pku2u {
     fn make_signature(
         &mut self,
         _flags: u32,
-        _message: &mut [SecurityBufferRef],
+        _message: &mut [SecurityBufferRef<'_>],
         _sequence_number: u32,
     ) -> crate::Result<()> {
         Err(Error::new(
@@ -365,7 +369,11 @@ impl Sspi for Pku2u {
         ))
     }
 
-    fn verify_signature(&mut self, _message: &mut [SecurityBufferRef], _sequence_number: u32) -> crate::Result<u32> {
+    fn verify_signature(
+        &mut self,
+        _message: &mut [SecurityBufferRef<'_>],
+        _sequence_number: u32,
+    ) -> crate::Result<u32> {
         Err(Error::new(
             ErrorKind::UnsupportedFunction,
             "verify_signature is not supported",

--- a/src/security_buffer.rs
+++ b/src/security_buffer.rs
@@ -36,7 +36,7 @@ pub struct SecurityBufferRef<'data> {
 
 impl<'data> SecurityBufferRef<'data> {
     /// Creates a [SecurityBufferRef] with a `Data` buffer type and empty buffer flags.
-    pub fn data_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn data_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::Data(data),
             buffer_flags: Default::default(),
@@ -44,7 +44,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `Token` buffer type and empty buffer flags.
-    pub fn token_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn token_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::Token(data),
             buffer_flags: Default::default(),
@@ -52,7 +52,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `StreamHeader` buffer type and empty buffer flags.
-    pub fn stream_header_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn stream_header_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::StreamHeader(data),
             buffer_flags: Default::default(),
@@ -60,7 +60,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `StreamTrailer` buffer type and empty buffer flags.
-    pub fn stream_trailer_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn stream_trailer_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::StreamTrailer(data),
             buffer_flags: Default::default(),
@@ -68,7 +68,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `Stream` buffer type and empty buffer flags.
-    pub fn stream_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn stream_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::Stream(data),
             buffer_flags: Default::default(),
@@ -76,7 +76,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `Extra` buffer type and empty buffer flags.
-    pub fn extra_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn extra_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::Extra(data),
             buffer_flags: Default::default(),
@@ -84,7 +84,7 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Creates a [SecurityBufferRef] with a `Padding` buffer type and empty buffer flags.
-    pub fn padding_buf(data: &mut [u8]) -> SecurityBufferRef {
+    pub fn padding_buf(data: &mut [u8]) -> SecurityBufferRef<'_> {
         SecurityBufferRef {
             buffer_type: UnflaggedSecurityBuffer::Padding(data),
             buffer_flags: Default::default(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -254,7 +254,7 @@ pub(crate) fn get_encryption_key(enc_params: &EncryptionParams) -> Result<&[u8]>
 ///   But in such a case, the `SECBUFFER_DATA` buffer is empty. So, we take the inner buffer from
 ///   the `SECBUFFER_STREAM` buffer, write decrypted data into it, and assign it to the `SECBUFFER_DATA` buffer.
 /// * If the `SECBUFFER_STREAM` is not present, we should just save all data in the `SECBUFFER_DATA` buffer.
-pub(crate) fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [SecurityBufferRef]) -> Result<()> {
+pub(crate) fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [SecurityBufferRef<'_>]) -> Result<()> {
     if let Ok(buffer) = SecurityBufferRef::find_buffer_mut(buffers, BufferType::Stream) {
         let decrypted_len = decrypted.len();
 
@@ -306,7 +306,7 @@ pub(crate) fn save_decrypted_data<'a>(decrypted: &'a [u8], buffers: &'a mut [Sec
 /// Extracts data to decrypt from the incoming buffers.
 ///
 /// Data to decrypt is `Token` + `Stream`/`Data` buffers concatenated together.
-pub(crate) fn extract_encrypted_data(buffers: &[SecurityBufferRef]) -> Result<Vec<u8>> {
+pub(crate) fn extract_encrypted_data(buffers: &[SecurityBufferRef<'_>]) -> Result<Vec<u8>> {
     let mut encrypted = SecurityBufferRef::buf_data(buffers, BufferType::Token)
         .unwrap_or_default()
         .to_vec();


### PR DESCRIPTION
> The `elided_lifetimes_in_paths` lint detects the use of hidden lifetime parameters.
>
> Elided lifetime parameters can make it difficult to see at a glance that borrowing is occurring. This lint ensures that lifetime parameters are always explicitly stated, even if it is the `'_` [placeholder lifetime](https://doc.rust-lang.org/reference/lifetime-elision.html#lifetime-elision-in-functions).

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetimes-in-paths