### PR TITLE
refactor: enable `single_use_lifetimes` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 # == Style, readability == #
 unreachable_pub = "warn"
+single_use_lifetimes = "warn"
 
 [workspace.dependencies]
 uuid = { version = "1.18", default-features = false }

--- a/src/builders/accept_sec_context.rs
+++ b/src/builders/accept_sec_context.rs
@@ -226,7 +226,7 @@ impl<
     }
 }
 
-impl<'b, 'a: 'b, CredsHandle> FilledAcceptSecurityContext<'a, CredsHandle> {
+impl<'b, CredsHandle> FilledAcceptSecurityContext<'b, CredsHandle> {
     /// Transforms the builder into new one with the other `AuthData` and `CredsHandle` types.
     /// Useful when we need to pass the builder into the security package with other `AuthData` and `CredsHandle` types.
     pub(crate) fn full_transform<CredsHandle2>(

--- a/src/builders/acq_cred_handle.rs
+++ b/src/builders/acq_cred_handle.rs
@@ -138,7 +138,7 @@ where
     }
 }
 
-impl<'b, 'a: 'b, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'a, CredsHandle, AuthData> {
+impl<'b, CredsHandle, AuthData> FilledAcquireCredentialsHandle<'b, CredsHandle, AuthData> {
     /// Transforms the builder into new one with the other `AuthData` and `CredsHandle` types.
     /// Useful when we need to pass the builder into the security package with other `AuthData` and `CredsHandle` types.
     pub(crate) fn full_transform<NewCredsHandle, NewAuthData>(

--- a/src/builders/init_sec_context.rs
+++ b/src/builders/init_sec_context.rs
@@ -73,6 +73,10 @@ pub struct InitializeSecurityContext<
     pub input: Option<&'a mut [SecurityBuffer]>,
 }
 
+// We allow it here because the crate does not compile with single lifetime.
+// The whole purpose of the `'a` lifetime is to allow the user to construct a new builder (via `full_transform` method)
+// with a different lifetime for `credentials_handle` field.
+#[allow(single_use_lifetimes)]
 impl<
         'b,
         'a: 'b,
@@ -92,6 +96,7 @@ impl<
     >
 {
     /// Creates a new builder with the other `AuthData` and `CredsHandle` types.
+    ///
     /// References to the input and output buffers will be moved to the created builder leaving the `None` instead.
     pub fn full_transform<CredsHandle2, CredHandleSet2: ToAssign>(
         &mut self,

--- a/src/credssp/sspi_cred_ssp/mod.rs
+++ b/src/credssp/sspi_cred_ssp/mod.rs
@@ -388,10 +388,10 @@ impl SspiCredSsp {
 
     #[instrument(ret, level = "debug", fields(state = ?self.state), skip_all)]
     #[async_recursion]
-    pub(crate) async fn initialize_security_context_impl<'a>(
+    pub(crate) async fn initialize_security_context_impl(
         &mut self,
         yield_point: &mut YieldPointLocal,
-        builder: &mut builders::FilledInitializeSecurityContext<'a, <Self as SspiImpl>::CredentialsHandle>,
+        builder: &mut builders::FilledInitializeSecurityContext<'_, <Self as SspiImpl>::CredentialsHandle>,
     ) -> Result<InitializeSecurityContextResult> {
         trace!(?builder);
         // In the CredSSP we always set DELEGATE flag

--- a/src/security_buffer.rs
+++ b/src/security_buffer.rs
@@ -349,8 +349,8 @@ impl<'data> SecurityBufferRef<'data> {
     }
 
     /// Returns the mutable reference to the inner buffer data leaving the empty buffer on its place.
-    pub fn take_buf_data_mut<'a>(
-        buffers: &'a mut [SecurityBufferRef<'data>],
+    pub fn take_buf_data_mut(
+        buffers: &mut [SecurityBufferRef<'data>],
         buffer_type: BufferType,
     ) -> Result<&'data mut [u8]> {
         Ok(SecurityBufferRef::find_buffer_mut(buffers, buffer_type)?.take_data())


### PR DESCRIPTION
> The `single_use_lifetimes` lint detects lifetimes that are only used once.
>
> Specifying an explicit lifetime like `'a` in a function or `impl` should only be used to link together two things. Otherwise, you should just use `'_` to indicate that the lifetime is not linked to anything, or elide the lifetime altogether if possible.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html?highlight=single_use_lifetimes#single-use-lifetimes