### PR TITLE
refactor: enable `unused_lifetimes`, `redundant_lifetimes`, and `trivial_numeric_casts` lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 unreachable_pub = "warn"
 single_use_lifetimes = "warn"
 elided_lifetimes_in_paths = "warn"
+unused_lifetimes = "warn"
+redundant_lifetimes = "warn"
+trivial_numeric_casts = "warn"
 
 [workspace.dependencies]
 uuid = { version = "1.18", default-features = false }

--- a/src/pku2u/cert_utils/win_extraction.rs
+++ b/src/pku2u/cert_utils/win_extraction.rs
@@ -183,7 +183,7 @@ unsafe fn export_certificate_private_key(cert: *const CERT_CONTEXT) -> Result<Pr
     // https://learn.microsoft.com/en-us/windows/win32/api/ncrypt/nf-ncrypt-ncryptexportkey
     // If pbOutput parameter is NULL, this function will place the required size in the pcbResult parameter.
     let status = NCryptExportKey(
-        private_key_handle as _,
+        private_key_handle,
         0,
         BCRYPT_RSAFULLPRIVATE_BLOB,
         null(),
@@ -231,7 +231,7 @@ unsafe fn export_certificate_private_key(cert: *const CERT_CONTEXT) -> Result<Pr
     let mut private_key_blob = vec![0; private_key_buffer_len as usize];
 
     let status = NCryptExportKey(
-        private_key_handle as _,
+        private_key_handle,
         0,
         BCRYPT_RSAFULLPRIVATE_BLOB,
         null(),


### PR DESCRIPTION
> The `unused_lifetimes` lint detects lifetime parameters that are never used.
>
> Unused lifetime parameters may signal a mistake or unfinished code. Consider removing the parameter.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-lifetimes

> The `redundant_lifetimes` lint detects lifetime parameters that are redundant because they are equal to another named lifetime.
>
> Unused lifetime parameters may signal a mistake or unfinished code. Consider removing the parameter.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#redundant-lifetimes

> The `trivial_numeric_casts` lint detects trivial numeric casts of types which could be removed.
>
> A trivial numeric cast is a cast of a numeric type to the same numeric type. This type of cast is usually unnecessary.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#trivial-numeric-casts