### PR TITLE
feat: implement `Default` for `SmartCardType`

### DIFF
--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -284,6 +284,14 @@ mod scard_credentials {
         WindowsNative,
     }
 
+    impl Default for SmartCardType {
+        fn default() -> Self {
+            Self::Emulated {
+                scard_pin: Secret::default(),
+            }
+        }
+    }
+
     /// Represents raw data needed for smart card authentication
     #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct SmartCardIdentityBuffers {


### PR DESCRIPTION
For use in [ironrdp_connector::credssp::CredSspSequence](https://github.com/Devolutions/IronRDP/pull/1028/files#diff-53ac0bab5ebaba1641334a689af83fc8bed484c7500d4aef5afa3e6cc11bd07cR130-R132)