### PR TITLE
revert: implement `Default` for `SmartCardType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [[0.18.2](https://github.com/Devolutions/sspi-rs/compare/sspi-v0.18.1...sspi-v0.18.2)] - 2025-11-04
+## [[0.18.2](https://github.com/Devolutions/sspi-rs/compare/sspi-v0.18.1...sspi-v0.18.2)] - 2025-11-04 (Yanked)
 
 ### <!-- 1 -->Features
 

--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -284,14 +284,6 @@ mod scard_credentials {
         WindowsNative,
     }
 
-    impl Default for SmartCardType {
-        fn default() -> Self {
-            Self::Emulated {
-                scard_pin: Secret::default(),
-            }
-        }
-    }
-
     /// Represents raw data needed for smart card authentication
     #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct SmartCardIdentityBuffers {


### PR DESCRIPTION
It actually does not make sense to implement Default for SmartCardType. A user-provided PIN must be set.

Release 0.18.2 was yanked.

Refs: 3555b377e8aeb5a8c376b2ecec9dcb1a2fd79560