### PR TITLE
refactor: enable `ambiguous_negative_literals` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ exclude = [
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 # == Correctness == #
-keyword_idents_2024 = "warn"
 ambiguous_negative_literals = "warn"
 
 # == Style, readability == #


### PR DESCRIPTION
> The `ambiguous_negative_literals` lint checks for cases that are confusing between a negative literal and a negation that's not part of the literal.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#ambiguous-negative-literals