### PR TITLE
ci(wasm): enable scard feature in wasm-testcompile

### DIFF
--- a/tools/wasm-testcompile/Cargo.toml
+++ b/tools/wasm-testcompile/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-sspi = { path = "../.." }
+sspi = { path = "../..", features = ["scard"] }
 
 whoami = "0.5"
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Add scard feature to sspi dependency to verify compatibility on WASM platform