### PR TITLE
build(deps): no zlib for flate2 on WASM

### DIFF
--- a/crates/winscard/Cargo.toml
+++ b/crates/winscard/Cargo.toml
@@ -26,7 +26,7 @@ time = { workspace = true, features = [
     "formatting",
 ] }
 uuid = { workspace = true, features = ["v4"] }
-flate2 = { version = "1.1", features = ["zlib", "rust_backend"], default-features = false }
+flate2 = { version = "1.1", default-features = false }
 rsa = { workspace = true, features = ["hazmat", "sha1"] }
 rand_core = "0.9"
 sha1.workspace = true
@@ -35,6 +35,13 @@ picky-asn1-der = { workspace = true, optional = true }
 num-derive.workspace = true
 num-traits.workspace = true
 crypto-bigint.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+flate2 = { version = "1.1", default-features = false, features = ["zlib"] }
+
+# Apple Clang cannot use system zlib for wasm32-unknown-unknown
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
 
 [dev-dependencies]
 proptest.workspace = true


### PR DESCRIPTION
The WASM build for IronRDP was [failing](https://github.com/Devolutions/IronRDP/actions/runs/19478263470) on macOS.

This PR switches flate2 to the default `miniz_oxide` (Rust-only implementation) for WASM and keeps using system `zlib` otherwise.

The zlib backends are described [here](https://github.com/rust-lang/flate2-rs?tab=readme-ov-file#backends).

I am hoping to have this PR merged and a new version cut so that https://github.com/Devolutions/IronRDP/pull/1028 can be merged.