### PR TITLE
ci: allow auto or explicit package version in nuget.yml

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: boolean
         default: true
+      version:
+        description: 'Package version'
+        default: "latest"
+        required: true
   schedule:
     - cron: '21 3 * * 1' # 3:21 AM UTC every Monday
 
@@ -17,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dry-run: ${{ steps.get-dry-run.outputs.dry-run }}
+      package-version: ${{ steps.info.outputs.package-version }}
 
     steps:
       - name: Get dry run
@@ -33,13 +38,29 @@ jobs:
             echo "dry-run=false" >> $Env:GITHUB_OUTPUT
           }
 
+      - name: Package information
+        id: info
+        shell: pwsh
+        run: |
+          $PackageVersion = '${{ inputs.version }}'
+          if ([string]::IsNullOrEmpty($PackageVersion) -or $PackageVersion -eq 'latest') {
+            $PackageVersion = (Get-Date -Format "yyyy.MM.dd") + ".0"
+          }
+
+          if ($PackageVersion -NotMatch '^\d+\.\d+\.\d+\.\d+$') {
+            throw "invalid version format: $PackageVersion, expected: 1.2.3.4"
+          }
+
+          echo "package-version=$PackageVersion" >> $Env:GITHUB_OUTPUT
+          echo "::notice::Version: $PackageVersion"
+
   build-native:
     uses: ./.github/workflows/build-native.yml
 
   build-managed:
     name: Managed build
     runs-on: windows-2022
-    needs: [build-native]
+    needs: [ preflight, build-native ] 
 
     steps:
       - name: Check out ${{ github.repository }}
@@ -65,6 +86,15 @@ jobs:
           $(Get-Item ".\sspi-*-release") | ForEach-Object { Rename-Item $_ $_.Name.Replace("-release", "") }
           $(Get-Item ".\sspi-*") | ForEach-Object { Rename-Item $_ $_.Name.Replace("sspi-", "") }
           Get-ChildItem * -Recurse
+
+      - name: Set package version
+        shell: pwsh
+        run: |
+          $PackageVersion = '${{ needs.preflight.outputs.package-version }}'
+          $csprojPath = "ffi\dotnet\Devolutions.Sspi\Devolutions.Sspi.csproj"
+          $csprojContent = Get-Content $csprojPath -Raw
+          $csprojContent = $csprojContent -Replace '(<Version>).*?(</Version>)', "<Version>$PackageVersion</Version>"
+          Set-Content -Path $csprojPath -Value $csprojContent -Encoding UTF8
 
       - name: Build sspi (managed)
         shell: pwsh


### PR DESCRIPTION
Allow setting the nuget version at build time, or leave "latest" default to build the version from today's date