### PR TITLE
feat(ffi): `SECPKG_ATTR_SESSION_KEY` support

### DIFF
--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use std::ptr::{self, NonNull};
+use std::ptr::{self, NonNull, copy_nonoverlapping};
 use std::slice::from_raw_parts;
 use std::sync::Mutex;
 
@@ -43,7 +43,8 @@ use super::sec_pkg_info::{RawSecPkgInfoA, RawSecPkgInfoW, SecNegoInfoA, SecNegoI
 use super::sec_winnt_auth_identity::auth_data_to_identity_buffers;
 use super::sspi_data_types::{
     CertTrustStatus, LpStr, LpcWStr, PSecurityString, PTimeStamp, SecChar, SecGetKeyFn, SecPkgContextConnectionInfo,
-    SecPkgContextFlags, SecPkgContextSizes, SecPkgContextStreamSizes, SecWChar, SecurityStatus,
+    SecPkgContextFlags, SecPkgContextSessionKey, SecPkgContextSizes, SecPkgContextStreamSizes, SecWChar,
+    SecurityStatus,
 };
 use super::utils::{hostname, transform_credentials_handle};
 use crate::utils::into_raw_ptr;
@@ -70,6 +71,8 @@ pub const SECPKG_ATTR_SERVER_AUTH_FLAGS: u32 = 0x80000083;
 pub const SECPKG_ATTR_CERT_TRUST_STATUS: u32 = 0x80000084;
 // detailed information on the established connection
 pub const SECPKG_ATTR_CONNECTION_INFO: u32 = 0x5a;
+// information about the session keys
+pub const SECPKG_ATTR_SESSION_KEY: u32 = 9;
 
 // Sets the name of a credential
 // In our library, we use this attribute to set the workstation for auth identity
@@ -972,9 +975,7 @@ unsafe fn query_context_attributes_common(
                 }
             }
             SECPKG_ATTR_SERVER_AUTH_FLAGS => {
-                let flags = SecPkgContextFlags {
-                    flags: 0,
-                };
+                let flags = SecPkgContextFlags { flags: 0 };
 
                 let sec_context_flags = p_buffer.cast::<*mut SecPkgContextFlags>();
                 // SAFETY: `sec_context_flags` is non-null because it was cast from a non-null `p_buffer`..
@@ -1010,7 +1011,42 @@ unsafe fn query_context_attributes_common(
 
                 return 0;
             }
-            _ => {},
+            SECPKG_ATTR_SESSION_KEY => {
+                let session_key = try_execute!(sspi_context.query_context_session_key()).session_key;
+                let session_key_len = session_key.as_ref().len();
+
+                let sec_pkg_context_session_key = p_buffer.cast::<SecPkgContextSessionKey>();
+
+                // SAFETY: `sec_pkg_context_session_key` is non-null because it was cast from a non-null `p_buffer`.
+                unsafe {
+                    (*sec_pkg_context_session_key).session_key_len = session_key_len.try_into().expect("session key length should fit into u32");
+                }
+
+                // SAFETY: Memory allocation is safe.
+                let buf = unsafe {
+                    libc::malloc(session_key_len)
+                }.cast::<u8>();
+
+                // SAFETY:
+                // - `session_key.as_ref().as_ptr()` pointer is valid for reads of `session_key_len` bytes,
+                //   because it is Rust-allocated vector of u8 values with size of `session_key_len`.
+                // - `sec_pkg_context_session_key_ptr` is valid for writes of `session_key_len` bytes.
+                // - `session_key` and memory behind `sec_pkg_context_session_key_ptr` are properly-aligned.
+                // - `session_key` and memory behind `sec_pkg_context_session_key_ptr` do not overlap,
+                //   because they are allocated separately.
+                unsafe {
+                    copy_nonoverlapping(session_key.as_ref().as_ptr(), buf, session_key_len);
+                }
+
+                // SAFETY:
+                // - `sec_pkg_context_session_key` is a valid pointer to a `SecPkgContextSessionKey` structure due to a previous check.
+                unsafe {
+                    (*sec_pkg_context_session_key).session_key = buf;
+                }
+
+                return 0;
+            }
+            _ => {}
         };
 
         let package_info = try_execute!(match ul_attribute.try_into().unwrap() {
@@ -1021,8 +1057,11 @@ unsafe fn query_context_attributes_common(
                 sspi_context.query_context_negotiation_package()
             }
             unsupported => {
-                Err(Error::new(ErrorKind::UnsupportedFunction, format!("Unsupported function ID {unsupported}")))
-            },
+                Err(Error::new(
+                    ErrorKind::UnsupportedFunction,
+                    format!("Unsupported function ID {unsupported}"),
+                ))
+            }
         });
 
         if is_wide {

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1747,7 +1747,7 @@ mod tests {
     use std::ffi::CStr;
     use std::ptr::{self, null, null_mut};
 
-    use libc::c_void;
+    use libc::{c_ulonglong, c_void};
     use sspi::Utf16StringExt;
     use widestring::Utf16String;
 
@@ -2251,5 +2251,53 @@ mod tests {
 
         let status = unsafe { FreeCredentialsHandle(&mut cred_handle) };
         assert_eq!(status, 0);
+    }
+
+    #[test]
+    fn query_context_session_key() {
+        use std::slice::from_raw_parts;
+
+        use sspi::credssp::SspiContext;
+
+        use crate::sspi::sec_handle::{QueryContextAttributesW, SECPKG_ATTR_SESSION_KEY, SspiHandle};
+        use crate::sspi::sspi_data_types::SecPkgContextSessionKey;
+        use crate::utils::into_raw_ptr;
+
+        let kerberos_client = sspi::kerberos::test_data::fake_client();
+
+        // Initialize the security handle: simulate the `p_ctxt_handle_to_sspi_context` function.
+        // We use Kerberos fake_client because we need established security context to query the session key.
+        let sspi_context = SspiHandle::new(SspiContext::Kerberos(kerberos_client));
+        let sspi_context_ptr = into_raw_ptr(sspi_context);
+        let mut sec_handle = SecHandle {
+            dw_lower: sspi_context_ptr as c_ulonglong,
+            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string()) as c_ulonglong,
+        };
+
+        let mut session_key = SecPkgContextSessionKey {
+            session_key_len: 0,
+            session_key: null_mut(),
+        };
+
+        let status = unsafe {
+            QueryContextAttributesW(
+                &mut sec_handle,
+                SECPKG_ATTR_SESSION_KEY,
+                ptr::from_mut(&mut session_key).cast(),
+            )
+        };
+        assert_eq!(status, 0);
+
+        // Print the session key
+        let key = unsafe { from_raw_parts(session_key.session_key, session_key.session_key_len as usize) };
+        println!("Session key length: {}", session_key.session_key_len);
+        println!("Session key: {:02x?}", key);
+
+        // Free the key buffer using FreeContextBuffer
+        let status = unsafe { FreeContextBuffer(session_key.session_key.cast()) };
+        assert_eq!(status, 0);
+
+        let _ = unsafe { Box::from_raw(sec_handle.dw_upper as *mut String) };
+        let _ = unsafe { Box::from_raw(sec_handle.dw_lower as *mut SspiHandle) };
     }
 }

--- a/ffi/src/sspi/sspi_data_types.rs
+++ b/ffi/src/sspi/sspi_data_types.rs
@@ -98,6 +98,20 @@ pub struct SecPkgContextConnectionInfo {
     pub dw_exch_strength: u32,
 }
 
+/// [_SecPkgContext_SessionKey](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secpkgcontext_sessionkey)
+///
+/// ```not_rust
+/// typedef struct _SecPkgContext_SessionKey {
+///   unsigned long SessionKeyLength;
+///   unsigned char *SessionKey;
+/// } SecPkgContext_SessionKey, *PSecPkgContext_SessionKey;
+/// ```
+#[repr(C)]
+pub struct SecPkgContextSessionKey {
+    pub session_key_len: u32,
+    pub session_key: *mut u8,
+}
+
 /// [CERT_TRUST_STATUS](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_trust_status)
 ///
 /// ```not_rust

--- a/ffi/src/sspi/sspi_data_types.rs
+++ b/ffi/src/sspi/sspi_data_types.rs
@@ -100,7 +100,7 @@ pub struct SecPkgContextConnectionInfo {
 
 /// [_SecPkgContext_SessionKey](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secpkgcontext_sessionkey)
 ///
-/// ```not_rust
+/// ```c
 /// typedef struct _SecPkgContext_SessionKey {
 ///   unsigned long SessionKeyLength;
 ///   unsigned char *SessionKey;


### PR DESCRIPTION
Hi,

Related PRs (#417 ) only addressed the `sspi` portion of `SECPKG_ATTR_SESSION_KEY` support. I added `SECPKG_ATTR_SESSION_KEY` support in the FFI module.

closes #168 