### PR TITLE
fix!: remove redundant PKCS#1 padding when signing hashes

### DIFF
--- a/src/smartcard.rs
+++ b/src/smartcard.rs
@@ -167,7 +167,7 @@ impl SmartCard {
         match &mut self.smart_card_type {
             SmartCardApi::PivEmulated(scard) => {
                 scard.verify_pin(self.pin.as_ref())?;
-                Ok(scard.sign_hashed(&encode_digest(digest)?)?)
+                Ok(scard.sign_hashed(digest)?)
             }
             #[cfg(not(target_arch = "wasm32"))]
             SmartCardApi::Pkcs11 {


### PR DESCRIPTION
Over at Teleport, we've noticed some errors from the winscard crate during logon with NLA:
```
CredSSP InternalError: Error while using a smart card: Error{ InternalError: Error: an unexpected RsaError happened: input must be hashed }
```

`Pkcs1v15Sign::new` already handles PKCS#1 padding internally and checks that the input vector matches the expected length of a SHA1 hash. Since the smart card implementation is modifying the input vector with `encode_digest`, this check fails resulting in the error above.