### PR TITLE
fix(sspi): ntlm: NTLM_SSP_NEGOTIATE_KEY_EXCH flag usage

### DIFF
--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -490,11 +490,14 @@ impl Ntlm {
         sequence_number: u32,
         digest: &[u8; 16],
     ) -> crate::Result<()> {
-        let checksum = self
-            .send_sealing_key
-            .as_mut()
-            .unwrap()
-            .process(&digest[0..SIGNATURE_CHECKSUM_SIZE]);
+        let checksum = if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
+            self.send_sealing_key
+                .as_mut()
+                .expect("NTLM send_sealing_key must be set")
+                .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
+        } else {
+            digest[0..SIGNATURE_CHECKSUM_SIZE].to_vec()
+        };
 
         let signature_buffer = SecurityBufferRef::find_buffer_mut(message, BufferType::Token)?;
         if signature_buffer.buf_len() < SIGNATURE_SIZE {
@@ -507,11 +510,15 @@ impl Ntlm {
     }
 
     fn check_signature(&mut self, sequence_number: u32, digest: &[u8; 16], signature: &[u8]) -> crate::Result<()> {
-        let checksum = self
-            .recv_sealing_key
-            .as_mut()
-            .unwrap()
-            .process(&digest[0..SIGNATURE_CHECKSUM_SIZE]);
+        let checksum = if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
+            self.recv_sealing_key
+                .as_mut()
+                .expect("NTLM recv_sealing_key must be set")
+                .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
+        } else {
+            digest[0..SIGNATURE_CHECKSUM_SIZE].to_vec()
+        };
+
         let expected_signature = compute_signature(&checksum, sequence_number);
 
         if signature != expected_signature.as_ref() {

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -490,14 +490,19 @@ impl Ntlm {
         sequence_number: u32,
         digest: &[u8; 16],
     ) -> crate::Result<()> {
-        let checksum = if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
-            self.send_sealing_key
-                .as_mut()
-                .expect("NTLM send_sealing_key must be set")
-                .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
-        } else {
-            digest[0..SIGNATURE_CHECKSUM_SIZE].to_vec()
-        };
+        let checksum: [u8; SIGNATURE_CHECKSUM_SIZE] =
+            if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
+                self.send_sealing_key
+                    .as_mut()
+                    .expect("NTLM send_sealing_key must be set")
+                    .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
+                    .try_into()
+                    .expect("checksum must be SIGNATURE_CHECKSUM_SIZE bytes long")
+            } else {
+                digest[0..SIGNATURE_CHECKSUM_SIZE]
+                    .try_into()
+                    .expect("checksum must be SIGNATURE_CHECKSUM_SIZE bytes long")
+            };
 
         let signature_buffer = SecurityBufferRef::find_buffer_mut(message, BufferType::Token)?;
         if signature_buffer.buf_len() < SIGNATURE_SIZE {
@@ -510,14 +515,19 @@ impl Ntlm {
     }
 
     fn check_signature(&mut self, sequence_number: u32, digest: &[u8; 16], signature: &[u8]) -> crate::Result<()> {
-        let checksum = if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
-            self.recv_sealing_key
-                .as_mut()
-                .expect("NTLM recv_sealing_key must be set")
-                .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
-        } else {
-            digest[0..SIGNATURE_CHECKSUM_SIZE].to_vec()
-        };
+        let checksum: [u8; SIGNATURE_CHECKSUM_SIZE] =
+            if self.flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH) {
+                self.recv_sealing_key
+                    .as_mut()
+                    .expect("NTLM recv_sealing_key must be set")
+                    .process(&digest[0..SIGNATURE_CHECKSUM_SIZE])
+                    .try_into()
+                    .expect("checksum must be SIGNATURE_CHECKSUM_SIZE bytes long")
+            } else {
+                digest[0..SIGNATURE_CHECKSUM_SIZE]
+                    .try_into()
+                    .expect("checksum must be SIGNATURE_CHECKSUM_SIZE bytes long")
+            };
 
         let expected_signature = compute_signature(&checksum, sequence_number);
 

--- a/src/ntlm/test.rs
+++ b/src/ntlm/test.rs
@@ -49,6 +49,7 @@ fn encrypt_message_crypts_data() {
 #[test]
 fn encrypt_message_correct_computes_digest() {
     let mut context = Ntlm::new();
+    context.flags.set(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH, true);
     context.our_seq_number = TEST_SEQ_NUM;
     context.send_signing_key = SIGNING_KEY.into();
     context.send_sealing_key = Some(Rc4::new(&SEALING_KEY));
@@ -66,6 +67,30 @@ fn encrypt_message_correct_computes_digest() {
 
     assert_eq!(result, SecurityStatus::Ok);
     assert_eq!(expected, &signature.data()[4..12]);
+}
+
+#[test]
+fn encrypt_message_correct_computes_unencrypted_digest() {
+    // When the NTLM_SSP_NEGOTIATE_KEY_EXCH flag is not set, the digest should be computed without encryption (HMAC only).
+    let digest = &[70, 148, 67, 212, 16, 164, 169, 167];
+
+    let mut context = Ntlm::new();
+    context.our_seq_number = TEST_SEQ_NUM;
+    context.send_signing_key = SIGNING_KEY.into();
+    context.send_sealing_key = Some(Rc4::new(&SEALING_KEY));
+
+    let mut token = [0; 100];
+    let mut data = TEST_DATA.to_vec();
+    let mut buffers = vec![
+        SecurityBufferRef::token_buf(token.as_mut_slice()),
+        SecurityBufferRef::data_buf(data.as_mut_slice()),
+    ];
+
+    let result = context.encrypt_message(EncryptionFlags::empty(), &mut buffers).unwrap();
+    let signature = SecurityBufferRef::find_buffer(&buffers, BufferType::Token).unwrap();
+
+    assert_eq!(result, SecurityStatus::Ok);
+    assert_eq!(digest, &signature.data()[4..12]);
 }
 
 #[test]
@@ -93,6 +118,7 @@ fn encrypt_message_writes_seq_num_to_signature() {
 #[test]
 fn decrypt_message_decrypts_data() {
     let mut context = Ntlm::new();
+    context.flags.set(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH, true);
     context.remote_seq_number = TEST_SEQ_NUM;
     context.recv_signing_key = SIGNING_KEY.into();
     context.recv_sealing_key = Some(Rc4::new(&SEALING_KEY));
@@ -113,8 +139,30 @@ fn decrypt_message_decrypts_data() {
 }
 
 #[test]
+fn decrypt_message_does_not_fail_on_unencrypted_signature() {
+    // When the NTLM_SSP_NEGOTIATE_KEY_EXCH flag is not set, the digest should be computed without encryption (HMAC only).
+    let signature = [1, 0, 0, 0, 70, 148, 67, 212, 16, 164, 169, 167, 210, 2, 150, 73];
+
+    let mut context = Ntlm::new();
+    context.remote_seq_number = TEST_SEQ_NUM;
+    context.recv_signing_key = SIGNING_KEY.into();
+    context.recv_sealing_key = Some(Rc4::new(&SEALING_KEY));
+
+    let mut encrypted_test_data = ENCRYPTED_TEST_DATA.to_vec();
+    let mut signature_test_data = signature.to_vec();
+
+    let mut buffers = vec![
+        SecurityBufferRef::data_buf(&mut encrypted_test_data),
+        SecurityBufferRef::token_buf(&mut signature_test_data),
+    ];
+
+    context.decrypt_message(&mut buffers).unwrap();
+}
+
+#[test]
 fn decrypt_message_does_not_fail_on_correct_signature() {
     let mut context = Ntlm::new();
+    context.flags.set(NegotiateFlags::NTLM_SSP_NEGOTIATE_KEY_EXCH, true);
     context.remote_seq_number = TEST_SEQ_NUM;
     context.recv_signing_key = SIGNING_KEY.into();
     context.recv_sealing_key = Some(Rc4::new(&SEALING_KEY));


### PR DESCRIPTION
Hi,

This PR is related to issue #640. It does not resolve it completely, but fixes some part of the behavior.

Let me explain what is going on here. In [my last comment](https://github.com/Devolutions/sspi-rs/issues/640#issuecomment-4420170462), I said the target SMB server does not want to accept `sspi-rs`-generated MIC token. This PR fixes this part of the problem. After this fix, the Samba server should accept the `sspi-rs` generated MIC token.

It turned out that the MIC generation was not broken. The NTLM MIC token (as any other NTLM checksum) is calculated in two stages:

1. HMAC digest calculation
3. Digest encryption using RC4

`sspi-rs` always sent an encrypted checksum. It was not a problem until #640.

It turned out that the Samba server disables the `NTLM_SSP_NEGOTIATE_KEY_EXCH` flag during NTLM negotiation and then expects an unencrypted checksum: https://gitlab.com/samba-team/samba/-/blob/6c5156b0452dda120b165e990df60348adef4af0/auth/ntlmssp/ntlmssp_sign.c#L158

```c
if (encrypt_sig && (ntlmssp_state->neg_flags & NTLMSSP_NEGOTIATE_KEY_EXCH)) {
    // This if-branch is not executed.
}
```

I improved the NTLM checksum calculation and added new tests to cover a new behavior.