### PR TITLE
fix(sspi): disable `mechListMIC` for NTLM guest logon in negotiate module

### DIFF
--- a/src/negotiate/client.rs
+++ b/src/negotiate/client.rs
@@ -188,7 +188,14 @@ pub(crate) async fn initialize_security_context<'a>(
                 let mech_type: String = (&selected_mech.0).into();
                 debug!("The remote server has selected {mech_type} mechanism id.");
 
-                negotiate.negotiate_protocol_by_mech_type(selected_mech)?;
+                negotiate.negotiate_protocol_by_mech_type(
+                    selected_mech,
+                    builder
+                        .credentials_handle
+                        .as_ref()
+                        .and_then(|handle| handle.as_ref().map(|handle| handle.as_auth_identity()))
+                        .and_then(|identity| identity.map(|identity| &identity.user)),
+                )?;
             }
 
             let input_token = SecurityBuffer::find_buffer_mut(input, BufferType::Token)?;

--- a/src/negotiate/client.rs
+++ b/src/negotiate/client.rs
@@ -93,7 +93,6 @@ pub(crate) async fn initialize_security_context<'a>(
                 negotiate.mic_verified = false;
             } else {
                 negotiate.mic_needed = false;
-                negotiate.mic_verified = true;
             }
 
             let result = negotiate

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 pub use config::{NegotiateConfig, ProtocolConfig};
 use picky::oids;
 use picky_krb::gss_api::MechType;
+use widestring::Utf16String;
 
 use crate::builders::{EmptyAcceptSecurityContext, FilledAcceptSecurityContext, FilledInitializeSecurityContext};
 use crate::generator::{
@@ -31,6 +32,7 @@ use crate::{
 };
 
 pub const PKG_NAME: &str = "Negotiate";
+const GUEST_USERNAME: &str = "/GUEST";
 
 pub static PACKAGE_INFO: LazyLock<PackageInfo> = LazyLock::new(|| PackageInfo {
     capabilities: PackageCapabilities::empty(),
@@ -338,7 +340,7 @@ impl Negotiate {
     }
 
     #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
-    fn negotiate_protocol_by_mech_type(&mut self, mech_type: &MechType) -> Result<()> {
+    fn negotiate_protocol_by_mech_type(&mut self, mech_type: &MechType, username: Option<&Utf16String>) -> Result<()> {
         let enabled_packages = self.package_list;
 
         if mech_type == &oids::ms_krb5() || mech_type == &oids::krb5() {
@@ -391,15 +393,23 @@ impl Negotiate {
                     NegotiatedProtocol::Ntlm(Ntlm::with_config(NtlmConfig::new(self.client_computer_name.clone())));
             }
 
-            // [MS-SPNG](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/f377a379-c24f-4a0f-a3eb-0d835389e28a):
-            // > If NTLM authentication is most preferred by the client and the server, and the client includes a MIC
-            // > in AUTHENTICATE_MESSAGE ([MS-NLMP] section 2.2.1.3), then the mechListMIC field becomes
-            // > mandatory in order for the authentication to succeed.
-            //
-            // We always include NTLM MIC token inside AUTHENTICATE_MESSAGE. So, we need to perform
-            // SPNEGO `mechListMIC` exchange.
-            self.mic_needed = true;
-            self.mic_verified = false;
+            if let Some(user) = username
+                && user.to_string().eq_ignore_ascii_case(GUEST_USERNAME)
+            {
+                // Do not require `mechListMIC` exchange when the user tries to log on under the guest account.
+                self.mic_needed = false;
+                self.mic_verified = false;
+            } else {
+                // [MS-SPNG](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/f377a379-c24f-4a0f-a3eb-0d835389e28a):
+                // > If NTLM authentication is most preferred by the client and the server, and the client includes a MIC
+                // > in AUTHENTICATE_MESSAGE ([MS-NLMP] section 2.2.1.3), then the mechListMIC field becomes
+                // > mandatory in order for the authentication to succeed.
+                //
+                // We always include NTLM MIC token inside AUTHENTICATE_MESSAGE. So, we need to perform
+                // SPNEGO `mechListMIC` exchange.
+                self.mic_needed = true;
+                self.mic_verified = false;
+            }
 
             return Ok(());
         }

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -290,6 +290,11 @@ impl Negotiate {
         })
     }
 
+    #[cfg(feature = "__test-data")]
+    pub fn mic_needed(&self) -> bool {
+        self.mic_needed
+    }
+
     fn protocol_name(&self) -> &str {
         self.protocol.protocol_name()
     }
@@ -398,7 +403,6 @@ impl Negotiate {
             {
                 // Do not require `mechListMIC` exchange when the user tries to log on under the guest account.
                 self.mic_needed = false;
-                self.mic_verified = false;
             } else {
                 // [MS-SPNG](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/f377a379-c24f-4a0f-a3eb-0d835389e28a):
                 // > If NTLM authentication is most preferred by the client and the server, and the client includes a MIC

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -169,6 +169,14 @@ impl NegotiatedProtocol {
 
         Ok(result)
     }
+
+    fn query_context_names(&mut self) -> Result<ContextNames> {
+        match self {
+            NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_names(),
+            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_names(),
+            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_names(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -307,11 +315,7 @@ impl Negotiate {
             ));
         };
 
-        let ContextNames { username } = match &mut self.protocol {
-            NegotiatedProtocol::Pku2u(pku2u) => pku2u.query_context_names()?,
-            NegotiatedProtocol::Kerberos(kerberos) => kerberos.query_context_names()?,
-            NegotiatedProtocol::Ntlm(ntlm) => ntlm.query_context_names()?,
-        };
+        let ContextNames { username } = self.protocol.query_context_names()?;
 
         let candidates: Vec<Credentials> = auth_data
             .iter()

--- a/src/negotiate/server.rs
+++ b/src/negotiate/server.rs
@@ -128,7 +128,7 @@ pub(crate) async fn accept_security_context(
         NegotiateState::InProgress => {
             let neg_token_targ: NegTokenTarg1 = picky_asn1_der::from_bytes(&input_token.buffer)?;
             let NegTokenTarg {
-                neg_result: _,
+                neg_result,
                 supported_mech: _,
                 response_token,
                 mech_list_mic,
@@ -154,6 +154,18 @@ pub(crate) async fn accept_security_context(
                     negotiate.verify_mic_token(mech_list_mic.as_deref())?;
 
                     negotiate.mic_verified = true;
+                }
+
+                if mech_list_mic.is_none()
+                    && neg_result.0.as_ref().map(|neg_result| neg_result.0.0.as_slice()) == Some(&ACCEPT_COMPLETE)
+                {
+                    if negotiate.mic_needed {
+                        warn!(
+                            "The SPNEGO server expected the `mechListMIC` exchange, but the client has skipped it. Skipping MIC exchange on the server side too..."
+                        );
+                    }
+
+                    negotiate.mic_needed = false;
                 }
 
                 let neg_result = if !negotiate.mic_needed || negotiate.mic_verified {

--- a/src/negotiate/server.rs
+++ b/src/negotiate/server.rs
@@ -5,12 +5,12 @@ use picky_krb::gss_api::{NegTokenTarg, NegTokenTarg1};
 
 use crate::builders::FilledAcceptSecurityContext;
 use crate::generator::YieldPointLocal;
-use crate::negotiate::NegotiateState;
 use crate::negotiate::extractors::{decode_initial_neg_init, negotiate_mech_type};
 use crate::negotiate::generators::{generate_final_neg_token_targ, generate_neg_token_targ, generate_neg_token_targ_1};
+use crate::negotiate::{GUEST_USERNAME, NegotiateState};
 use crate::{
-    AcceptSecurityContextResult, BufferType, Error, ErrorKind, Negotiate, NegotiatedProtocol, Result, SecurityBuffer,
-    SecurityStatus, ServerRequestFlags, ServerResponseFlags, SspiImpl,
+    AcceptSecurityContextResult, BufferType, ContextNames, Error, ErrorKind, Negotiate, NegotiatedProtocol, Result,
+    SecurityBuffer, SecurityStatus, ServerRequestFlags, ServerResponseFlags, SspiImpl,
 };
 
 /// Performs one authentication step.
@@ -156,13 +156,18 @@ pub(crate) async fn accept_security_context(
                     negotiate.mic_verified = true;
                 }
 
-                if mech_list_mic.is_none()
+                if negotiate.mic_needed
+                    && mech_list_mic.is_none()
                     && neg_result.0.as_ref().map(|neg_result| neg_result.0.0.as_slice()) == Some(&ACCEPT_COMPLETE)
                 {
-                    if negotiate.mic_needed {
-                        warn!(
-                            "The SPNEGO server expected the `mechListMIC` exchange, but the client has skipped it. Skipping MIC exchange on the server side too..."
-                        );
+                    // We should skip `mechListMIC` exchange when the client tries guest logon.
+                    let ContextNames { username } = negotiate.protocol.query_context_names()?;
+
+                    if !username.inner().eq_ignore_ascii_case(GUEST_USERNAME) {
+                        return Err(Error::new(
+                            ErrorKind::InvalidToken,
+                            "the client skipped `mechListMIC` exchange, but it is required for non-guest logon",
+                        ));
                     }
 
                     negotiate.mic_needed = false;

--- a/tests/sspi/client_server/negotiate.rs
+++ b/tests/sspi/client_server/negotiate.rs
@@ -11,13 +11,13 @@ use crate::client_server::{TARGET_NAME, test_encryption, test_rpc_request_encryp
 
 const CLIENT_COMPUTER_NAME: &str = "DESKTOP-IHPPQ95.example.com";
 
-fn run_spnego_ntlm(target_name: Option<&str>) {
+fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mic_expected: bool) {
     let ntlm_config = NtlmConfig {
         client_computer_name: Some(CLIENT_COMPUTER_NAME.to_owned()),
     };
     let credentials = Credentials::AuthIdentity(AuthIdentity {
-        username: Username::parse("test_user@example.com").unwrap(),
-        password: Secret::from("test_password".to_owned()),
+        username: Username::parse(username).unwrap(),
+        password: Secret::from(password.to_owned()),
     });
 
     let mut client = SspiContext::Negotiate(
@@ -96,9 +96,22 @@ fn run_spnego_ntlm(target_name: Option<&str>) {
         }
 
         if status == SecurityStatus::Ok {
+            let negotiate_client = match &client {
+                SspiContext::Negotiate(negotiate) => negotiate,
+                _ => unreachable!(),
+            };
+            assert_eq!(negotiate_client.mic_needed(), mic_expected);
+
+            let negotiate_server = match &server {
+                SspiContext::Negotiate(negotiate) => negotiate,
+                _ => unreachable!(),
+            };
+            assert_eq!(negotiate_server.mic_needed(), mic_expected);
+
             test_encryption(&mut client, &mut server);
             test_stream_buffer_encryption(&mut client, &mut server);
             test_rpc_request_encryption(&mut client, &mut server);
+
             return;
         }
     }
@@ -108,10 +121,15 @@ fn run_spnego_ntlm(target_name: Option<&str>) {
 
 #[test]
 fn spnego_ntlm_client_server() {
-    run_spnego_ntlm(Some(TARGET_NAME));
+    run_spnego_ntlm(Some(TARGET_NAME), "test_user@example.com", "test_password", true);
+}
+
+#[test]
+fn spnego_ntlm_guest_logon() {
+    run_spnego_ntlm(Some(TARGET_NAME), "/GUEST", "", false);
 }
 
 #[test]
 fn spnego_ntlm_without_target_name() {
-    run_spnego_ntlm(None);
+    run_spnego_ntlm(None, "test_user@example.com", "test_password", true);
 }

--- a/tests/sspi/client_server/ntlm.rs
+++ b/tests/sspi/client_server/ntlm.rs
@@ -41,10 +41,10 @@ fn test_readonly_buffers_encryption(client: &mut SspiContext, server: &mut SspiC
     assert_eq!(plain_message, message[2].data());
 }
 
-fn run_ntlm(config: NtlmConfig, target_name: Option<&str>) {
+fn run_ntlm(config: NtlmConfig, target_name: Option<&str>, username: &str, password: &str) {
     let credentials = Credentials::AuthIdentity(AuthIdentity {
-        username: Username::parse("test_user").unwrap(),
-        password: Secret::from("test_password".to_owned()),
+        username: Username::parse(username).unwrap(),
+        password: Secret::from(password.to_owned()),
     });
 
     let mut client = SspiContext::Ntlm(Ntlm::with_config(config.clone()));
@@ -122,6 +122,8 @@ fn ntlm_with_computer_name() {
             client_computer_name: Some("DESKTOP-3D83IAN.example.com".to_owned()),
         },
         Some(TARGET_NAME),
+        "test_user",
+        "test_password",
     );
 }
 
@@ -132,6 +134,20 @@ fn ntlm_without_computer_name() {
             client_computer_name: None,
         },
         Some(TARGET_NAME),
+        "test_user",
+        "test_password",
+    );
+}
+
+#[test]
+fn ntlm_guest_logon() {
+    run_ntlm(
+        NtlmConfig {
+            client_computer_name: None,
+        },
+        Some("cifs/DESKTOP-8F33RFH.example.com"),
+        "/GUEST",
+        "",
     );
 }
 
@@ -142,5 +158,7 @@ fn ntlm_without_target_name() {
             client_computer_name: None,
         },
         None,
+        "test_user",
+        "test_password",
     );
 }


### PR DESCRIPTION
Hi,
This PR fixes another issue that is related to #640. The regular SPNEGO NTLM scenario requires `mechListMIC` exchange except for the NTLM guest logon.

When the user tries to log on under the `/GUEST` account, the `sspi-rs` will not send the MIC token.

I also added tests to cover a new behavior.