### PR TITLE
build(ffi): Change C# bindings' target framework to net6.0

### DIFF
--- a/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
+++ b/ffi/dotnet/Devolutions.Sspi/Devolutions.Sspi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Company>Devolutions</Company>
     <Description>Portable Rust SSPI library</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Version>2025.10.9.0</Version>
     <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION
Drops support for netstandard2.0 and therefore the old .NET Framework.

Paves the way for PR #679