### PR TITLE
fix(ffi): Don't attempt to package tests during NuGet CI build

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Build sspi (managed)
         shell: pwsh
         run: |
-          dotnet build .\ffi\dotnet\Devolutions.Sspi.sln -o package
+          dotnet build .\ffi\dotnet\Devolutions.Sspi\Devolutions.Sspi.csproj -o package
 
       - name: Upload managed components
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
PR #679 added some smoke tests, but this breaks the CI script which tries to build and package the whole solution, including the tests.