### PR TITLE
fix(credssp): complete the SPNEGO mechListMIC exchange in CredSspServer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,16 +101,18 @@ jobs:
           - manifest: crates/dpapi-native-transport/Cargo.toml
             crate-name: dpapi-native-transport
 
-          # Per-OS feature overrides for specific manifests
+          # Per-OS feature overrides for specific manifests.
+          # `__test-data` enables the `tests/sspi/client_server` suite (gated on
+          # `all(network_client, __test-data)`), which otherwise never runs in CI.
           - os: win
             manifest: Cargo.toml
-            additional-args: --features network_client,dns_resolver,scard,tsssp
+            additional-args: --features network_client,dns_resolver,scard,tsssp,__test-data
           - os: osx
             manifest: Cargo.toml
-            additional-args: --features network_client,scard
+            additional-args: --features network_client,scard,__test-data
           - os: linux
             manifest: Cargo.toml
-            additional-args: --features network_client,dns_resolver,scard
+            additional-args: --features network_client,dns_resolver,scard,__test-data
 
           - os: win
             manifest: ffi/Cargo.toml

--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -513,7 +513,12 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
             client_nonce,
             peer_version,
         )?;
-        context.encrypt_public_key(self.public_key.as_ref(), EndpointType::Server, client_nonce, peer_version)
+        context.encrypt_public_key(
+            self.public_key.as_ref(),
+            EndpointType::Server,
+            client_nonce,
+            peer_version,
+        )
     }
 
     #[instrument(fields(state = ?self.state), skip_all)]
@@ -621,10 +626,8 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
                         ts_request
                     );
                     let client_nonce = ts_request.client_nonce;
-                    let pub_key_auth = try_cred_ssp_server!(
-                        self.exchange_pub_key_auth(pub_key_auth, &client_nonce),
-                        ts_request
-                    );
+                    let pub_key_auth =
+                        try_cred_ssp_server!(self.exchange_pub_key_auth(pub_key_auth, &client_nonce), ts_request);
                     ts_request.nego_tokens = None;
                     ts_request.pub_key_auth = Some(pub_key_auth);
 

--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -454,6 +454,10 @@ pub struct CredSspServer<C: CredentialsProxy<AuthenticationData = AuthIdentity>>
     credentials_handle: Option<CredentialsBuffers>,
     ts_request_version: u32,
     context_config: Option<ServerMode>,
+    /// Set when the security context completed but the final SPNEGO token (accept-completed +
+    /// `mechListMIC`) still had to be sent to the client: the client cannot send `pubKeyAuth`
+    /// until it has verified that token, so `pubKeyAuth` arrives on the *next* leg.
+    awaiting_pub_key_auth: bool,
 }
 
 impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServer<C> {
@@ -466,6 +470,7 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
             credentials_handle: None,
             ts_request_version: TS_REQUEST_VERSION,
             context_config: Some(client_mode),
+            awaiting_pub_key_auth: false,
         })
     }
 
@@ -483,7 +488,32 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
             credentials_handle: None,
             ts_request_version,
             context_config: Some(client_mode),
+            awaiting_pub_key_auth: false,
         })
+    }
+
+    /// Decrypts and verifies the client's `pubKeyAuth`, returning the server-side `pubKeyAuth`
+    /// to send back.
+    fn exchange_pub_key_auth(
+        &mut self,
+        pub_key_auth: Vec<u8>,
+        client_nonce: &Option<[u8; NONCE_SIZE]>,
+    ) -> crate::Result<Vec<u8>> {
+        let peer_version = self
+            .context
+            .as_ref()
+            .unwrap()
+            .peer_version
+            .expect("an decrypt public key server function cannot be fired without any incoming TSRequest");
+        let context = self.context.as_mut().unwrap();
+        context.decrypt_public_key(
+            self.public_key.as_ref(),
+            pub_key_auth.as_ref(),
+            EndpointType::Server,
+            client_nonce,
+            peer_version,
+        )?;
+        context.encrypt_public_key(self.public_key.as_ref(), EndpointType::Server, client_nonce, peer_version)
     }
 
     #[instrument(fields(state = ?self.state), skip_all)]
@@ -576,6 +606,34 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
                 Ok(ServerState::Finished(auth_identity))
             }
             CredSspState::NegoToken => {
+                if self.awaiting_pub_key_auth {
+                    // The SPNEGO `mechListMIC` exchange deferred the client's `pubKeyAuth` by one
+                    // leg: the security context is already established and the final SPNEGO token
+                    // has been sent, so this TSRequest carries `pubKeyAuth` alone. Calling the
+                    // acceptor again would be out-of-sequence.
+                    let pub_key_auth = try_cred_ssp_server!(
+                        ts_request.pub_key_auth.take().ok_or_else(|| {
+                            Error::new(
+                                ErrorKind::InvalidToken,
+                                String::from("CredSSP server expected an encrypted public key"),
+                            )
+                        }),
+                        ts_request
+                    );
+                    let client_nonce = ts_request.client_nonce;
+                    let pub_key_auth = try_cred_ssp_server!(
+                        self.exchange_pub_key_auth(pub_key_auth, &client_nonce),
+                        ts_request
+                    );
+                    ts_request.nego_tokens = None;
+                    ts_request.pub_key_auth = Some(pub_key_auth);
+
+                    self.awaiting_pub_key_auth = false;
+                    self.state = CredSspState::AuthInfo;
+
+                    return Ok(ServerState::ReplyNeeded(ts_request));
+                }
+
                 let input = ts_request.nego_tokens.take().unwrap_or_default();
                 let mut input_token = vec![SecurityBuffer::new(input, BufferType::Token)];
                 let mut output_token = vec![SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
@@ -628,42 +686,38 @@ impl<C: CredentialsProxy<AuthenticationData = AuthIdentity> + Send> CredSspServe
                             self.context.as_mut().unwrap().sspi_context.complete_auth_token(&mut []),
                             ts_request
                         );
-                        ts_request.nego_tokens = None;
 
-                        let pub_key_auth = try_cred_ssp_server!(
-                            ts_request.pub_key_auth.take().ok_or_else(|| {
-                                Error::new(
-                                    ErrorKind::InvalidToken,
-                                    String::from("CredSSP server expected an encrypted public key"),
-                                )
-                            }),
-                            ts_request
-                        );
-                        let peer_version = self.context.as_ref().unwrap().peer_version.expect(
-                            "an decrypt public key server function cannot be fired without any incoming TSRequest",
-                        );
-                        try_cred_ssp_server!(
-                            self.context.as_mut().unwrap().decrypt_public_key(
-                                self.public_key.as_ref(),
-                                pub_key_auth.as_ref(),
-                                EndpointType::Server,
-                                &ts_request.client_nonce,
-                                peer_version,
-                            ),
-                            ts_request
-                        );
-                        let pub_key_auth = try_cred_ssp_server!(
-                            self.context.as_mut().unwrap().encrypt_public_key(
-                                self.public_key.as_ref(),
-                                EndpointType::Server,
-                                &ts_request.client_nonce,
-                                peer_version,
-                            ),
-                            ts_request
-                        );
-                        ts_request.pub_key_auth = Some(pub_key_auth);
+                        let final_token = output_token.remove(0).buffer;
+                        if ts_request.pub_key_auth.is_none() && !final_token.is_empty() {
+                            // SPNEGO `mechListMIC` exchange ([MS-SPNG] 3.3.5.5 / RFC 4178 §5): the
+                            // security context is established, but the client cannot send
+                            // `pubKeyAuth` until it has received and verified our final SPNEGO
+                            // token (accept-completed + `mechListMIC`), so that token must reach
+                            // the wire instead of being dropped. `pubKeyAuth` arrives on the next
+                            // leg.
+                            ts_request.nego_tokens = Some(final_token);
+                            self.awaiting_pub_key_auth = true;
+                        } else {
+                            ts_request.nego_tokens = None;
 
-                        self.state = CredSspState::AuthInfo;
+                            let pub_key_auth = try_cred_ssp_server!(
+                                ts_request.pub_key_auth.take().ok_or_else(|| {
+                                    Error::new(
+                                        ErrorKind::InvalidToken,
+                                        String::from("CredSSP server expected an encrypted public key"),
+                                    )
+                                }),
+                                ts_request
+                            );
+                            let client_nonce = ts_request.client_nonce;
+                            let pub_key_auth = try_cred_ssp_server!(
+                                self.exchange_pub_key_auth(pub_key_auth, &client_nonce),
+                                ts_request
+                            );
+                            ts_request.pub_key_auth = Some(pub_key_auth);
+
+                            self.state = CredSspState::AuthInfo;
+                        }
                     }
                     result => {
                         try_cred_ssp_server!(

--- a/tests/sspi/client_server/credssp.rs
+++ b/tests/sspi/client_server/credssp.rs
@@ -110,6 +110,54 @@ fn credssp_ntlm() {
 }
 
 #[test]
+fn credssp_negotiate_ntlm() {
+    // NTLM wrapped in SPNEGO on both sides — the pairing RDP requires (Windows RDP servers
+    // reject bare NTLM inside CredSSP). Because the client always includes an NTLM MIC, the
+    // SPNEGO `mechListMIC` exchange is mandatory ([MS-SPNG]): the client defers `pubKeyAuth`
+    // until it has verified the server's final SPNEGO token, so the handshake takes four
+    // client legs (NEGOTIATE, AUTHENTICATE+mechListMIC, pubKeyAuth, authInfo) instead of
+    // NTLM-only's three. Regression test for #687: the server used to drop its final SPNEGO
+    // token and demand `pubKeyAuth` on the AUTHENTICATE leg, failing the handshake.
+    let auth_identity = AuthIdentity {
+        username: Username::parse("test_user").unwrap(),
+        password: Secret::from("test_password".to_owned()),
+    };
+    let credentials = Credentials::AuthIdentity(auth_identity.clone());
+
+    let mut client = CredSspClient::new(
+        PUBLIC_KEY.to_vec(),
+        credentials.clone(),
+        CredSspMode::WithCredentials,
+        ClientMode::Negotiate(NegotiateConfig::new(
+            Box::new(NtlmConfig {
+                client_computer_name: Some("DESKTOP-3D83IAN.example.com".to_owned()),
+            }),
+            Some("ntlm,!kerberos,!pku2u".to_owned()),
+            "DESKTOP-3D83IAN.example.com".to_owned(),
+        )),
+        TARGET_NAME.to_owned(),
+    )
+    .unwrap();
+
+    let mut server = CredSspServer::new(
+        PUBLIC_KEY.to_vec(),
+        CredentialsProxyImpl::new(&auth_identity),
+        ServerMode::Negotiate(NegotiateConfig::new(
+            Box::new(NtlmConfig {
+                client_computer_name: Some("DESKTOP-3D83IAN.example.com".to_owned()),
+            }),
+            Some("ntlm,!kerberos,!pku2u".to_owned()),
+            "SERVER.example.com".to_owned(),
+        )),
+    )
+    .unwrap();
+
+    let mut network_client = NetworkClientMock { kdc: KdcMock::empty() };
+
+    run_credssp(&mut client, &mut server, &auth_identity, &mut network_client);
+}
+
+#[test]
 fn credssp_kerberos() {
     // CredSSP with Kerberos inside requires SPNEGO. We cannot use Kerberos inside CredSSP without SPNEGO.
 


### PR DESCRIPTION
Closes #687.

## Problem

`CredSspServer` cannot authenticate sspi's own `CredSspClient` when both sides run NTLM inside SPNEGO (`ClientMode::Negotiate` / `ServerMode::Negotiate` — the pairing RDP requires, since Windows RDP servers reject bare NTLM inside CredSSP). The handshake fails on the AUTHENTICATE leg with:

```
Error { error_type: InvalidToken, description: "CredSSP server expected an encrypted public key", nstatus: None }
```

Because the client always includes an NTLM MIC, the SPNEGO `mechListMIC` exchange is mandatory ([MS-SPNG 3.3.5.5](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/f377a379-c24f-4a0f-a3eb-0d835389e28a) / RFC 4178 §5), so the client defers `pubKeyAuth` until it has received and verified the server's final SPNEGO token. The server side, however, dropped that final token (`ts_request.nego_tokens = None`) at the moment its acceptor completed, and demanded `pubKeyAuth` in the same TSRequest — one leg earlier than its own client sends it.

## Fix

In `CredSspServer`'s `NegoToken` state, when the acceptor completes (`Ok`/`CompleteNeeded`) but the incoming TSRequest carries **no** `pubKeyAuth` and the acceptor produced a final output token:

- reply `ServerState::ReplyNeeded` carrying that final SPNEGO token (accept-completed + `mechListMIC`) instead of dropping it, and
- accept `pubKeyAuth` on the **following** leg (`awaiting_pub_key_auth` flag; calling the acceptor again on that leg would hit `NegotiateState::Ok → OutOfSequence`).

This matches the client's behavior and what Windows RDP servers do on the wire. Pairings where `pubKeyAuth` arrives together with the last nego token (bare NTLM, Kerberos) take the unchanged single-leg path — the new branch only activates when `pubKeyAuth` is absent *and* a final token exists. The `pubKeyAuth` decrypt/encrypt sequence is extracted into `exchange_pub_key_auth` to avoid duplicating it across the two legs.

## Resulting wire flow (Negotiate-NTLM)

```
before: NEGOTIATE → CHALLENGE → AUTHENTICATE+mechListMIC → ❌ InvalidToken
after:  NEGOTIATE → CHALLENGE → AUTHENTICATE+mechListMIC → accept-completed+mechListMIC
        → pubKeyAuth → pubKeyAuth (server) → authInfo → Finished ✅
```

## Tests

- New `credssp_negotiate_ntlm` client↔server test pins the four-client-leg handshake — it fails with the pre-fix error on master and passes with this change. (The suite previously paired only `Ntlm↔Ntlm` and `Negotiate↔Negotiate`-Kerberos, so this path was never exercised.)
- Existing `credssp_ntlm` (3 legs, unchanged) and `credssp_kerberos` (single-leg `pubKeyAuth`, unchanged) still pass — `cargo test --test sspi --features "network_client,__test-data"`: 19 passed; `cargo test -p sspi --lib`: 230 passed.

Found while building an RDP client that drives `CredSspClient` in Negotiate mode against real Windows hosts (which complete this exact client flow) and attempting to stand up an sspi-based loopback CredSSP server for integration tests.


## CI

`f8959ca` adds `__test-data` to the three root-manifest test-matrix rows, so the `client_server` suite (gated on `all(network_client, __test-data)`) actually runs in CI from now on — it previously never did, which is how #687 shipped unnoticed. The suite is hermetic (`KdcMock` / `NetworkClientMock`); verified locally with the exact win-row feature combo and the shared minimal combo, all green.
