### PR TITLE
build(deps): advance RustCrypto pins to the current rc.18/rc.33/rc.10 cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.10"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.1",
  "inout",
@@ -479,9 +479,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -589,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -851,9 +851,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.17"
+version = "0.17.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
+checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
 dependencies = [
  "der",
  "digest 0.11.3",
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -890,22 +890,22 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.31"
+version = "0.14.0-rc.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
+checksum = "102d3643d30dd8b559613c5cced68317199597fffb278cdc88daa2ef7fafc935"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.1",
  "digest 0.11.3",
+ "ff",
+ "group",
  "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.10.1",
- "rustcrypto-ff",
- "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
@@ -961,11 +961,11 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1222,12 +1222,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.14.0-pre.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1385,9 +1385,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "subtle",
  "typenum",
@@ -1967,9 +1967,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b97e3bf0465157ae90975ff52dbeb1362ba618924878c9f74c25baa27a65f9a"
+checksum = "41adc63effe99d48837a8cc0e6d7a77e32ae6a07f6000df466178dbc2193093e"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437f30ebcb1e16ff48acead5f08bd69fbcdbc82421687bb48af5c315a0bfab03"
+checksum = "9bd5333afa5ae0347f39e6a0f2c9c155da431583fd71fe5555bd0521b4ccaf02"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd792bab86ecf6249561752fb5a413511f999887107dd054bbda5143743d7"
+checksum = "a3a5297f53dc16d35909060ba3032cff7867e8809f01e273ff325579d5f0ceae"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -2048,9 +2048,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.10"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
  "hmac",
@@ -2073,9 +2073,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.23"
+version = "7.0.0-rc.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8b243c0a8e59483c7b0f746aed1c1719245692a92e9a35693f9edb88a0b712"
+checksum = "229e470e338efcd711c3f5ec92b3ff726ac1757082b2c96db46333ac693e3689"
 dependencies = [
  "base64",
  "crypto-bigint",
@@ -2098,12 +2098,10 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "pkcs1",
- "pkcs8",
  "primefield",
  "primeorder",
  "rand 0.10.1",
  "rand_core 0.10.1",
- "rfc6979",
  "rsa",
  "rustcrypto-ff",
  "rustcrypto-ff_derive",
@@ -2112,7 +2110,6 @@ dependencies = [
  "sha1 0.11.0",
  "sha2",
  "sha3",
- "signature",
  "thiserror",
  "x25519-dalek",
  "zeroize",
@@ -2160,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "picky-krb"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43602452fdea9ee3fa4141a918c3659bc43d0277143e4ee06be89e26c22e8676"
+checksum = "2d188f3192356068dbdba54bddbca6fd0f7a09565d3861eeb8efe1ab77ae8e97"
 dependencies = [
  "aes",
  "block-padding",
@@ -2230,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -2316,23 +2313,23 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
+checksum = "8675564771a62f69a0af716b03e89b917b963c7b173b5855575e84fd4f605ca0"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.1",
+ "ff",
  "rand_core 0.10.1",
- "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0556580e42c19833f5d232aca11a7687a503ee41f937b54f5ae1d50fc2a6a36a"
+checksum = "7d2793f22b9b6fd11ef3ac1d59bf003c2573593e4968702341605c2748fd90bf"
 dependencies = [
  "elliptic-curve",
 ]
@@ -2625,9 +2622,9 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
 dependencies = [
  "hmac",
  "subtle",
@@ -2649,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.17"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -2991,12 +2988,13 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3016,9 +3014,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest 0.11.3",
  "rand_core 0.10.1",
@@ -3070,6 +3068,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sspi"
@@ -4367,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+checksum = "f17b575e04fcdb37e5509a85a14ff08116678a1c9724befb8b571db742dbdbb0"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ sha2 = "0.11"
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
 
-picky = { version = "=7.0.0-rc.23", default-features = false }
+picky = { version = "=7.0.0-rc.24", default-features = false }
 picky-asn1 = "0.10"
 picky-asn1-der = "0.5"
 picky-asn1-x509 = "0.15"
@@ -105,7 +105,7 @@ dpapi-pdu = { version = "0.1.0", path = "crates/dpapi-pdu" }
 dpapi-transport = { version = "0.1.0", path = "crates/dpapi-transport" }
 dpapi-native-transport = { version = "0.1.0", path = "crates/dpapi-native-transport" }
 
-rsa = { version = "=0.10.0-rc.17", default-features = false }
+rsa = { version = "=0.10.0-rc.18", default-features = false }
 base64 = "0.22"
 whoami = "2.1"
 tracing-subscriber = "0.3"
@@ -203,24 +203,24 @@ tokio = { workspace = true, features = ["time", "rt", "rt-multi-thread"] }
 # TODO: Remove when stable versions will be released
 # RustCrypto crates
 pkcs1 = "=0.8.0-rc.4"
-pkcs8 = "=0.11.0-rc.11"
-signature = "=3.0.0-rc.10"
-p256 = "=0.14.0-rc.9"
-primefield = "=0.14.0-rc.9"
-primeorder = "=0.14.0-rc.9"
-p384 = "=0.14.0-rc.9"
-p521 = "=0.14.0-rc.9"
+pkcs8 = "0.11"
+signature = "3.0.0"
+p256 = "=0.14.0-rc.10"
+primefield = "=0.14.0-rc.12"
+primeorder = "=0.14.0-rc.10"
+p384 = "=0.14.0-rc.10"
+p521 = "=0.14.0-rc.10"
 
 # "Zero-knowledge Cryptography in Rust" crates
-ff = { version = "=0.14.0-pre.0", default-features = false }
-group = "=0.14.0-pre.0"
+ff = { version = "0.14", default-features = false }
+group = "0.14"
 rustcrypto-ff = "=0.14.0-rc.1"
 rustcrypto-ff_derive = "=0.14.0-rc.0"
 rustcrypto-group = "=0.14.0-rc.1"
 
 # "dalek cryptography" crates
-ed25519-dalek = "=3.0.0-pre.6"
-curve25519-dalek = "=5.0.0-pre.6"
+ed25519-dalek = "=3.0.0-rc.0"
+curve25519-dalek = "=5.0.0-rc.0"
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/dpapi/Cargo.toml
+++ b/crates/dpapi/Cargo.toml
@@ -41,10 +41,10 @@ dpapi-transport.workspace = true
 sspi = { path = "../..", version = "0.21" } # public
 
 kbkdf = "=0.1.0-rc.1"
-elliptic-curve = { version = "=0.14.0-rc.31", features = ["sec1", "std"] }
-p521 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
-p256 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
-p384 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
+elliptic-curve = { version = "=0.14.0-rc.33", features = ["sec1", "std"] }
+p521 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
+p256 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
+p384 = { version = "=0.14.0-rc.10", features = ["ecdh"] }
 concat-kdf = { git = "https://github.com/RustCrypto/KDFs.git", rev = "f2f5c03" } # TODO: We need the new version, but it's not released yet.
 typenum = "1.20"
 aes-kw = "0.3"
@@ -58,25 +58,25 @@ getrandom = "0.4"
 
 # Pin transitive dependencies
 # TODO: Remove when stable versions will be released
-pkcs8 = "=0.11.0-rc.11"
-signature = "=3.0.0-rc.10"
-ecdsa = "=0.17.0-rc.17"
-rfc6979 = "=0.5.0-rc.5"
-aead = "=0.6.0-rc.10"
-ed25519 = "=3.0.0-rc.4"
-pbkdf2 = "=0.13.0-rc.10"
+pkcs8 = "0.11"
+signature = "3.0.0"
+ecdsa = "=0.17.0-rc.18"
+rfc6979 = "0.5"
+aead = "0.6"
+ed25519 = "3.0.0"
+pbkdf2 = "0.13"
 pkcs1 = "=0.8.0-rc.4"
-rsa = { version = "=0.10.0-rc.17", default-features = false }
-ff = { version = "=0.14.0-pre.0", default-features = false }
-group = "=0.14.0-pre.0"
+rsa = { version = "=0.10.0-rc.18", default-features = false }
+ff = { version = "0.14", default-features = false }
+group = "0.14"
 rustcrypto-ff = "=0.14.0-rc.1"
 rustcrypto-ff_derive = "=0.14.0-rc.0"
 rustcrypto-group = "=0.14.0-rc.1"
-primefield = "=0.14.0-rc.9"
-primeorder = "=0.14.0-rc.9"
-ed25519-dalek = "=3.0.0-pre.6"
-curve25519-dalek = "=5.0.0-pre.6"
-x25519-dalek = "=3.0.0-pre.6"
+primefield = "=0.14.0-rc.12"
+primeorder = "=0.14.0-rc.10"
+ed25519-dalek = "=3.0.0-rc.0"
+curve25519-dalek = "=5.0.0-rc.0"
+x25519-dalek = "=3.0.0-rc.0"
 
 [dev-dependencies]
 paste = "1.0"


### PR DESCRIPTION
The exact-pinned RustCrypto release candidates in `sspi` and `dpapi` lag the versions published and shared across the ecosystem, so they stop resolving next to crates that already moved (russh 0.61 pulls ecdsa 0.17.0-rc.18, elliptic-curve 0.14.0-rc.33, the p-curves at rc.10, rsa 0.10.0-rc.18, and the dalek rc.0 line). This advances the pins to that cluster.

`Cargo.toml` and `crates/dpapi/Cargo.toml`:

| crate | from | to |
|-------|------|----|
| ecdsa (dpapi) | 0.17.0-rc.17 | 0.17.0-rc.18 |
| elliptic-curve (dpapi) | 0.14.0-rc.31 | 0.14.0-rc.33 |
| p256 / p384 / p521 | 0.14.0-rc.9 | 0.14.0-rc.10 |
| primeorder | 0.14.0-rc.9 | 0.14.0-rc.10 |
| primefield | 0.14.0-rc.9 | 0.14.0-rc.12 |
| rsa | 0.10.0-rc.17 | 0.10.0-rc.18 |
| ed25519-dalek | 3.0.0-pre.6 | 3.0.0-rc.0 |
| x25519-dalek (dpapi) | 3.0.0-pre.6 | 3.0.0-rc.0 |
| curve25519-dalek | 5.0.0-pre.6 | 5.0.0-rc.0 |

`ed25519`, `signature`, `pkcs8`, `ff`, `group`, `aead`, `pbkdf2`, and `rfc6979` have stable releases, so their pins drop the RC suffix and follow the stable line.

The bump needs no source changes. `cargo build -p sspi --features scard`, `cargo test -p sspi --features scard`, and the full workspace build pass on a 1.96 toolchain.

**Update:** picky `7.0.0-rc.24` shipped on 2026-06-23 with the matching bump (companion PR Devolutions/picky-rs#501), so the earlier ordering caveat is gone. This bumps the `picky` pin from rc.23 to rc.24 and regenerates `Cargo.lock`; the workspace now resolves from crates.io with no local picky patch. The validation above was rerun against rc.24.
