### PR TITLE
fix(ntlm): read channel bindings on the client authenticate step

### DIFF
--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -454,6 +454,15 @@ impl Ntlm {
                 let input_token = SecurityBuffer::find_buffer(input, BufferType::Token)?;
                 let output_token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
 
+                // Pick up a caller-supplied channel binding (e.g. tls-server-end-point)
+                // so write_authenticate can stamp it into the Type-3 message. NTLM under
+                // Strict EPA (WinRM over HTTPS) needs this. The acceptor path and the
+                // Kerberos client read the buffer the same way; without it the client
+                // ignores the CBT buffer.
+                if let Ok(sec_buffer) = SecurityBuffer::find_buffer(input, BufferType::ChannelBindings) {
+                    self.channel_bindings = Some(ChannelBindings::from_bytes(&sec_buffer.buffer)?);
+                }
+
                 client::read_challenge(self, input_token.buffer.as_slice())?;
 
                 client::write_authenticate(


### PR DESCRIPTION
The NTLM client ignored a caller-supplied `ChannelBindings` buffer. On the Challenge → Authenticate step it read the token buffer but never the `SECBUFFER_CHANNEL_BINDINGS` buffer, so `write_authenticate` had nothing to stamp into the Type-3 message. A server enforcing Strict EPA (WinRM over HTTPS advertising `tls-server-end-point`) then rejected the logon.

This reads the `ChannelBindings` buffer during the `Challenge` state and stores it on the context, the same pattern the NTLM acceptor (`Authenticate` state, `src/ntlm/mod.rs`) and the Kerberos client already use. The buffer stays optional: when the caller passes no binding, behavior is unchanged.

`cargo build -p sspi` and the full workspace build pass. `cargo test -p sspi` passes (234 + 2 unit/integration tests, 16 doctests, 0 failures).
