### PR TITLE
fix(dns): avoid panic on short SRV record RDATA on macOS

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -153,6 +153,7 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_os="macos", target_os="ios"))] {
+        use std::fmt;
         use std::time::Duration;
         use tokio::time::timeout;
         use futures::stream::{StreamExt};
@@ -166,36 +167,100 @@ cfg_if::cfg_if! {
             target: String
         }
 
-        impl From<&QueryRecordResult> for DnsSrvRecord {
-            fn from(record: &QueryRecordResult) -> Self {
-                let rdata = record.rdata.as_slice();
-                let priority = u16::from_be_bytes(rdata[0..2].try_into().unwrap());
-                let weight = u16::from_be_bytes(rdata[2..4].try_into().unwrap());
-                let port = u16::from_be_bytes(rdata[4..6].try_into().unwrap());
-                let target_data = &rdata[6..rdata.len()];
-                DnsSrvRecord {
-                    priority,
-                    weight,
-                    port,
-                    target: dns_decode_target_data_to_string(target_data)
+        /// Why an SRV callback could not be turned into a usable record, kept for diagnostics.
+        #[derive(Debug)]
+        pub(crate) enum SrvRecordParseError {
+            /// RDATA is shorter than the 6-byte fixed header (priority + weight + port).
+            RdataTooShort,
+            /// The target is the DNS root ("."), which per RFC 2782 means the service is not
+            /// available, so there is no host to connect to.
+            EmptyTarget,
+            /// The target name is not a well-formed DNS name: a label runs past the end of the
+            /// RDATA, a label exceeds the 63-byte limit, or the name is not root-terminated.
+            MalformedTarget,
+        }
+
+        impl fmt::Display for SrvRecordParseError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self {
+                    Self::RdataTooShort => f.write_str("RDATA shorter than the 6-byte SRV fixed fields"),
+                    Self::EmptyTarget => f.write_str("SRV target names no host"),
+                    Self::MalformedTarget => f.write_str("SRV target is not a well-formed DNS name"),
                 }
             }
         }
 
-        pub(crate) fn dns_decode_target_data_to_string(v: &[u8]) -> String {
+        impl std::error::Error for SrvRecordParseError {}
+
+        impl DnsSrvRecord {
+            /// Parses the wire RDATA of an SRV record (RFC 2782: priority, weight, port, target).
+            fn from_rdata(rdata: &[u8]) -> Result<Self, SrvRecordParseError> {
+                // An SRV record's RDATA is 2 (priority) + 2 (weight) + 2 (port) = 6 fixed
+                // bytes, followed by the target as a DNS name. Fewer than 6 bytes cannot be
+                // indexed for the fixed fields. In practice such a short RDATA only shows up
+                // in the negative/removal callbacks handled by the caller, so this guard is
+                // defensive.
+                if rdata.len() < 6 {
+                    return Err(SrvRecordParseError::RdataTooShort);
+                }
+                let priority = u16::from_be_bytes(rdata[0..2].try_into().unwrap());
+                let weight = u16::from_be_bytes(rdata[2..4].try_into().unwrap());
+                let port = u16::from_be_bytes(rdata[4..6].try_into().unwrap());
+                // A malformed name (truncated label, oversized label, missing root terminator)
+                // is rejected here rather than silently accepted as a partial hostname.
+                let target = dns_decode_target_data_to_string(&rdata[6..])?;
+                // An empty (root, ".") target per RFC 2782 explicitly means the service is not
+                // available, so there is no usable endpoint. Reject it rather than emit a
+                // "scheme://:port" URL with an empty host.
+                if target.is_empty() {
+                    return Err(SrvRecordParseError::EmptyTarget);
+                }
+                Ok(DnsSrvRecord {
+                    priority,
+                    weight,
+                    port,
+                    target,
+                })
+            }
+        }
+
+        impl TryFrom<&QueryRecordResult> for DnsSrvRecord {
+            type Error = SrvRecordParseError;
+
+            fn try_from(record: &QueryRecordResult) -> Result<Self, Self::Error> {
+                Self::from_rdata(record.rdata.as_slice())
+            }
+        }
+
+        /// Decodes a DNS name in wire format (length-prefixed labels ending in a root label)
+        /// into a dotted string.
+        ///
+        /// The name must be well-formed: every label fully present and at most 63 bytes, ending
+        /// with the root label (a zero length byte). A truncated label, an oversized label byte
+        /// (>63, e.g. a compression pointer, which RFC 2782 forbids in an SRV target), or a name
+        /// that runs off the end without a root terminator is rejected as `MalformedTarget`
+        /// rather than returning the partial labels collected so far.
+        pub(crate) fn dns_decode_target_data_to_string(v: &[u8]) -> Result<String, SrvRecordParseError> {
+            const MAX_LABEL_LEN: usize = 63;
+
             let mut names = Vec::new();
 
             let mut i = 0;
             while i < v.len() {
                 let size = v[i] as usize;
-                if size == 0 || i + 1 + size > v.len() {
-                    break;
+                if size == 0 {
+                    // Root label: the name is complete and correctly terminated.
+                    return Ok(names.join("."));
+                }
+                if size > MAX_LABEL_LEN || i + 1 + size > v.len() {
+                    return Err(SrvRecordParseError::MalformedTarget);
                 }
                 names.push(String::from_utf8_lossy(&v[i+1..i+1+size]));
                 i = i + 1 + size;
             }
 
-            names.join(".")
+            // Reached the end without a root label: the name is truncated.
+            Err(SrvRecordParseError::MalformedTarget)
         }
 
         pub(crate) fn dns_query_srv_records(name: &str) -> Vec<DnsSrvRecord> {
@@ -208,8 +273,38 @@ cfg_if::cfg_if! {
                 loop {
                     match timeout(Duration::from_millis(query_timeout), query.next()).await {
                         Ok(Some(Ok(dns_record))) => {
-                            let srv_record: DnsSrvRecord = (&dns_record).into();
-                            dns_records.push(srv_record.to_owned());
+                            // A normal "no SRV records" outcome is a query timeout (the
+                            // Err arm below): mDNSResponder simply never calls back. Some
+                            // environments, however, have a resolver in the path (VPN,
+                            // enterprise DNS filtering, a local stub) that answers the SRV
+                            // query immediately with a negative/empty or non-SRV response.
+                            // Such a callback carries the ADD flag cleared and/or RDATA too
+                            // short to be an SRV record; parsing it blindly panics. Only ADD
+                            // callbacks with a well-formed SRV RDATA are usable records; the
+                            // rest are logged so the offending response can be diagnosed.
+                            if !dns_record.flags.contains(QueriedRecordFlags::ADD) {
+                                debug!(
+                                    name,
+                                    rr_type = ?dns_record.rr_type,
+                                    rr_class = ?dns_record.rr_class,
+                                    rdata_len = dns_record.rdata.len(),
+                                    "Skipping DNS SRV callback without ADD flag (negative response or record removal)"
+                                );
+                            } else {
+                                match DnsSrvRecord::try_from(&dns_record) {
+                                    Ok(srv_record) => dns_records.push(srv_record),
+                                    Err(reason) => {
+                                        warn!(
+                                            name,
+                                            %reason,
+                                            rr_type = ?dns_record.rr_type,
+                                            rr_class = ?dns_record.rr_class,
+                                            rdata_len = dns_record.rdata.len(),
+                                            "Ignoring malformed DNS SRV callback"
+                                        );
+                                    }
+                                }
+                            }
                             if !dns_record.flags.contains(QueriedRecordFlags::MORE_COMING) {
                                 break;
                             }
@@ -410,5 +505,102 @@ pub(crate) fn detect_kdc_hosts_from_dns(domain: &str) -> Vec<String> {
         } else {
             Vec::new()
         }
+    }
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+mod apple_srv_tests {
+    use super::{DnsSrvRecord, SrvRecordParseError};
+
+    /// Builds SRV RDATA: priority, weight, port, then `target` as length-prefixed DNS labels
+    /// terminated by the root label.
+    fn srv_rdata(priority: u16, weight: u16, port: u16, target: &str) -> Vec<u8> {
+        let mut rdata = Vec::new();
+        rdata.extend_from_slice(&priority.to_be_bytes());
+        rdata.extend_from_slice(&weight.to_be_bytes());
+        rdata.extend_from_slice(&port.to_be_bytes());
+        for label in target.split('.').filter(|label| !label.is_empty()) {
+            rdata.push(label.len() as u8);
+            rdata.extend_from_slice(label.as_bytes());
+        }
+        rdata.push(0); // root label
+        rdata
+    }
+
+    #[test]
+    fn parses_well_formed_srv_record() {
+        let rdata = srv_rdata(1, 2, 88, "dc.example.com");
+        let record = DnsSrvRecord::from_rdata(&rdata).expect("valid SRV record should parse");
+        assert_eq!(record.priority, 1);
+        assert_eq!(record.weight, 2);
+        assert_eq!(record.port, 88);
+        assert_eq!(record.target, "dc.example.com");
+    }
+
+    #[test]
+    fn rejects_empty_rdata() {
+        // The original crash: an empty negative-response callback sliced as if it were SRV.
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&[]),
+            Err(SrvRecordParseError::RdataTooShort)
+        ));
+    }
+
+    #[test]
+    fn rejects_rdata_shorter_than_fixed_header() {
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&[0, 1, 0]),
+            Err(SrvRecordParseError::RdataTooShort)
+        ));
+    }
+
+    #[test]
+    fn rejects_six_byte_rdata_with_no_target() {
+        // Exactly the 6 fixed bytes, not even a root label: a truncated name.
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&[0, 1, 0, 2, 0, 88]),
+            Err(SrvRecordParseError::MalformedTarget)
+        ));
+    }
+
+    #[test]
+    fn rejects_rfc2782_root_target() {
+        // Target "." (a lone root label): RFC 2782 "service not available".
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&[0, 1, 0, 2, 0, 88, 0]),
+            Err(SrvRecordParseError::EmptyTarget)
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_label() {
+        // "dc" then a label claiming 5 bytes with only 1 present, and no root terminator:
+        // must not be silently accepted as the partial name "dc".
+        let rdata = [0, 1, 0, 2, 0, 88, 2, b'd', b'c', 5, b'x'];
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&rdata),
+            Err(SrvRecordParseError::MalformedTarget)
+        ));
+    }
+
+    #[test]
+    fn rejects_name_without_root_terminator() {
+        // A complete label but the name runs off the end without a root label.
+        let rdata = [0, 1, 0, 2, 0, 88, 2, b'd', b'c'];
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&rdata),
+            Err(SrvRecordParseError::MalformedTarget)
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_label_length() {
+        // A label length byte above the 63-byte limit (e.g. a compression pointer 0xC0),
+        // which RFC 2782 forbids in an SRV target.
+        let rdata = [0, 1, 0, 2, 0, 88, 0xC0, 0x0C];
+        assert!(matches!(
+            DnsSrvRecord::from_rdata(&rdata),
+            Err(SrvRecordParseError::MalformedTarget)
+        ));
     }
 }


### PR DESCRIPTION
We've received crash reports from a client application on macOS showing

> thread " (46265) panicked at src/dns.rs:172:56: range end index 2 out of range for slice of length O
note: run with 'RUST_BACKTRACE=1' environment variable to display a backtrace

It's the first we've seen of it, but this client reports that it crashes _consistently_ in his environment.

The cited line lands exactly on `rdata[0..2]` inside the SRV-record parser. Presumably the `rdata` buffer was empty so slicing it caused a panic. But why is the record empty? I'm not sure.

Every callback from the DNS query returns a `DnsSrvRecord `, where the RDATA is at least 6 bytes (priority + weight + port, then the target name). The code assumes a well formed SRV record.  We see some (potential) defects in the code:

1. The parser is unguarded and trusts `rdata` to always be at least 6 bytes
2. I believe (but am not sure) that the normal "this realm has no SRV record" outcome is **not** an empty callback, but a timeout. mDNSResponder doesn't call back in time, our timeout fires and we return an empty list. I guess in this case _something_ causes the SRV query to be answered immediately, with a negative (empty) response. I'm equally not sure what that could be: VPN resolver, enterprise DNS, a local stub resolver.... Not sure.

The (blind) fix:

In `src/dns.rs`, in the macOS/iOS path:

- From → TryFrom, returning `Err` when `rdata.len() < 6` instead of slicing
- The query loop now filters on the `ADD` flag (the correct signal for "this is a real, added record"), skipping negative responses and removals rather than parsing them.
- Both skip cases are logged (`debug!`/`warn!`) with the record's `rr_type`, `rr_class`, and `rdata_len`, so if a resolver sends something unexpected again, we can see exactly what it returned instead of guessing.

For a realm with no SRV records, the empty/negative answer is ignored, we now fall through to the UDP query and then return an empty host list.