### PR TITLE
feat(sspi): add format-tagged Username::parts view

### DIFF
--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -384,13 +384,20 @@ impl From<AuthIdentity> for AuthIdentityBuffers {
     fn from(credentials: AuthIdentity) -> Self {
         let password: &str = credentials.password.as_ref().as_ref();
 
-        let domain = match credentials.username.parts() {
-            UsernameParts::UserPrincipalName { suffix, .. } => suffix,
-            UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain.unwrap_or_default(),
+        // Encode the username so that it round-trips back to the same format through
+        // `TryFrom<&AuthIdentityBuffers>` (which parses `user` and treats `domain` as a NetBIOS
+        // domain). A UPN is stored whole in `user` with an empty `domain` (parsing recovers the UPN
+        // via its `@`), while a down-level logon name keeps the `(account_name, netbios_domain)` split.
+        let (user, domain) = match credentials.username.parts() {
+            UsernameParts::UserPrincipalName { upn, .. } => (upn, ""),
+            UsernameParts::DownLevelLogonName {
+                account_name,
+                netbios_domain,
+            } => (account_name, netbios_domain.unwrap_or_default()),
         };
 
         Self {
-            user: credentials.username.account_name().into(),
+            user: user.into(),
             domain: domain.into(),
             password: ZeroizedUtf16String(password.into()).into(),
         }
@@ -882,5 +889,28 @@ mod tests {
         let upn = Username::new_upn("alice", "example").expect("upn");
         let dlln = Username::new_down_level_logon_name("alice", "example").expect("dlln");
         assert!(!upn.eq_ignore_ascii_case(&dlln));
+    }
+
+    #[test]
+    fn auth_identity_buffers_round_trip_preserves_format() {
+        // Converting to `AuthIdentityBuffers` and back must preserve the user name format: a UPN
+        // must not silently degrade into a down-level logon name.
+        for username in [
+            Username::new_upn("alice", "example.com").expect("upn"),
+            Username::new_upn("bob@dept", "example.com").expect("upn with @ in account name"),
+            Username::new_down_level_logon_name("carol", "EXAMPLE").expect("dlln"),
+            Username::parse("dave").expect("bare name"),
+        ] {
+            let identity = AuthIdentity {
+                username: username.clone(),
+                password: String::new().into(),
+            };
+
+            let buffers = AuthIdentityBuffers::from(identity);
+            let round_trip = AuthIdentity::try_from(&buffers).expect("round-trip");
+
+            assert_eq!(round_trip.username, username);
+            assert_eq!(round_trip.username.format(), username.format());
+        }
     }
 }

--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -44,6 +44,91 @@ pub struct Username {
     sep_idx: Option<usize>,
 }
 
+/// A format-tagged, borrowed view into the components of a [`Username`].
+///
+/// Unlike the (deprecated) [`Username::domain_name`] accessor, each variant only exposes the
+/// fields that are actually meaningful for its [`UserNameFormat`]. This makes it impossible to
+/// mistake a UPN suffix for a NetBIOS domain name (or vice versa): the [`UsernameParts::UserPrincipalName`]
+/// arm has no "domain" field at all, only a `suffix`.
+///
+/// Matching is exhaustive over the two [User Name Formats], so callers are forced to handle both.
+///
+/// [User Name Formats]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum UsernameParts<'a> {
+    /// [User principal name] components, e.g. `account_name@suffix`.
+    ///
+    /// [User principal name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name
+    UserPrincipalName {
+        /// The account name, i.e. the part before the `@`.
+        account_name: &'a str,
+        /// The UPN suffix, i.e. the part after the `@`. This is *not* a NetBIOS domain name.
+        suffix: &'a str,
+        /// The complete user principal name (`account_name@suffix`), borrowed as-is.
+        ///
+        /// For a UPN, this whole string is what identifies the user (e.g. it is used verbatim as the
+        /// NT-ENTERPRISE client name in Kerberos), unlike a down-level logon name where only
+        /// `account_name` does. Prefer this over reconstructing the string from `account_name`/`suffix`
+        /// or reaching for [`Username::inner`].
+        upn: &'a str,
+    },
+    /// [Down-level logon name] components, e.g. `netbios_domain\account_name`.
+    ///
+    /// [Down-level logon name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name
+    DownLevelLogonName {
+        /// The account name, i.e. the part after the `\` (or the whole value when there is no separator).
+        account_name: &'a str,
+        /// The NetBIOS domain name, i.e. the part before the `\`, or `None` when the value has no separator.
+        netbios_domain: Option<&'a str>,
+    },
+}
+
+impl UsernameParts<'_> {
+    /// Compares two username views for equality, ignoring ASCII case.
+    ///
+    /// Equality is *format-aware*: a [`UsernameParts::UserPrincipalName`] and a
+    /// [`UsernameParts::DownLevelLogonName`] are never equal, even if their account names and their
+    /// UPN suffix / NetBIOS domain happen to match case-insensitively. Because the format is part of
+    /// the comparison, a UPN suffix is only ever compared against another UPN suffix, and a NetBIOS
+    /// domain only ever against another NetBIOS domain: the two can never be conflated.
+    pub fn eq_ignore_ascii_case(&self, other: &UsernameParts<'_>) -> bool {
+        match (*self, *other) {
+            (
+                UsernameParts::UserPrincipalName {
+                    account_name: lhs_account,
+                    suffix: lhs_suffix,
+                    ..
+                },
+                UsernameParts::UserPrincipalName {
+                    account_name: rhs_account,
+                    suffix: rhs_suffix,
+                    ..
+                },
+            ) => lhs_account.eq_ignore_ascii_case(rhs_account) && lhs_suffix.eq_ignore_ascii_case(rhs_suffix),
+            (
+                UsernameParts::DownLevelLogonName {
+                    account_name: lhs_account,
+                    netbios_domain: lhs_domain,
+                },
+                UsernameParts::DownLevelLogonName {
+                    account_name: rhs_account,
+                    netbios_domain: rhs_domain,
+                },
+            ) => {
+                let domains_equal = match (lhs_domain, rhs_domain) {
+                    (Some(lhs_domain), Some(rhs_domain)) => lhs_domain.eq_ignore_ascii_case(rhs_domain),
+                    (None, None) => true,
+                    _ => false,
+                };
+
+                lhs_account.eq_ignore_ascii_case(rhs_account) && domains_equal
+            }
+            // Different formats are distinct identities.
+            _ => false,
+        }
+    }
+}
+
 impl Username {
     /// Builds a user principal name from an account name and an UPN suffix
     pub fn new_upn(account_name: &str, upn_suffix: &str) -> Result<Self, UsernameError> {
@@ -123,7 +208,44 @@ impl Username {
         self.format
     }
 
+    /// Returns a format-tagged, borrowed view into the components of the username.
+    ///
+    /// Prefer this over [`Username::domain_name`]: matching on the returned [`UsernameParts`]
+    /// forces both user name formats to be handled explicitly and prevents confusing a UPN
+    /// suffix with a NetBIOS domain name.
+    pub fn parts(&self) -> UsernameParts<'_> {
+        match self.format {
+            UserNameFormat::UserPrincipalName => {
+                // A user principal name is always built with a separator (the `@`).
+                let idx = self.sep_idx.expect("a UPN always has an `@` separator");
+                UsernameParts::UserPrincipalName {
+                    account_name: &self.value[..idx],
+                    suffix: &self.value[idx + 1..],
+                    upn: &self.value,
+                }
+            }
+            UserNameFormat::DownLevelLogonName => match self.sep_idx {
+                Some(idx) => UsernameParts::DownLevelLogonName {
+                    account_name: &self.value[idx + 1..],
+                    netbios_domain: Some(&self.value[..idx]),
+                },
+                None => UsernameParts::DownLevelLogonName {
+                    account_name: &self.value,
+                    netbios_domain: None,
+                },
+            },
+        }
+    }
+
     /// May return an UPN suffix or NetBIOS domain name depending on the internal format
+    #[allow(
+        clippy::deprecated_semver,
+        reason = "`<next-version>` placeholder filled in at release time"
+    )]
+    #[deprecated(
+        since = "<next-version>",
+        note = "conflates UPN suffix with NetBIOS domain; match on `Username::parts()` instead — see https://github.com/Devolutions/sspi-rs/issues/708"
+    )]
     pub fn domain_name(&self) -> Option<&str> {
         self.sep_idx.map(|idx| match self.format {
             UserNameFormat::UserPrincipalName => &self.value[idx + 1..],
@@ -141,6 +263,15 @@ impl Username {
         } else {
             &self.value
         }
+    }
+
+    /// Compares two usernames for equality, ignoring ASCII case.
+    ///
+    /// This is a case-insensitive counterpart to the (case-sensitive) [`PartialEq`] implementation,
+    /// matching Windows' case-insensitive treatment of account and domain names. Usernames of
+    /// different [formats](UserNameFormat) are never equal (see [`UsernameParts::eq_ignore_ascii_case`]).
+    pub fn eq_ignore_ascii_case(&self, other: &Username) -> bool {
+        self.parts().eq_ignore_ascii_case(&other.parts())
     }
 }
 
@@ -253,9 +384,14 @@ impl From<AuthIdentity> for AuthIdentityBuffers {
     fn from(credentials: AuthIdentity) -> Self {
         let password: &str = credentials.password.as_ref().as_ref();
 
+        let domain = match credentials.username.parts() {
+            UsernameParts::UserPrincipalName { suffix, .. } => suffix,
+            UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain.unwrap_or_default(),
+        };
+
         Self {
             user: credentials.username.account_name().into(),
-            domain: credentials.username.domain_name().unwrap_or_default().into(),
+            domain: domain.into(),
             password: ZeroizedUtf16String(password.into()).into(),
         }
     }
@@ -613,18 +749,35 @@ mod tests {
             let initial_username = res.unwrap();
             assert_eq!(initial_username.inner(), value);
 
-            if let Some(domain_name) = initial_username.domain_name() {
-                let upn = Username::new_upn(initial_username.account_name(), domain_name).expect("UPN");
-                assert_eq!(upn.account_name(), initial_username.account_name());
-                assert_eq!(upn.domain_name(), initial_username.domain_name());
+            // The "domain-ish" component, whatever its format-specific meaning is.
+            let domain = match initial_username.parts() {
+                UsernameParts::UserPrincipalName { suffix, .. } => Some(suffix),
+                UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain,
+            };
+
+            if let Some(domain) = domain {
+                let reconstructed_upn = Username::new_upn(initial_username.account_name(), domain).expect("UPN");
+                assert_eq!(reconstructed_upn.account_name(), initial_username.account_name());
+                assert_eq!(
+                    reconstructed_upn.parts(),
+                    UsernameParts::UserPrincipalName {
+                        account_name: initial_username.account_name(),
+                        suffix: domain,
+                        upn: reconstructed_upn.inner(),
+                    }
+                );
             }
 
             // A down-level user name can't contain a @ in the account name
             if !initial_username.account_name().contains('@') {
-                let netbios_name = Username::new(initial_username.account_name(), initial_username.domain_name()).expect("NetBIOS");
+                let netbios_name = Username::new(initial_username.account_name(), domain).expect("NetBIOS");
                 assert_eq!(netbios_name.format(), UserNameFormat::DownLevelLogonName);
                 assert_eq!(netbios_name.account_name(), initial_username.account_name());
-                assert_eq!(netbios_name.domain_name(), initial_username.domain_name());
+                let netbios_domain = match netbios_name.parts() {
+                    UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain,
+                    UsernameParts::UserPrincipalName { .. } => unreachable!("constructed as a down-level logon name"),
+                };
+                assert_eq!(netbios_domain, domain);
             }
         })
     }
@@ -640,8 +793,15 @@ mod tests {
             let username = Username::new_upn(&account_name, &domain_name).expect("UPN");
 
             assert_eq!(username.account_name(), account_name);
-            assert_eq!(username.domain_name(), Some(domain_name.as_str()));
             assert_eq!(username.format(), UserNameFormat::UserPrincipalName);
+            assert_eq!(
+                username.parts(),
+                UsernameParts::UserPrincipalName {
+                    account_name: &account_name,
+                    suffix: &domain_name,
+                    upn: username.inner(),
+                }
+            );
 
             check_round_trip_property(&username);
         })
@@ -653,10 +813,74 @@ mod tests {
             let username = Username::new_down_level_logon_name(&account_name, &domain_name).expect("down-level logon name");
 
             assert_eq!(username.account_name(), account_name);
-            assert_eq!(username.domain_name(), Some(domain_name.as_str()));
             assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
+            assert_eq!(
+                username.parts(),
+                UsernameParts::DownLevelLogonName {
+                    account_name: &account_name,
+                    netbios_domain: Some(&domain_name),
+                }
+            );
 
             check_round_trip_property(&username);
         })
+    }
+
+    #[test]
+    fn down_level_logon_name_without_domain_parts() {
+        // When a bare name (no `\` and no `@`) is parsed, it is a down-level logon name with no
+        // NetBIOS domain: the `netbios_domain` field must be `None`.
+        proptest!(|(account_name in "[a-zA-Z0-9.]{1,3}")| {
+            let username = Username::parse(&account_name).expect("parse");
+
+            assert_eq!(username.account_name(), account_name);
+            assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
+            assert_eq!(
+                username.parts(),
+                UsernameParts::DownLevelLogonName {
+                    account_name: &account_name,
+                    netbios_domain: None,
+                }
+            );
+
+            check_round_trip_property(&username);
+        })
+    }
+
+    #[test]
+    fn eq_ignore_ascii_case_matches_within_format() {
+        // UPNs that differ only by ASCII case are equal.
+        let upn = Username::new_upn("Alice", "Example.COM").expect("upn");
+        let upn_other_case = Username::new_upn("alice", "example.com").expect("upn");
+        assert!(upn.eq_ignore_ascii_case(&upn_other_case));
+
+        // Down-level logon names that differ only by ASCII case are equal.
+        let dlln = Username::new_down_level_logon_name("Bob", "EXAMPLE").expect("dlln");
+        let dlln_other_case = Username::new_down_level_logon_name("bob", "example").expect("dlln");
+        assert!(dlln.eq_ignore_ascii_case(&dlln_other_case));
+
+        // Bare down-level logon names (no NetBIOS domain) compare on the account name only.
+        let bare = Username::parse("Carol").expect("parse");
+        let bare_other_case = Username::parse("carol").expect("parse");
+        assert!(bare.eq_ignore_ascii_case(&bare_other_case));
+    }
+
+    #[test]
+    fn eq_ignore_ascii_case_distinguishes_components_and_formats() {
+        // Different account names are not equal.
+        let alice = Username::new_upn("alice", "example.com").expect("upn");
+        let bob = Username::new_upn("bob", "example.com").expect("upn");
+        assert!(!alice.eq_ignore_ascii_case(&bob));
+
+        // A present NetBIOS domain never equals an absent one.
+        let with_domain = Username::new_down_level_logon_name("alice", "EXAMPLE").expect("dlln");
+        let without_domain = Username::parse("alice").expect("parse");
+        assert!(!with_domain.eq_ignore_ascii_case(&without_domain));
+
+        // A UPN and a down-level logon name are distinct identities even with matching components:
+        // the UPN suffix must never be conflated with the NetBIOS domain across formats.
+        let upn = Username::new_upn("alice", "example").expect("upn");
+        let dlln = Username::new_down_level_logon_name("alice", "example").expect("dlln");
+        assert!(!upn.eq_ignore_ascii_case(&dlln));
     }
 }

--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -47,11 +47,15 @@ pub struct Username {
 /// A format-tagged, borrowed view into the components of a [`Username`].
 ///
 /// Unlike the (deprecated) [`Username::domain_name`] accessor, each variant only exposes the
-/// fields that are actually meaningful for its [`UserNameFormat`]. This makes it impossible to
-/// mistake a UPN suffix for a NetBIOS domain name (or vice versa): the [`UsernameParts::UserPrincipalName`]
-/// arm has no "domain" field at all, only a `suffix`.
+/// components that are actually meaningful for its [`UserNameFormat`]. This makes it impossible to
+/// mistake a UPN suffix for a NetBIOS domain name (or vice versa): the [`UserPrincipalNameParts`]
+/// arm has no "domain" component at all, only a suffix.
 ///
 /// Matching is exhaustive over the two [User Name Formats], so callers are forced to handle both.
+///
+/// A `UsernameParts` can only be obtained from [`Username::parts`]; the variant payloads are opaque
+/// (accessor-only, not constructible outside this crate), so a view can never be forged into an
+/// inconsistent state.
 ///
 /// [User Name Formats]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -59,28 +63,66 @@ pub enum UsernameParts<'a> {
     /// [User principal name] components, e.g. `account_name@suffix`.
     ///
     /// [User principal name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name
-    UserPrincipalName {
-        /// The account name, i.e. the part before the `@`.
-        account_name: &'a str,
-        /// The UPN suffix, i.e. the part after the `@`. This is *not* a NetBIOS domain name.
-        suffix: &'a str,
-        /// The complete user principal name (`account_name@suffix`), borrowed as-is.
-        ///
-        /// For a UPN, this whole string is what identifies the user (e.g. it is used verbatim as the
-        /// NT-ENTERPRISE client name in Kerberos), unlike a down-level logon name where only
-        /// `account_name` does. Prefer this over reconstructing the string from `account_name`/`suffix`
-        /// or reaching for [`Username::inner`].
-        upn: &'a str,
-    },
+    UserPrincipalName(UserPrincipalNameParts<'a>),
     /// [Down-level logon name] components, e.g. `netbios_domain\account_name`.
     ///
     /// [Down-level logon name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name
-    DownLevelLogonName {
-        /// The account name, i.e. the part after the `\` (or the whole value when there is no separator).
-        account_name: &'a str,
-        /// The NetBIOS domain name, i.e. the part before the `\`, or `None` when the value has no separator.
-        netbios_domain: Option<&'a str>,
-    },
+    DownLevelLogonName(DownLevelLogonNameParts<'a>),
+}
+
+/// The components of a [user principal name](UsernameParts::UserPrincipalName).
+///
+/// Obtained via [`Username::parts`]; the components are opaque and exposed through accessors only,
+/// so this type can never be constructed with inconsistent fields.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct UserPrincipalNameParts<'a> {
+    account_name: &'a str,
+    suffix: &'a str,
+    upn: &'a str,
+}
+
+impl<'a> UserPrincipalNameParts<'a> {
+    /// The account name, i.e. the part before the `@`.
+    pub fn account_name(&self) -> &'a str {
+        self.account_name
+    }
+
+    /// The UPN suffix, i.e. the part after the `@`. This is *not* a NetBIOS domain name.
+    pub fn suffix(&self) -> &'a str {
+        self.suffix
+    }
+
+    /// The complete user principal name (`account_name@suffix`), borrowed as-is.
+    ///
+    /// For a UPN, this whole string is what identifies the user (e.g. it is used verbatim as the
+    /// NT-ENTERPRISE client name in Kerberos), unlike a down-level logon name where only
+    /// `account_name` does. Prefer this over reconstructing the string from `account_name`/`suffix`
+    /// or reaching for [`Username::inner`].
+    pub fn upn(&self) -> &'a str {
+        self.upn
+    }
+}
+
+/// The components of a [down-level logon name](UsernameParts::DownLevelLogonName).
+///
+/// Obtained via [`Username::parts`]; the components are opaque and exposed through accessors only,
+/// so this type can never be constructed with inconsistent fields.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DownLevelLogonNameParts<'a> {
+    account_name: &'a str,
+    netbios_domain: Option<&'a str>,
+}
+
+impl<'a> DownLevelLogonNameParts<'a> {
+    /// The account name, i.e. the part after the `\` (or the whole value when there is no separator).
+    pub fn account_name(&self) -> &'a str {
+        self.account_name
+    }
+
+    /// The NetBIOS domain name, i.e. the part before the `\`, or `None` when the value has no separator.
+    pub fn netbios_domain(&self) -> Option<&'a str> {
+        self.netbios_domain
+    }
 }
 
 impl UsernameParts<'_> {
@@ -92,36 +134,19 @@ impl UsernameParts<'_> {
     /// the comparison, a UPN suffix is only ever compared against another UPN suffix, and a NetBIOS
     /// domain only ever against another NetBIOS domain: the two can never be conflated.
     pub fn eq_ignore_ascii_case(&self, other: &UsernameParts<'_>) -> bool {
-        match (*self, *other) {
-            (
-                UsernameParts::UserPrincipalName {
-                    account_name: lhs_account,
-                    suffix: lhs_suffix,
-                    ..
-                },
-                UsernameParts::UserPrincipalName {
-                    account_name: rhs_account,
-                    suffix: rhs_suffix,
-                    ..
-                },
-            ) => lhs_account.eq_ignore_ascii_case(rhs_account) && lhs_suffix.eq_ignore_ascii_case(rhs_suffix),
-            (
-                UsernameParts::DownLevelLogonName {
-                    account_name: lhs_account,
-                    netbios_domain: lhs_domain,
-                },
-                UsernameParts::DownLevelLogonName {
-                    account_name: rhs_account,
-                    netbios_domain: rhs_domain,
-                },
-            ) => {
-                let domains_equal = match (lhs_domain, rhs_domain) {
+        match (self, other) {
+            (UsernameParts::UserPrincipalName(lhs), UsernameParts::UserPrincipalName(rhs)) => {
+                // `upn` is fully determined by `account_name` and `suffix`, so it needs no comparison.
+                lhs.account_name.eq_ignore_ascii_case(rhs.account_name) && lhs.suffix.eq_ignore_ascii_case(rhs.suffix)
+            }
+            (UsernameParts::DownLevelLogonName(lhs), UsernameParts::DownLevelLogonName(rhs)) => {
+                let domains_equal = match (lhs.netbios_domain, rhs.netbios_domain) {
                     (Some(lhs_domain), Some(rhs_domain)) => lhs_domain.eq_ignore_ascii_case(rhs_domain),
                     (None, None) => true,
                     _ => false,
                 };
 
-                lhs_account.eq_ignore_ascii_case(rhs_account) && domains_equal
+                lhs.account_name.eq_ignore_ascii_case(rhs.account_name) && domains_equal
             }
             // Different formats are distinct identities.
             _ => false,
@@ -156,6 +181,16 @@ impl Username {
 
         if netbios_domain_name.contains(['\\', '@']) {
             return Err(UsernameError::MixedFormat);
+        }
+
+        // An empty NetBIOS domain means "no domain": represent it accurately as a separator-less
+        // down-level logon name (`netbios_domain == None`) rather than a distinct `Some("")`.
+        if netbios_domain_name.is_empty() {
+            return Ok(Self {
+                value: account_name.to_owned(),
+                format: UserNameFormat::DownLevelLogonName,
+                sep_idx: None,
+            });
         }
 
         Ok(Self {
@@ -218,21 +253,21 @@ impl Username {
             UserNameFormat::UserPrincipalName => {
                 // A user principal name is always built with a separator (the `@`).
                 let idx = self.sep_idx.expect("a UPN always has an `@` separator");
-                UsernameParts::UserPrincipalName {
+                UsernameParts::UserPrincipalName(UserPrincipalNameParts {
                     account_name: &self.value[..idx],
                     suffix: &self.value[idx + 1..],
                     upn: &self.value,
-                }
+                })
             }
             UserNameFormat::DownLevelLogonName => match self.sep_idx {
-                Some(idx) => UsernameParts::DownLevelLogonName {
+                Some(idx) => UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
                     account_name: &self.value[idx + 1..],
                     netbios_domain: Some(&self.value[..idx]),
-                },
-                None => UsernameParts::DownLevelLogonName {
+                }),
+                None => UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
                     account_name: &self.value,
                     netbios_domain: None,
-                },
+                }),
             },
         }
     }
@@ -389,11 +424,10 @@ impl From<AuthIdentity> for AuthIdentityBuffers {
         // domain). A UPN is stored whole in `user` with an empty `domain` (parsing recovers the UPN
         // via its `@`), while a down-level logon name keeps the `(account_name, netbios_domain)` split.
         let (user, domain) = match credentials.username.parts() {
-            UsernameParts::UserPrincipalName { upn, .. } => (upn, ""),
-            UsernameParts::DownLevelLogonName {
-                account_name,
-                netbios_domain,
-            } => (account_name, netbios_domain.unwrap_or_default()),
+            UsernameParts::UserPrincipalName(parts) => (parts.upn(), ""),
+            UsernameParts::DownLevelLogonName(parts) => {
+                (parts.account_name(), parts.netbios_domain().unwrap_or_default())
+            }
         };
 
         Self {
@@ -758,8 +792,8 @@ mod tests {
 
             // The "domain-ish" component, whatever its format-specific meaning is.
             let domain = match initial_username.parts() {
-                UsernameParts::UserPrincipalName { suffix, .. } => Some(suffix),
-                UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain,
+                UsernameParts::UserPrincipalName(upn) => Some(upn.suffix()),
+                UsernameParts::DownLevelLogonName(dlln) => dlln.netbios_domain(),
             };
 
             if let Some(domain) = domain {
@@ -767,11 +801,11 @@ mod tests {
                 assert_eq!(reconstructed_upn.account_name(), initial_username.account_name());
                 assert_eq!(
                     reconstructed_upn.parts(),
-                    UsernameParts::UserPrincipalName {
+                    UsernameParts::UserPrincipalName(UserPrincipalNameParts {
                         account_name: initial_username.account_name(),
                         suffix: domain,
                         upn: reconstructed_upn.inner(),
-                    }
+                    })
                 );
             }
 
@@ -781,8 +815,8 @@ mod tests {
                 assert_eq!(netbios_name.format(), UserNameFormat::DownLevelLogonName);
                 assert_eq!(netbios_name.account_name(), initial_username.account_name());
                 let netbios_domain = match netbios_name.parts() {
-                    UsernameParts::DownLevelLogonName { netbios_domain, .. } => netbios_domain,
-                    UsernameParts::UserPrincipalName { .. } => unreachable!("constructed as a down-level logon name"),
+                    UsernameParts::DownLevelLogonName(dlln) => dlln.netbios_domain(),
+                    UsernameParts::UserPrincipalName(_) => unreachable!("constructed as a down-level logon name"),
                 };
                 assert_eq!(netbios_domain, domain);
             }
@@ -803,11 +837,11 @@ mod tests {
             assert_eq!(username.format(), UserNameFormat::UserPrincipalName);
             assert_eq!(
                 username.parts(),
-                UsernameParts::UserPrincipalName {
+                UsernameParts::UserPrincipalName(UserPrincipalNameParts {
                     account_name: &account_name,
                     suffix: &domain_name,
                     upn: username.inner(),
-                }
+                })
             );
 
             check_round_trip_property(&username);
@@ -823,10 +857,10 @@ mod tests {
             assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
             assert_eq!(
                 username.parts(),
-                UsernameParts::DownLevelLogonName {
+                UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
                     account_name: &account_name,
                     netbios_domain: Some(&domain_name),
-                }
+                })
             );
 
             check_round_trip_property(&username);
@@ -844,10 +878,10 @@ mod tests {
             assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
             assert_eq!(
                 username.parts(),
-                UsernameParts::DownLevelLogonName {
+                UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
                     account_name: &account_name,
                     netbios_domain: None,
-                }
+                })
             );
 
             check_round_trip_property(&username);
@@ -899,6 +933,8 @@ mod tests {
             Username::new_upn("alice", "example.com").expect("upn"),
             Username::new_upn("bob@dept", "example.com").expect("upn with @ in account name"),
             Username::new_down_level_logon_name("carol", "EXAMPLE").expect("dlln"),
+            // An empty NetBIOS domain is normalized to a separator-less down-level logon name.
+            Username::new_down_level_logon_name("erin", "").expect("dlln without domain"),
             Username::parse("dave").expect("bare name"),
         ] {
             let identity = AuthIdentity {
@@ -912,5 +948,21 @@ mod tests {
             assert_eq!(round_trip.username, username);
             assert_eq!(round_trip.username.format(), username.format());
         }
+    }
+
+    #[test]
+    fn empty_netbios_domain_is_normalized_to_no_domain() {
+        // An empty NetBIOS domain means "no domain": it must not produce a distinct `Some("")` view
+        // that would compare unequal to a separator-less down-level logon name.
+        let empty_domain = Username::new_down_level_logon_name("alice", "").expect("dlln without domain");
+        let bare = Username::parse("alice").expect("parse");
+
+        assert_eq!(empty_domain, bare);
+        assert_eq!(empty_domain.inner(), "alice");
+        assert!(matches!(
+            empty_domain.parts(),
+            UsernameParts::DownLevelLogonName(dlln) if dlln.netbios_domain().is_none()
+        ));
+        assert!(empty_domain.eq_ignore_ascii_case(&bare));
     }
 }

--- a/src/kerberos/client/change_password.rs
+++ b/src/kerberos/client/change_password.rs
@@ -10,8 +10,9 @@ use crate::kerberos::client::extractors::{
 };
 use crate::kerberos::client::generators::{
     EncKey, GenerateAsPaDataOptions, GenerateAsReqOptions, GenerateAuthenticatorOptions, generate_as_req_kdc_body,
-    generate_authenticator, generate_krb_priv_request, get_client_principal_name_type, get_client_principal_realm,
+    generate_authenticator, generate_krb_priv_request,
 };
+use crate::kerberos::client::principal::{get_client_principal_name_type, get_client_principal_realm};
 use crate::kerberos::pa_datas::AsReqPaDataOptions;
 use crate::kerberos::utils::serialize_message;
 use crate::kerberos::{CHANGE_PASSWORD_SERVICE_NAME, DEFAULT_ENCRYPTION_TYPE, KADMIN, client};

--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -1,5 +1,3 @@
-use std::env;
-use std::path::Path;
 use std::str::FromStr;
 
 use bitflags;
@@ -19,8 +17,8 @@ use picky_krb::constants::key_usages::{
 };
 use picky_krb::constants::types::{
     AD_AUTH_DATA_AP_OPTION_TYPE, AP_REP_MSG_TYPE, AP_REQ_MSG_TYPE, AS_REQ_MSG_TYPE, KERB_AP_OPTIONS_CBT, KRB_PRIV,
-    NET_BIOS_ADDR_TYPE, NT_ENTERPRISE, NT_PRINCIPAL, NT_SRV_INST, PA_ENC_TIMESTAMP, PA_ENC_TIMESTAMP_KEY_USAGE,
-    PA_PAC_OPTIONS_TYPE, PA_PAC_REQUEST_TYPE, PA_TGS_REQ_TYPE, TGS_REQ_MSG_TYPE, TGT_REQ_MSG_TYPE,
+    NET_BIOS_ADDR_TYPE, NT_SRV_INST, PA_ENC_TIMESTAMP, PA_ENC_TIMESTAMP_KEY_USAGE, PA_PAC_OPTIONS_TYPE,
+    PA_PAC_REQUEST_TYPE, PA_TGS_REQ_TYPE, TGS_REQ_MSG_TYPE, TGT_REQ_MSG_TYPE,
 };
 use picky_krb::crypto::CipherSuite;
 use picky_krb::data_types::{
@@ -42,9 +40,34 @@ use crate::channel_bindings::ChannelBindings;
 use crate::crypto::compute_md5_channel_bindings_hash;
 use crate::kerberos::flags::{ApOptions as ApOptionsFlags, KdcOptions};
 use crate::kerberos::{DEFAULT_ENCRYPTION_TYPE, EncryptionParams, KERBEROS_VERSION};
-use crate::krb::Krb5Conf;
 use crate::utils::parse_target_name;
 use crate::{ClientRequestFlags, Error, ErrorKind, Result, Secret};
+
+/// Moved to [`super::principal::get_client_principal_name_type`].
+#[allow(
+    clippy::deprecated_semver,
+    reason = "`<next-version>` placeholder filled in at release time"
+)]
+#[deprecated(
+    since = "<next-version>",
+    note = "moved to the `kerberos::client::principal` module — see https://github.com/Devolutions/sspi-rs/issues/708"
+)]
+pub fn get_client_principal_name_type(username: &str, domain: &str) -> u8 {
+    super::principal::get_client_principal_name_type(username, domain)
+}
+
+/// Moved to [`super::principal::get_client_principal_realm`].
+#[allow(
+    clippy::deprecated_semver,
+    reason = "`<next-version>` placeholder filled in at release time"
+)]
+#[deprecated(
+    since = "<next-version>",
+    note = "moved to the `kerberos::client::principal` module — see https://github.com/Devolutions/sspi-rs/issues/708"
+)]
+pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
+    super::principal::get_client_principal_realm(username, domain)
+}
 
 const TGT_TICKET_LIFETIME_DAYS: i64 = 3;
 const NONCE_LEN: usize = 4;
@@ -75,83 +98,6 @@ pub const AUTHENTICATOR_DEFAULT_CHECKSUM: [u8; 24] = [
     0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00,
 ];
-
-/// [MS-KILE] 3.3.5.6.1 Client Principal Lookup
-/// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c
-pub fn get_client_principal_name_type(username: &str, _domain: &str) -> u8 {
-    if username.contains('@') {
-        NT_ENTERPRISE
-    } else {
-        NT_PRINCIPAL
-    }
-}
-
-pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
-    // https://web.mit.edu/kerberos/krb5-current/doc/user/user_config/kerberos.html#environment-variables
-
-    let krb5_config = env::var("KRB5_CONFIG").unwrap_or_else(|_| "/etc/krb5.conf:/usr/local/etc/krb5.conf".to_string());
-    let krb5_conf_paths = krb5_config.split(':').map(Path::new).collect::<Vec<&Path>>();
-
-    get_client_principal_realm_impl(&krb5_conf_paths, username, domain)
-}
-
-fn get_client_principal_realm_impl(krb5_conf_paths: &[&Path], username: &str, domain: &str) -> String {
-    let domain = if domain.is_empty() {
-        if let Some((_left, right)) = username.split_once('@') {
-            right.to_string()
-        } else {
-            String::new()
-        }
-    } else {
-        domain.to_string()
-    };
-
-    for krb5_conf_path in krb5_conf_paths {
-        if !krb5_conf_path.exists() {
-            continue;
-        }
-
-        if let Some(krb5_conf) = Krb5Conf::new_from_file(krb5_conf_path)
-            && let Some(mappings) = krb5_conf.get_values_in_section(&["domain_realm"])
-        {
-            for (mapping_domain, realm) in mappings {
-                if matches_domain(&domain, mapping_domain) {
-                    return realm.to_owned();
-                }
-            }
-        }
-    }
-
-    domain.to_uppercase()
-}
-
-/// Checks if the given domain matches the mapping domain (usually from krb5.conf file).
-///
-/// # Mapping rules
-///
-/// We follow the MIT KRB5 behavior: https://github.com/krb5/krb5/commit/8f5ce824012f2caab6770df464f096c38dc4cb2e.
-///
-/// - If the mapping domain starts with a dot (e.g., `.example.com`),
-///   it matches all hosts under the domain, but not the host with the name `example.com`.
-///   For example, "test.example.com" or "d1.example.com" will match `.example.com`, but `example.com` will not.
-/// - If the mapping domain does not start with a dot (e.g., `example.com`),
-///   it matches all hosts under the domain `example.com` (including `example.com`).
-///
-/// So, the mappings order in `krb5.conf` matters.
-fn matches_domain(domain: &str, mapping_domain: &str) -> bool {
-    let domain = domain.to_lowercase();
-    let mapping_domain = mapping_domain.to_lowercase();
-
-    if mapping_domain.starts_with('.') {
-        // If mapping_domain starts with a dot, it matches subdomains only
-        // e.g., `.example.com` matches `test.example.com` but not `example.com`
-        domain.ends_with(&mapping_domain)
-    } else {
-        // If mapping_domain doesn't start with a dot, it matches the domain itself
-        // and all subdomains (e.g., `example.com` matches `example.com` and `test.example.com`).
-        domain == mapping_domain || domain.ends_with(&format!(".{mapping_domain}"))
-    }
-}
 
 pub(super) fn generate_tgt_req(sname: &[&str]) -> Result<TgtReq> {
     let sname = sname
@@ -894,9 +840,9 @@ pub fn generate_krb_priv_request(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use picky_krb::constants::types::NT_PRINCIPAL;
 
-    const KRB5_CONFIG_FILE_PATH: &str = "test_assets/krb5.conf";
+    use super::*;
 
     #[test]
     fn test_set_flags() {
@@ -925,42 +871,6 @@ mod tests {
         checksum_values.set_flags(flags);
         let expected_bytes = [0x3E, 0x00, 0x00, 0x00];
         assert_eq!(checksum_values.inner[20..24], expected_bytes);
-    }
-
-    #[test]
-    fn test_get_client_principal_realm_from_domain() {
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "TBT.COM");
-        assert_eq!(realm, "TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "C1.DEV.TBT.COM");
-        assert_eq!(realm, "TEST.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "P1.C2.DEV.TBT.COM");
-        assert_eq!(realm, "TEST.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "DEV.TBT.COM");
-        assert_eq!(realm, "DEV.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "TEST.TBT.COM");
-        assert_eq!(realm, "STAGE.TBT.COM");
-    }
-
-    #[test]
-    fn test_get_client_principal_realm_from_username() {
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@tbt.com", "");
-        assert_eq!(realm, "TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@c1.dev.tbt.com", "");
-        assert_eq!(realm, "TEST.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@p1.c2.dev.tbt.com", "");
-        assert_eq!(realm, "TEST.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@dev.tbt.com", "");
-        assert_eq!(realm, "DEV.TBT.COM");
-
-        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@test.tbt.com", "");
-        assert_eq!(realm, "STAGE.TBT.COM");
     }
 
     fn cname_components(username: &str) -> Vec<String> {

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -2,6 +2,7 @@ mod as_exchange;
 mod change_password;
 pub mod extractors;
 pub mod generators;
+pub mod principal;
 
 use std::io::Write;
 
@@ -23,7 +24,9 @@ use self::generators::{
     ChecksumOptions, ChecksumValues, EncKey, GenerateAsPaDataOptions, GenerateAsReqOptions,
     GenerateAuthenticatorOptions, GenerateKeytabPaDataOptions, GenerateTgsReqOptions, GssFlags, generate_ap_rep,
     generate_ap_req, generate_as_req_kdc_body, generate_authenticator, generate_tgs_req,
-    get_client_principal_name_type, get_client_principal_realm,
+};
+use self::principal::{
+    ClientPrincipalName, get_client_principal_name, get_client_principal_name_type, get_client_principal_realm,
 };
 use crate::channel_bindings::ChannelBindings;
 use crate::generator::YieldPointLocal;
@@ -36,7 +39,6 @@ use crate::utils::{generate_random_symmetric_key, parse_target_name};
 use crate::{
     BufferType, ClientRequestFlags, ClientResponseFlags, CredentialsBuffers, Error, ErrorKind,
     InitializeSecurityContextResult, Kerberos, KerberosState, Result, SecurityBuffer, SecurityStatus, SspiImpl,
-    UserNameFormat,
 };
 
 /// Inspects the `sname` of a ticket returned in a TGS-REP to decide whether it is a cross-realm
@@ -163,24 +165,17 @@ pub async fn initialize_security_context<'a>(
                     (username, password, realm.to_uppercase(), cname_type)
                 }
                 CredentialsBuffers::Keytab(keytab) => {
-                    // Classify the principal exactly like the AuthIdentity branch: a UPN must
-                    // reach `get_client_principal_name_type` with its `@suffix` intact so that it
-                    // is recognized as NT_ENTERPRISE (MS-KILE 3.3.5.6.1). For down-level logon
-                    // names, the account name and NetBIOS domain are passed separately, yielding
-                    // NT_PRINCIPAL as before.
-                    let (username, domain) = match keytab.principal.format() {
-                        UserNameFormat::UserPrincipalName => (keytab.principal.inner().to_string(), String::new()),
-                        UserNameFormat::DownLevelLogonName => (
-                            keytab.principal.account_name().to_string(),
-                            keytab.principal.domain_name().unwrap_or_default().to_string(),
-                        ),
-                    };
+                    // The name type is read off the principal's user name format explicitly.
+                    let ClientPrincipalName {
+                        name,
+                        realm_domain,
+                        name_type,
+                    } = get_client_principal_name(&keytab.principal);
 
-                    let realm = get_client_principal_realm(&username, &domain);
-                    let cname_type = get_client_principal_name_type(&username, &domain);
+                    let realm = get_client_principal_realm(name, realm_domain);
 
                     // No password: the keytab key is used directly for pre-auth.
-                    (username, String::new(), realm, cname_type)
+                    (name.to_owned(), String::new(), realm, name_type)
                 }
             };
             client.realm = Some(realm.clone());

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -65,7 +65,8 @@ pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
 
 fn get_client_principal_realm_impl(krb5_conf_paths: &[&Path], username: &str, domain: &str) -> String {
     let domain = if domain.is_empty() {
-        if let Some((_left, right)) = username.split_once('@') {
+        // Match `Username::parse`, which splits a UPN on its *last* `@` (account names may contain `@`).
+        if let Some((_left, right)) = username.rsplit_once('@') {
             right.to_string()
         } else {
             String::new()
@@ -188,5 +189,13 @@ mod tests {
 
         let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@test.tbt.com", "");
         assert_eq!(realm, "STAGE.TBT.COM");
+    }
+
+    #[test]
+    fn realm_from_username_splits_on_last_at() {
+        // `Username::parse` splits a UPN on its *last* `@`, so the realm must be derived from the
+        // suffix after the final `@` even when the account name itself contains an `@`.
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@dept@tbt.com", "");
+        assert_eq!(realm, "TBT.COM");
     }
 }

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -1,0 +1,192 @@
+//! Helpers deriving the Kerberos client principal (name, name type and realm) from credentials.
+
+use std::env;
+use std::path::Path;
+
+use picky_krb::constants::types::{NT_ENTERPRISE, NT_PRINCIPAL};
+
+use crate::krb::Krb5Conf;
+use crate::{Username, UsernameParts};
+
+/// [MS-KILE] 3.3.5.6.1 Client Principal Lookup
+/// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c
+pub fn get_client_principal_name_type(username: &str, _domain: &str) -> u8 {
+    if username.contains('@') {
+        NT_ENTERPRISE
+    } else {
+        NT_PRINCIPAL
+    }
+}
+
+/// The Kerberos client name (cname) derived from a [`Username`], along with the pieces needed to
+/// build the AS-REQ.
+///
+/// This centralizes the mapping from a [`UserNameFormat`](crate::UserNameFormat) to a Kerberos
+/// principal name type: it reads the name type off the username format explicitly instead of
+/// sniffing for an `@`, so a UPN principal is an NT-ENTERPRISE name (whose full value is the client
+/// name) and a down-level logon name is an NT-PRINCIPAL name identified by its account name alone.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ClientPrincipalName<'a> {
+    /// The name to place in the AS-REQ as the Kerberos client name (cname).
+    pub name: &'a str,
+    /// The domain used to resolve the client realm (the UPN suffix or the NetBIOS domain).
+    pub realm_domain: &'a str,
+    /// The Kerberos principal name type (`NT-ENTERPRISE` or `NT-PRINCIPAL`).
+    pub name_type: u8,
+}
+
+/// Derives the [`ClientPrincipalName`] for a principal from its user name format.
+pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_> {
+    match username.parts() {
+        UsernameParts::UserPrincipalName { upn, suffix, .. } => ClientPrincipalName {
+            name: upn,
+            realm_domain: suffix,
+            name_type: NT_ENTERPRISE,
+        },
+        UsernameParts::DownLevelLogonName {
+            account_name,
+            netbios_domain,
+        } => ClientPrincipalName {
+            name: account_name,
+            realm_domain: netbios_domain.unwrap_or_default(),
+            name_type: NT_PRINCIPAL,
+        },
+    }
+}
+
+pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
+    // https://web.mit.edu/kerberos/krb5-current/doc/user/user_config/kerberos.html#environment-variables
+
+    let krb5_config = env::var("KRB5_CONFIG").unwrap_or_else(|_| "/etc/krb5.conf:/usr/local/etc/krb5.conf".to_string());
+    let krb5_conf_paths = krb5_config.split(':').map(Path::new).collect::<Vec<&Path>>();
+
+    get_client_principal_realm_impl(&krb5_conf_paths, username, domain)
+}
+
+fn get_client_principal_realm_impl(krb5_conf_paths: &[&Path], username: &str, domain: &str) -> String {
+    let domain = if domain.is_empty() {
+        if let Some((_left, right)) = username.split_once('@') {
+            right.to_string()
+        } else {
+            String::new()
+        }
+    } else {
+        domain.to_string()
+    };
+
+    for krb5_conf_path in krb5_conf_paths {
+        if !krb5_conf_path.exists() {
+            continue;
+        }
+
+        if let Some(krb5_conf) = Krb5Conf::new_from_file(krb5_conf_path)
+            && let Some(mappings) = krb5_conf.get_values_in_section(&["domain_realm"])
+        {
+            for (mapping_domain, realm) in mappings {
+                if matches_domain(&domain, mapping_domain) {
+                    return realm.to_owned();
+                }
+            }
+        }
+    }
+
+    domain.to_uppercase()
+}
+
+/// Checks if the given domain matches the mapping domain (usually from krb5.conf file).
+///
+/// # Mapping rules
+///
+/// We follow the MIT KRB5 behavior: https://github.com/krb5/krb5/commit/8f5ce824012f2caab6770df464f096c38dc4cb2e.
+///
+/// - If the mapping domain starts with a dot (e.g., `.example.com`),
+///   it matches all hosts under the domain, but not the host with the name `example.com`.
+///   For example, "test.example.com" or "d1.example.com" will match `.example.com`, but `example.com` will not.
+/// - If the mapping domain does not start with a dot (e.g., `example.com`),
+///   it matches all hosts under the domain `example.com` (including `example.com`).
+///
+/// So, the mappings order in `krb5.conf` matters.
+fn matches_domain(domain: &str, mapping_domain: &str) -> bool {
+    let domain = domain.to_lowercase();
+    let mapping_domain = mapping_domain.to_lowercase();
+
+    if mapping_domain.starts_with('.') {
+        // If mapping_domain starts with a dot, it matches subdomains only
+        // e.g., `.example.com` matches `test.example.com` but not `example.com`
+        domain.ends_with(&mapping_domain)
+    } else {
+        // If mapping_domain doesn't start with a dot, it matches the domain itself
+        // and all subdomains (e.g., `example.com` matches `example.com` and `test.example.com`).
+        domain == mapping_domain || domain.ends_with(&format!(".{mapping_domain}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KRB5_CONFIG_FILE_PATH: &str = "test_assets/krb5.conf";
+
+    #[test]
+    fn client_principal_name_from_upn_is_enterprise() {
+        let username = Username::parse("user@example.com").expect("UPN");
+        let cname = get_client_principal_name(&username);
+        assert_eq!(cname.name, "user@example.com");
+        assert_eq!(cname.realm_domain, "example.com");
+        assert_eq!(cname.name_type, NT_ENTERPRISE);
+    }
+
+    #[test]
+    fn client_principal_name_from_down_level_is_principal() {
+        let username = Username::parse("EXAMPLE\\user").expect("down-level logon name");
+        let cname = get_client_principal_name(&username);
+        assert_eq!(cname.name, "user");
+        assert_eq!(cname.realm_domain, "EXAMPLE");
+        assert_eq!(cname.name_type, NT_PRINCIPAL);
+    }
+
+    #[test]
+    fn client_principal_name_from_bare_name_has_empty_realm_domain() {
+        let username = Username::parse("user").expect("bare name");
+        let cname = get_client_principal_name(&username);
+        assert_eq!(cname.name, "user");
+        assert_eq!(cname.realm_domain, "");
+        assert_eq!(cname.name_type, NT_PRINCIPAL);
+    }
+
+    #[test]
+    fn test_get_client_principal_realm_from_domain() {
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "TBT.COM");
+        assert_eq!(realm, "TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "C1.DEV.TBT.COM");
+        assert_eq!(realm, "TEST.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "P1.C2.DEV.TBT.COM");
+        assert_eq!(realm, "TEST.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "DEV.TBT.COM");
+        assert_eq!(realm, "DEV.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "", "TEST.TBT.COM");
+        assert_eq!(realm, "STAGE.TBT.COM");
+    }
+
+    #[test]
+    fn test_get_client_principal_realm_from_username() {
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@tbt.com", "");
+        assert_eq!(realm, "TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@c1.dev.tbt.com", "");
+        assert_eq!(realm, "TEST.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@p1.c2.dev.tbt.com", "");
+        assert_eq!(realm, "TEST.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@dev.tbt.com", "");
+        assert_eq!(realm, "DEV.TBT.COM");
+
+        let realm = get_client_principal_realm_impl(&[Path::new(KRB5_CONFIG_FILE_PATH)], "user@test.tbt.com", "");
+        assert_eq!(realm, "STAGE.TBT.COM");
+    }
+}

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -44,17 +44,14 @@ pub struct ClientPrincipalName<'a> {
 /// Derives the [`ClientPrincipalName`] for a principal from its user name format.
 pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_> {
     match username.parts() {
-        UsernameParts::UserPrincipalName { upn, suffix, .. } => ClientPrincipalName {
-            name: upn,
-            realm_domain: suffix,
+        UsernameParts::UserPrincipalName(parts) => ClientPrincipalName {
+            name: parts.upn(),
+            realm_domain: parts.suffix(),
             name_type: NT_ENTERPRISE,
         },
-        UsernameParts::DownLevelLogonName {
-            account_name,
-            netbios_domain,
-        } => ClientPrincipalName {
-            name: account_name,
-            realm_domain: netbios_domain.unwrap_or_default(),
+        UsernameParts::DownLevelLogonName(parts) => ClientPrincipalName {
+            name: parts.account_name(),
+            realm_domain: parts.netbios_domain().unwrap_or_default(),
             name_type: NT_PRINCIPAL,
         },
     }

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -10,6 +10,12 @@ use crate::{Username, UsernameParts};
 
 /// [MS-KILE] 3.3.5.6.1 Client Principal Lookup
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c
+//
+// FIXME: this should take a `&Username` instead of two `&str` parameters. It currently sniffs for an
+// `@` to guess the name type (and ignores `_domain` entirely), which is exactly the lossy heuristic
+// `Username`/`UsernameParts` exist to replace: the name type can be read off the user name format
+// directly (see `get_client_principal_name`). Once the deprecated string-based callers are gone (#708),
+// fold this into `get_client_principal_name`.
 pub fn get_client_principal_name_type(username: &str, _domain: &str) -> u8 {
     if username.contains('@') {
         NT_ENTERPRISE
@@ -54,6 +60,11 @@ pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_>
     }
 }
 
+// FIXME: like `get_client_principal_name_type`, this should take a `&Username` (or a `UsernameParts`)
+// instead of two `&str` parameters. `get_client_principal_realm_impl` re-derives the suffix by
+// splitting on `@` to reconcile the `username`/`domain` pair, which duplicates the parsing
+// `Username::parts()` already does. Migrating callers off the raw-string form (#708) would
+// let this take the parsed username directly and drop the ad-hoc split.
 pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
     // https://web.mit.edu/kerberos/krb5-current/doc/user/user_config/kerberos.html#environment-variables
 

--- a/src/kerberos/server/as_exchange.rs
+++ b/src/kerberos/server/as_exchange.rs
@@ -6,10 +6,8 @@ use rand_core::{Rng as _, SeedableRng as _};
 
 use crate::generator::YieldPointLocal;
 use crate::kerberos::client::extractors::extract_encryption_params_from_as_rep;
-use crate::kerberos::client::generators::{
-    GenerateAsPaDataOptions, GenerateAsReqOptions, generate_as_req_kdc_body, get_client_principal_name_type,
-    get_client_principal_realm,
-};
+use crate::kerberos::client::generators::{GenerateAsPaDataOptions, GenerateAsReqOptions, generate_as_req_kdc_body};
+use crate::kerberos::client::principal::{get_client_principal_name_type, get_client_principal_realm};
 use crate::kerberos::pa_datas::{AsRepSessionKeyExtractor, AsReqPaDataOptions};
 use crate::kerberos::{TGT_SERVICE_NAME, client};
 use crate::{ClientRequestFlags, CredentialsBuffers, Error, ErrorKind, Kerberos, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub use utils::modpow;
 
 pub use self::auth_identity::{
     AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, KeytabIdentity, UserNameFormat, Username,
+    UsernameParts,
 };
 #[cfg(feature = "scard")]
 pub use self::auth_identity::{CertificateRaw, SmartCardIdentity, SmartCardIdentityBuffers, SmartCardType};
@@ -1010,7 +1011,7 @@ where
     ///
     /// let names = ntlm.query_context_names().unwrap();
     /// println!("Username: {:?}", names.username.account_name());
-    /// println!("Domain: {:?}", names.username.domain_name());
+    /// println!("Parts: {:?}", names.username.parts());
     /// ```
     ///
     /// # MSDN

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ use utils::map_keb_error_code_to_sspi_error;
 pub use utils::modpow;
 
 pub use self::auth_identity::{
-    AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, KeytabIdentity, UserNameFormat, Username,
-    UsernameParts,
+    AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, DownLevelLogonNameParts, KeytabIdentity,
+    UserNameFormat, UserPrincipalNameParts, Username, UsernameParts,
 };
 #[cfg(feature = "scard")]
 pub use self::auth_identity::{CertificateRaw, SmartCardIdentity, SmartCardIdentityBuffers, SmartCardType};

--- a/src/negotiate/client.rs
+++ b/src/negotiate/client.rs
@@ -4,6 +4,7 @@ use picky_krb::constants::gss_api::{ACCEPT_COMPLETE, ACCEPT_INCOMPLETE};
 use picky_krb::gss_api::{NegTokenTarg, NegTokenTarg1};
 
 use crate::generator::YieldPointLocal;
+use crate::kerberos::client::principal::get_client_principal_name;
 use crate::negotiate::NegotiateState;
 use crate::negotiate::generators::{
     generate_final_neg_token_targ, generate_mech_type_list, generate_neg_token_init, generate_neg_token_targ_1,
@@ -52,7 +53,9 @@ pub(crate) async fn initialize_security_context<'a>(
         let auth_identity =
             AuthIdentity::try_from(&*identity).map_err(|e| Error::new(ErrorKind::InvalidParameter, e))?;
         let account_name = auth_identity.username.account_name();
-        let domain_name = auth_identity.username.domain_name().unwrap_or_default();
+        // `realm_domain` is the per-format "authority" (UPN suffix or NetBIOS domain) used purely
+        // as a best-effort realm/Azure-AD hint for protocol negotiation, not as an identity.
+        let domain_name = get_client_principal_name(&auth_identity.username).realm_domain;
         negotiate.negotiate_protocol(account_name, domain_name)?;
         negotiate.auth_identity = Some(CredentialsBuffers::AuthIdentity(auth_identity.into()));
     }
@@ -65,7 +68,7 @@ pub(crate) async fn initialize_security_context<'a>(
             // If the user provided smart card credentials, then they definitely want to use Kerberos,
             // because NTLM does not support scard logon.
 
-            use crate::kerberos::client::generators::get_client_principal_realm;
+            use crate::kerberos::client::principal::get_client_principal_realm;
             use crate::{Kerberos, KerberosConfig, detect_kdc_url};
 
             let username = identity.username.to_string();

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -19,7 +19,7 @@ use crate::generator::{
     GeneratorAcceptSecurityContext, GeneratorChangePassword, GeneratorInitSecurityContext, YieldPointLocal,
 };
 use crate::kdc::detect_kdc_url;
-use crate::kerberos::client::generators::get_client_principal_realm;
+use crate::kerberos::client::principal::{get_client_principal_name, get_client_principal_realm};
 use crate::ntlm::NtlmConfig;
 #[allow(unused)]
 use crate::utils::is_azure_ad_domain;
@@ -322,17 +322,13 @@ impl Negotiate {
             .filter(|auth_data| {
                 trace!("Comparing usernames: {:?} with {:?}", auth_data.username, username);
 
-                let domains_equal = match (auth_data.username.domain_name(), username.domain_name()) {
-                    (Some(auth_domain), Some(negotiated_domain)) => auth_domain.eq_ignore_ascii_case(negotiated_domain),
-                    (None, None) => true,
-                    _ => false,
-                };
-
-                auth_data
-                    .username
-                    .account_name()
-                    .eq_ignore_ascii_case(username.account_name())
-                    && domains_equal
+                // Usernames match only when they share the same format and the same components.
+                // `eq_ignore_ascii_case` is format-aware, so it is safe to fold the UPN suffix and the
+                // NetBIOS domain into a single "domain" comparison here: a UPN and a down-level logon
+                // name are distinct identities and never compare equal, which means the qualifier being
+                // compared always has one unambiguous meaning (a UPN suffix is only ever matched against
+                // a UPN suffix, a NetBIOS domain only ever against a NetBIOS domain).
+                auth_data.username.eq_ignore_ascii_case(&username)
             })
             .cloned()
             .map(Credentials::from)
@@ -799,7 +795,9 @@ impl SspiImpl for Negotiate {
 
         if let Some(Credentials::AuthIdentity(identity)) = builder.auth_data {
             let account_name = identity.username.account_name();
-            let domain_name = identity.username.domain_name().unwrap_or("");
+            // `realm_domain` is the per-format "authority" (UPN suffix or NetBIOS domain) used purely
+            // as a best-effort realm/Azure-AD hint for protocol negotiation, not as an identity.
+            let domain_name = get_client_principal_name(&identity.username).realm_domain;
             self.negotiate_protocol(account_name, domain_name)?;
         }
 


### PR DESCRIPTION
Add `UsernameParts`, a format-tagged, borrowed view into a `Username`, and `Username::parts()` returning it. Each variant only exposes the fields that are meaningful for its user name format, so a UPN suffix can no longer be mistaken for a NetBIOS domain: the `UserPrincipalName` arm has a `suffix` (and the full `upn`) but no "domain" field, while `DownLevelLogonName` carries an `Option<netbios_domain>` that models accurately the no-separator case. Matching is exhaustive over the two Microsoft user name formats.

`Username::domain_name()` conflates a UPN suffix with a NetBIOS domain and is deprecated in favor of `Username::parts()`. Deprecation alone is non-breaking, so this is a minor bump. Removal is a future breaking release tracked by #708.

This also fixes three UPN-vs-NetBIOS confusion bugs, all rooted in `domain_name()` returning the UPN suffix and the NetBIOS domain indistinguishably:

1. Server credential matching matched across formats: `Negotiate::set_auth_identity` collapsed both formats to a single "domain", so UPN `user@EXAMPLE` and DLLN `EXAMPLE\user` compared equal even though they are distinct identities.

2. UPN format lost through `AuthIdentityBuffers` round-trip: UPNs were stored as `(user=account, domain=suffix)`, but the reverse conversion reads `domain` as a NetBIOS domain, degrading `alice@example.com` into `example.com\alice`.

3. Realm split on the wrong `@`: `get_client_principal_realm_impl` used the first `@` while `Username::parse` uses the last, so `user@dept@example.com` derived the wrong realm.

The new format-tagged `Username::parts()` API makes this class of confusion unrepresentable.