### PR TITLE
fix(kerberos): remove unnecessary sequence number incrementation

### DIFF
--- a/src/kerberos/client/extractors.rs
+++ b/src/kerberos/client/extractors.rs
@@ -196,13 +196,13 @@ pub fn extract_status_code_from_krb_priv_response(
     Ok(u16::from_be_bytes(user_data[0..2].try_into().unwrap()))
 }
 
-/// Extracts the sequence number from the [ApRep].
+/// Decrypt and decodes the encrypted part of the encoded [ApRep] message.
 #[instrument(level = "trace", ret)]
-pub fn extract_seq_number_from_ap_rep(
+pub fn decrypt_ap_rep(
     ap_rep: &ApRep,
     session_key: &Secret<Vec<u8>>,
     enc_params: &EncryptionParams,
-) -> Result<Vec<u8>> {
+) -> Result<EncApRepPart> {
     let cipher = enc_params
         .encryption_type
         .as_ref()
@@ -218,51 +218,45 @@ pub fn extract_seq_number_from_ap_rep(
             )
         })?;
 
-    let ap_rep_enc_part: EncApRepPart = picky_asn1_der::from_bytes(&res)?;
-
-    Ok(ap_rep_enc_part
-        .0
-        .seq_number
-        .0
-        .ok_or_else(|| Error::new(ErrorKind::InvalidToken, "missing sequence number in ap_rep"))?
-        .0
-        .0)
+    Ok(picky_asn1_der::from_bytes(&res)?)
 }
 
-/// Extracts a sub-session key from the [ApRep].
+/// Extracts a sub-session key from the [EncApRepPart].
 #[instrument(level = "trace", ret)]
-pub fn extract_sub_session_key_from_ap_rep(
-    ap_rep: &ApRep,
-    session_key: &Secret<Vec<u8>>,
-    enc_params: &EncryptionParams,
-) -> Result<Secret<Vec<u8>>> {
-    let cipher = enc_params
-        .encryption_type
-        .as_ref()
-        .unwrap_or(&DEFAULT_ENCRYPTION_TYPE)
-        .cipher();
-
-    let res = cipher
-        .decrypt(session_key.as_ref(), AP_REP_ENC, &ap_rep.0.enc_part.cipher.0.0)
-        .map_err(|err| {
-            Error::new(
-                ErrorKind::DecryptFailure,
-                format!("cannot decrypt ap_rep.enc_part: {err:?}"),
-            )
-        })?;
-
-    let ap_rep_enc_part: EncApRepPart = picky_asn1_der::from_bytes(&res)?;
-
+pub fn extract_sub_session_key_from_ap_rep(ap_rep_enc_part: &EncApRepPart) -> Result<Secret<Vec<u8>>> {
     Ok(ap_rep_enc_part
         .0
         .subkey
         .0
+        .clone()
         .ok_or_else(|| Error::new(ErrorKind::InvalidToken, "missing sub-key in ap_req"))?
         .0
         .key_value
         .0
         .0
         .into())
+}
+
+/// Extracts a sequence number from the [EncApRepPart].
+#[instrument(level = "trace", ret)]
+pub fn extract_seq_number_from_ap_rep(ap_rep_enc_part: &EncApRepPart) -> Result<u32> {
+    let seq_number_bytes = ap_rep_enc_part
+        .0
+        .seq_number
+        .0
+        .clone()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidToken, "missing seq-number in ap_rep"))?
+        .0
+        .0;
+
+    let seq_number = u32::from_be_bytes(seq_number_bytes.try_into().map_err(|err| {
+        Error::new(
+            ErrorKind::InvalidToken,
+            format!("invalid ApRep sequence number: {:?}", err),
+        )
+    })?);
+
+    Ok(seq_number)
 }
 
 /// Extracts TGT Ticket from encoded [NegTokenTarg1].

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -17,8 +17,8 @@ use rand::rngs::{StdRng, SysRng};
 use rand_core::{Rng as _, SeedableRng as _};
 
 use self::extractors::{
-    extract_encryption_params_from_as_rep, extract_seq_number_from_ap_rep, extract_session_key_from_tgs_rep,
-    extract_sub_session_key_from_ap_rep, extract_tgt_ticket_with_oid,
+    decrypt_ap_rep, extract_encryption_params_from_as_rep, extract_seq_number_from_ap_rep,
+    extract_session_key_from_tgs_rep, extract_sub_session_key_from_ap_rep, extract_tgt_ticket_with_oid,
 };
 use self::generators::{
     ChecksumOptions, ChecksumValues, EncKey, GenerateAsPaDataOptions, GenerateAsReqOptions,
@@ -486,15 +486,24 @@ pub async fn initialize_security_context<'a>(
                     .session_key
                     .as_ref()
                     .ok_or_else(|| Error::new(ErrorKind::InternalError, "session key is not set"))?;
-                let sub_session_key =
-                    extract_sub_session_key_from_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
-                let seq_number = extract_seq_number_from_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
+                let ap_rep_enc_part = decrypt_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
+                let sub_session_key = extract_sub_session_key_from_ap_rep(&ap_rep_enc_part)?;
+                client.remote_seq_number = extract_seq_number_from_ap_rep(&ap_rep_enc_part)?;
+
+                let seq_number_bytes = ap_rep_enc_part
+                    .0
+                    .seq_number
+                    .0
+                    .ok_or_else(|| Error::new(ErrorKind::InvalidToken, "missing seq-number in ap_rep"))?
+                    .0
+                    .0
+                    .clone();
 
                 trace!(?sub_session_key, "DCE AP_REP sub-session key");
 
                 client.encryption_params.sub_session_key = Some(sub_session_key);
 
-                let ap_rep = generate_ap_rep(session_key, seq_number, &client.encryption_params)?;
+                let ap_rep = generate_ap_rep(session_key, seq_number_bytes, &client.encryption_params)?;
                 let ap_rep = picky_asn1_der::to_vec(&ap_rep)?;
 
                 let output_token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
@@ -507,8 +516,9 @@ pub async fn initialize_security_context<'a>(
                     .session_key
                     .as_ref()
                     .ok_or_else(|| Error::new(ErrorKind::InternalError, "session key is not set"))?;
-                let sub_session_key =
-                    extract_sub_session_key_from_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
+                let ap_rep_enc_part = decrypt_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
+                let sub_session_key = extract_sub_session_key_from_ap_rep(&ap_rep_enc_part)?;
+                client.remote_seq_number = extract_seq_number_from_ap_rep(&ap_rep_enc_part)?;
 
                 client.encryption_params.sub_session_key = Some(sub_session_key);
             }

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -511,8 +511,6 @@ pub async fn initialize_security_context<'a>(
                     extract_sub_session_key_from_ap_rep(&ap_rep, session_key, &client.encryption_params)?;
 
                 client.encryption_params.sub_session_key = Some(sub_session_key);
-
-                client.next_seq_number();
             }
 
             client.state = KerberosState::Final;

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -99,6 +99,7 @@ pub struct Kerberos {
     pub(crate) dh_parameters: Option<DhParameters>,
     pub(crate) krb5_user_to_user: bool,
     pub(crate) server: Option<Box<ServerProperties>>,
+    pub(crate) remote_seq_number: u32,
 }
 
 impl Kerberos {
@@ -119,6 +120,7 @@ impl Kerberos {
             dh_parameters: None,
             krb5_user_to_user: false,
             server: None,
+            remote_seq_number: 0,
         })
     }
 
@@ -139,6 +141,7 @@ impl Kerberos {
             dh_parameters: None,
             krb5_user_to_user: false,
             server: Some(Box::new(server_properties)),
+            remote_seq_number: 0,
         })
     }
 
@@ -752,7 +755,13 @@ impl SspiEx for Kerberos {
     }
 
     fn verify_mic_token(&mut self, token: &[u8], data: &[u8], _: crate::private::Sealed) -> Result<()> {
-        utils::validate_mic_token(self.is_client(), token, &self.encryption_params, data)
+        utils::validate_mic_token(
+            self.is_client(),
+            self.remote_seq_number.into(),
+            token,
+            &self.encryption_params,
+            data,
+        )
     }
 
     fn generate_mic_token(&mut self, data: &[u8], _: crate::private::Sealed) -> Result<Vec<u8>> {
@@ -825,6 +834,7 @@ pub mod test_data {
             dh_parameters: None,
             krb5_user_to_user: false,
             server: None,
+            remote_seq_number: 0,
         }
     }
 
@@ -871,6 +881,7 @@ pub mod test_data {
             dh_parameters: None,
             krb5_user_to_user: false,
             server: Some(Box::new(fake_server_properties())),
+            remote_seq_number: 0,
         }
     }
 }

--- a/src/kerberos/server/mod.rs
+++ b/src/kerberos/server/mod.rs
@@ -24,7 +24,7 @@ use self::generators::generate_ap_rep;
 use crate::builders::FilledAcceptSecurityContext;
 use crate::generator::YieldPointLocal;
 use crate::kerberos::DEFAULT_ENCRYPTION_TYPE;
-use crate::kerberos::client::extractors::extract_seq_number_from_ap_rep;
+use crate::kerberos::client::extractors::{decrypt_ap_rep, extract_seq_number_from_ap_rep};
 use crate::kerberos::flags::ApOptions;
 use crate::kerberos::messages::{decode_krb_message, generate_krb_message};
 use crate::kerberos::server::as_exchange::request_tgt;
@@ -305,6 +305,10 @@ pub async fn accept_security_context(
                     u32::from_be_bytes(buf)
                 });
 
+                if let Some(seq) = authenticator_seq_number {
+                    server.remote_seq_number = seq;
+                }
+
                 // [3.2.3.  Receipt of KRB_AP_REQ Message](https://www.rfc-editor.org/rfc/rfc4120#section-3.2.3)
                 // The name and realm of the client from the ticket are compared against the same fields in the authenticator.
                 if ticket_enc_part.0.crealm.0 != crealm.0 || ticket_enc_part.0.cname != cname.0 {
@@ -509,13 +513,8 @@ pub async fn accept_security_context(
                     .session_key
                     .as_ref()
                     .ok_or_else(|| Error::new(ErrorKind::InternalError, "session key is not set"))?;
-                let seq_number = extract_seq_number_from_ap_rep(&ap_rep, session_key, &server.encryption_params)?;
-                let seq_number = u32::from_be_bytes(seq_number.try_into().map_err(|err| {
-                    Error::new(
-                        ErrorKind::InvalidToken,
-                        format!("invalid ApRep sequence number: {:?}", err),
-                    )
-                })?);
+                let ap_rep_enc_part = decrypt_ap_rep(&ap_rep, session_key, &server.encryption_params)?;
+                let seq_number = extract_seq_number_from_ap_rep(&ap_rep_enc_part)?;
 
                 let expected_seq_number = server.seq_number + 1;
                 if seq_number != expected_seq_number {

--- a/src/kerberos/tests.rs
+++ b/src/kerberos/tests.rs
@@ -75,6 +75,7 @@ fn secbuffer_readonly_with_checksum() {
         dh_parameters: None,
         krb5_user_to_user: false,
         server: Some(Box::new(test_data::fake_server_properties())),
+        remote_seq_number: 0,
     };
 
     // RPC header
@@ -255,6 +256,7 @@ fn integrity_only_wrap_decryption() {
         dh_parameters: None,
         krb5_user_to_user: false,
         server: None,
+        remote_seq_number: 0,
     };
 
     let mut buffer = token_bytes;

--- a/src/kerberos/utils.rs
+++ b/src/kerberos/utils.rs
@@ -23,6 +23,7 @@ pub(super) fn serialize_message<T: ?Sized + Serialize>(v: &T) -> Result<Vec<u8>>
 
 pub(super) fn validate_mic_token(
     is_client: bool,
+    expected_seq_number: u64,
     raw_token: &[u8],
     params: &EncryptionParams,
     mech_types: &[u8],
@@ -31,6 +32,16 @@ pub(super) fn validate_mic_token(
 
     let token = MicToken::decode(raw_token)?;
     let token_flags = token.flags;
+
+    if token.seq_num != expected_seq_number {
+        return Err(Error::new(
+            ErrorKind::InvalidToken,
+            format!(
+                "invalid MIC token sequence number: expected {expected_seq_number} but got {}",
+                token.seq_num
+            ),
+        ));
+    }
 
     // [Flags Field](https://datatracker.ietf.org/doc/html/rfc4121#section-4.2.2):
     //

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -38,7 +38,7 @@ use self::generators::{
 };
 use crate::builders::{ChangePassword, FilledAcceptSecurityContext};
 use crate::generator::{GeneratorAcceptSecurityContext, GeneratorInitSecurityContext, YieldPointLocal};
-use crate::kerberos::client::extractors::extract_sub_session_key_from_ap_rep;
+use crate::kerberos::client::extractors::{decrypt_ap_rep, extract_sub_session_key_from_ap_rep};
 use crate::kerberos::client::generators::{
     ChecksumOptions, EncKey, GenerateAsReqOptions, GenerateAuthenticatorOptions, generate_ap_req, generate_as_req,
     generate_as_req_kdc_body,
@@ -792,11 +792,12 @@ impl Pku2u {
 
                 let (ap_rep, _): (ApRep, _) = extract_krb_rep(&acceptor_exchange.exchange)?;
 
-                let sub_session_key = extract_sub_session_key_from_ap_rep(
+                let ap_rep_enc_part = decrypt_ap_rep(
                     &ap_rep,
                     check_if_empty!(self.encryption_params.session_key.as_ref(), "session key is not set"),
                     &self.encryption_params,
                 )?;
+                let sub_session_key = extract_sub_session_key_from_ap_rep(&ap_rep_enc_part)?;
 
                 self.encryption_params.sub_session_key = Some(sub_session_key);
 


### PR DESCRIPTION
Hi,
This PR fixes the authentication issue inside the Kerberos implementation.

The problem was in an unnecessary sequence number incrementation: https://github.com/Devolutions/sspi-rs/blob/847304fe35859a8aec401a50033e39df4c7235f4/src/kerberos/client/mod.rs#L515. It was added last year in #435.

### Why did we add it?

It was necessary back then. But after the big Negotiate refactoring and NTLM fallback improvement, this sequence number incrementation became unneeded.

### Why did the tests not catch it?

Because our Kerberos implementation did not check the MIC token sequence number properly. I improved the implementation, and now it will fail if we mess it up again.

### Why did we not notice it during dev testing?

Because it happens only when the MIC token exchange is present. After the Negotiate module refactoring and NTLM fallback improvements, we skip MIC token exchange in many cases. For example, regular password-based Kerberos auth using FreeRDP always worked.

### Related issues

https://github.com/Devolutions/IronRDP/issues/1469

closes #668 