### PR TITLE
refactor!: enable `as_conversions` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ undocumented_unsafe_blocks = "warn"
 multiple_unsafe_ops_per_block = "warn"
 
 # == Correctness == #
+as_conversions = "warn"
 as_underscore = "warn"
 filetype_is_file = "warn"
 float_cmp_const = "warn"

--- a/crates/dpapi-core/src/str.rs
+++ b/crates/dpapi-core/src/str.rs
@@ -21,7 +21,7 @@ pub fn from_utf16_le(data: &[u8]) -> DecodeResult<String> {
     String::from_utf16(
         &data
             .chunks(2)
-            .map(|c| u16::from_le_bytes(c.try_into().unwrap()))
+            .map(|c| u16::from_le_bytes(c.try_into().expect("chunk should be 2 bytes due to prior check")))
             .collect::<Vec<u16>>(),
     )
     .map_err(|err| DecodeError::invalid_field("", "UTF-16 data", "is not valid UTF-16").with_source(err))

--- a/crates/dpapi-native-transport/src/lib.rs
+++ b/crates/dpapi-native-transport/src/lib.rs
@@ -111,9 +111,7 @@ impl NativeTransport {
                     ))))
                 });
 
-            Ok(TokioStream::new(
-                Box::new(transport::WsStream::new(ws_compat)) as ErasedReadWrite
-            ))
+            Ok(TokioStream::new(Box::new(transport::WsStream::new(ws_compat))))
         }
     }
 }
@@ -137,8 +135,8 @@ impl Transport for NativeTransport {
     async fn connect(connection_options: &ConnectOptions) -> Result<Self::Stream, Error> {
         match connection_options {
             ConnectOptions::Tcp(addr) => {
-                let stream =
-                    TokioStream::new(Box::new(TcpStream::connect(url_to_socket_addr(addr)?).await?) as ErasedReadWrite);
+                let stream: TokioStream<ErasedReadWrite> =
+                    TokioStream::new(Box::new(TcpStream::connect(url_to_socket_addr(addr)?).await?));
                 Ok(stream)
             }
             ConnectOptions::WsTunnel {

--- a/crates/dpapi-pdu/src/gkdi.rs
+++ b/crates/dpapi-pdu/src/gkdi.rs
@@ -132,7 +132,8 @@ impl DecodeOwned for GetKey {
     fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 8 /* target_sd_len */ + 8 /* offset */);
 
-        let target_sd_len = { cast_int!("GetKey", "target_sd len", src.read_u64()) as DecodeResult<_> }?;
+        let target_sd_len: DecodeResult<_> = cast_int!("GetKey", "target_sd len", src.read_u64());
+        let target_sd_len = target_sd_len?;
         let _offset = src.read_u64();
 
         ensure_size!(in: src, size: target_sd_len);
@@ -261,7 +262,8 @@ impl DecodeOwned for KdfParameters {
             })?;
         }
 
-        let hash_name_len = { cast_int!("KdfParameters", "hash name len", src.read_u32()) as DecodeResult<_> }?;
+        let hash_name_len: DecodeResult<_> = cast_int!("KdfParameters", "hash name len", src.read_u32());
+        let hash_name_len = hash_name_len?;
 
         let magic_identifier_2 = src.read_slice(Self::MAGIC_IDENTIFIER_2.len());
 
@@ -408,7 +410,8 @@ impl DecodeOwned for FfcdhParameters {
         }
 
         let key_length = src.read_u32();
-        let key_len = { cast_int!("FfcdhParameters", "key len", key_length) as DecodeResult<_> }?;
+        let key_len: DecodeResult<_> = cast_int!("FfcdhParameters", "key len", key_length);
+        let key_len = key_len?;
         ensure_size!(in: src, size: key_len * 2);
 
         let field_order = BoxedUint::from_be_slice_vartime(src.read_slice(key_len));
@@ -529,7 +532,8 @@ impl DecodeOwned for FfcdhKey {
         }
 
         let key_length = src.read_u32();
-        let key_len = { cast_int!("FfcdhKey", "key len", key_length) as DecodeResult<_> }?;
+        let key_len: DecodeResult<_> = cast_int!("FfcdhKey", "key len", key_length);
+        let key_len = key_len?;
 
         ensure_size!(in: src, size: key_len * 3);
 
@@ -664,7 +668,8 @@ impl DecodeOwned for EcdhKey {
         let curve = EllipticCurve::try_from(curve_id)?;
 
         let key_length = src.read_u32();
-        let key_len = { cast_int!("EcdgKey", "key len", key_length) as DecodeResult<_> }?;
+        let key_len: DecodeResult<_> = cast_int!("EcdhKey", "key len", key_length);
+        let key_len = key_len?;
 
         ensure_size!(in: src, size: key_len * 2);
 
@@ -791,9 +796,12 @@ impl DecodeOwned for KeyIdentifier {
         let l2 = src.read_i32();
         let root_key_identifier = decode_uuid(src)?;
 
-        let key_info_len = { cast_int!("KeyIdentifier", "key info len", src.read_u32()) as DecodeResult<_> }?;
+        let key_info_len: DecodeResult<_> = cast_int!("KeyIdentifier", "key info len", src.read_u32());
+        let key_info_len = key_info_len?;
 
-        let domain_len = { cast_int!("KeyIdentifier", "domain name len", src.read_u32()) as DecodeResult<_> }?;
+        let domain_len: DecodeResult<_> = cast_int!("KeyIdentifier", "domain name len", src.read_u32());
+        let domain_len = domain_len?;
+
         if domain_len < 2 {
             Err(Error::InvalidLength {
                 name: "KeyIdentifier domain name",
@@ -802,7 +810,8 @@ impl DecodeOwned for KeyIdentifier {
             })?;
         }
 
-        let forest_len = { cast_int!("KeyIdentifier", "forest name len", src.read_u32()) as DecodeResult<_> }?;
+        let forest_len: DecodeResult<_> = cast_int!("KeyIdentifier", "forest name len", src.read_u32());
+        let forest_len = forest_len?;
         if forest_len < 2 {
             Err(Error::InvalidLength {
                 name: "KeyIdentifier forest name",
@@ -997,16 +1006,25 @@ impl DecodeOwned for GroupKeyEnvelope {
         let l2 = src.read_i32();
         let root_key_identifier = decode_uuid(src)?;
 
-        let kdf_alg_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let kdf_parameters_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let secret_alg_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let secret_parameters_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
+        let kdf_alg_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "kdf alg len", src.read_u32());
+        let kdf_alg_len = kdf_alg_len?;
+        let kdf_parameters_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "kdf parameters len", src.read_u32());
+        let kdf_parameters_len = kdf_parameters_len?;
+        let secret_alg_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "secret alg len", src.read_u32());
+        let secret_alg_len = secret_alg_len?;
+        let secret_parameters_len: DecodeResult<_> =
+            cast_int!("GroupKeyEnvelope", "secret parameters len", src.read_u32());
+        let secret_parameters_len = secret_parameters_len?;
         let private_key_length = src.read_u32();
         let public_key_length = src.read_u32();
-        let l1_key_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let l2_key_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let domain_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
-        let forest_len = { cast_int!("GroupKeyEnvelope", "", src.read_u32()) as DecodeResult<_> }?;
+        let l1_key_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "l1 key len", src.read_u32());
+        let l1_key_len = l1_key_len?;
+        let l2_key_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "l2 key len", src.read_u32());
+        let l2_key_len = l2_key_len?;
+        let domain_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "domain len", src.read_u32());
+        let domain_len = domain_len?;
+        let forest_len: DecodeResult<_> = cast_int!("GroupKeyEnvelope", "forest len", src.read_u32());
+        let forest_len = forest_len?;
 
         let kdf_alg = read_c_str_utf16_le(kdf_alg_len, src)?;
 

--- a/crates/dpapi-pdu/src/rpc/bind.rs
+++ b/crates/dpapi-pdu/src/rpc/bind.rs
@@ -50,7 +50,10 @@ pub enum BindTimeFeatureNegotiationBitmask {
 
 impl BindTimeFeatureNegotiationBitmask {
     pub fn as_u64(&self) -> u64 {
-        *self as u64
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u64
+        }
     }
 }
 
@@ -187,7 +190,10 @@ pub enum ContextResultCode {
 
 impl ContextResultCode {
     pub fn as_u16(&self) -> u16 {
-        *self as u16
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u16
+        }
     }
 }
 

--- a/crates/dpapi-pdu/src/rpc/epm.rs
+++ b/crates/dpapi-pdu/src/rpc/epm.rs
@@ -79,7 +79,10 @@ pub enum FloorProtocol {
 
 impl FloorProtocol {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -173,7 +176,7 @@ impl DecodeWithContextOwned for TcpFloor {
         }
 
         Ok(Self {
-            port: u16::from_be_bytes(rhs.try_into().unwrap()),
+            port: u16::from_be_bytes(rhs.try_into().expect("rhs length is 2 bytes due to prior check")),
         })
     }
 }
@@ -225,7 +228,7 @@ impl DecodeWithContextOwned for IpFloor {
         }
 
         Ok(Self {
-            addr: u32::from_be_bytes(rhs.try_into().unwrap()),
+            addr: u32::from_be_bytes(rhs.try_into().expect("rhs length is 4 bytes due to prior check")),
         })
     }
 }
@@ -287,7 +290,7 @@ impl DecodeWithContextOwned for RpcConnectionOrientedFloor {
         let rhs = src.read_slice(rhs_len).to_vec();
 
         Ok(Self {
-            version_minor: u16::from_le_bytes(rhs.try_into().unwrap()),
+            version_minor: u16::from_le_bytes(rhs.try_into().expect("rhs length is 2 bytes due to prior check")),
         })
     }
 }
@@ -352,10 +355,15 @@ impl DecodeWithContextOwned for UuidFloor {
         ensure_size!(in: src, size: rhs_len);
         let rhs = src.read_slice(rhs_len).to_vec();
 
+        let (raw_uuid, version) = lhs.split_at(Uuid::FIXED_PART_SIZE);
         Ok(Self {
-            uuid: decode_uuid(&mut ReadCursor::new(&lhs[0..Uuid::FIXED_PART_SIZE]))?,
-            version: u16::from_le_bytes(lhs[Uuid::FIXED_PART_SIZE..].try_into().unwrap()),
-            version_minor: u16::from_le_bytes(rhs.try_into().unwrap()),
+            uuid: decode_uuid(&mut ReadCursor::new(raw_uuid))?,
+            version: u16::from_le_bytes(
+                version
+                    .try_into()
+                    .expect("lhs length is 18 bytes, so version is 2 bytes due to prior check"),
+            ),
+            version_minor: u16::from_le_bytes(rhs.try_into().expect("rhs length is 2 bytes due to prior check")),
         })
     }
 }
@@ -595,7 +603,9 @@ impl DecodeOwned for EptMap {
         // Tower referent id 2
         src.read_u64();
 
-        let tower_length = { cast_length!("EptMap", "tower length", src.read_u64()) as DecodeResult<_> }?;
+        let tower_length: DecodeResult<_> = cast_length!("EptMap", "tower length", src.read_u64());
+        let tower_length = tower_length?;
+
         if tower_length < 2
         /* floor length */
         {
@@ -622,12 +632,13 @@ impl DecodeOwned for EptMap {
         }
 
         let pad = compute_padding(8, {
-            cast_length!(
+            let len: DecodeResult<_> = cast_length!(
                 "RptMap",
                 "towers count",
                 tower_length + 4 /* encoded tower length */
-            ) as DecodeResult<_>
-        }?);
+            );
+            len?
+        });
         read_padding(pad, src)?;
 
         let entry_handle = EntryHandle::decode_owned(src)?;
@@ -734,7 +745,8 @@ impl DecodeOwned for EptMapResult {
         // tower offset
         src.read_u64();
 
-        let tower_count: usize = { cast_int!("EprMapResult", "tower count", src.read_u64()) as DecodeResult<_> }?;
+        let tower_count: DecodeResult<_> = cast_int!("EprMapResult", "tower count", src.read_u64());
+        let tower_count: usize = tower_count?;
         ensure_size!(in: src, size: tower_count.checked_mul(8).ok_or(DecodeError::invalid_field(
                 "EptMapResult",
                 "tower count",
@@ -750,7 +762,9 @@ impl DecodeOwned for EptMapResult {
             .map(|_| {
                 ensure_size!(in: src, size: 8 /* tower length */ + 4 + 2 /* floor length */);
 
-                let tower_length = { cast_length!("EptMap", "tower length", src.read_u64()) as DecodeResult<_> }?;
+                let tower_length: DecodeResult<_> = cast_length!("EptMap", "tower length", src.read_u64());
+                let tower_length = tower_length?;
+
                 if tower_length < 2
                 /* floor length */
                 {
@@ -777,7 +791,7 @@ impl DecodeOwned for EptMapResult {
 
                 read_padding(
                     compute_padding(4, {
-                        cast_length!(
+                        let len: DecodeResult<_> = cast_length!(
                             "EptMapResult",
                             "tower length",
                             tower_length.checked_add(4).ok_or(DecodeError::invalid_field(
@@ -785,8 +799,9 @@ impl DecodeOwned for EptMapResult {
                                 "tower length",
                                 "tower length is too big",
                             ))?
-                        ) as DecodeResult<_>
-                    }?),
+                        );
+                        len?
+                    }),
                     src,
                 )?;
 

--- a/crates/dpapi-pdu/src/rpc/pdu.rs
+++ b/crates/dpapi-pdu/src/rpc/pdu.rs
@@ -92,7 +92,10 @@ pub enum IntRepr {
 
 impl IntRepr {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -107,7 +110,10 @@ pub enum CharacterRepr {
 
 impl CharacterRepr {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -124,7 +130,10 @@ pub enum FloatingPointRepr {
 
 impl FloatingPointRepr {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -155,7 +164,10 @@ pub enum PacketType {
 
 impl PacketType {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -196,7 +208,7 @@ impl Encode for DataRepr {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        let first_octet = ((self.byte_order.as_u8()) << 4) | self.character.as_u8();
+        let first_octet = (self.byte_order.as_u8() << 4) | self.character.as_u8();
         dst.write_u8(first_octet);
         dst.write_u8(self.floating_point.as_u8());
 
@@ -323,7 +335,10 @@ pub enum SecurityProvider {
 
 impl SecurityProvider {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 
@@ -342,7 +357,10 @@ pub enum AuthenticationLevel {
 
 impl AuthenticationLevel {
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 }
 

--- a/crates/dpapi-pdu/src/rpc/verification.rs
+++ b/crates/dpapi-pdu/src/rpc/verification.rs
@@ -39,7 +39,10 @@ pub enum CommandType {
 
 impl CommandType {
     pub fn as_u16(self) -> u16 {
-        self as u16
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            self as u16
+        }
     }
 }
 

--- a/crates/dpapi-web/src/transport.rs
+++ b/crates/dpapi-web/src/transport.rs
@@ -102,7 +102,7 @@ impl WasmTransport {
             }
         }
 
-        Ok(FuturesStream::new(Box::new(ws) as ErasedReadWrite))
+        Ok(FuturesStream::new(Box::new(ws)))
     }
 }
 

--- a/crates/dpapi/src/blob.rs
+++ b/crates/dpapi/src/blob.rs
@@ -221,7 +221,7 @@ impl DpapiBlob {
             })?;
         }
 
-        let key_identifier: KeyIdentifier = decode_owned(&kek_info.kek_id.key_identifier.0 as &[u8])?;
+        let key_identifier: KeyIdentifier = decode_owned(kek_info.kek_id.key_identifier.0.as_ref())?;
 
         let protection_descriptor = if let Some(OtherKeyAttribute { key_attr_id, key_attr }) = &kek_info.kek_id.other.0
         {

--- a/crates/winscard/src/compression.rs
+++ b/crates/winscard/src/compression.rs
@@ -15,8 +15,8 @@ pub(crate) fn compress_cert<'c>(cert: &'_ [u8], buff: &'c mut Vec<u8>) -> WinSca
     let mut compressor = Compress::new(Compression::fast(), /* zlib header */ true);
 
     loop {
-        let read_before = compressor.total_in() as usize;
-        let written_before = compressor.total_out() as usize;
+        let read_before = usize::try_from(compressor.total_in())?;
+        let written_before = usize::try_from(compressor.total_out())?;
 
         let status = compressor
             .compress(data_to_compress, &mut buff[total_written..], FlushCompress::Finish)
@@ -27,8 +27,8 @@ pub(crate) fn compress_cert<'c>(cert: &'_ [u8], buff: &'c mut Vec<u8>) -> WinSca
                 )
             })?;
 
-        let read_after = compressor.total_in() as usize;
-        let written_after = compressor.total_out() as usize;
+        let read_after = usize::try_from(compressor.total_in())?;
+        let written_after = usize::try_from(compressor.total_out())?;
 
         let read_len = read_after - read_before;
         let written_len = written_after - written_before;

--- a/crates/winscard/src/lib.rs
+++ b/crates/winscard/src/lib.rs
@@ -351,7 +351,10 @@ pub enum ErrorKind {
 
 impl From<ErrorKind> for u32 {
     fn from(value: ErrorKind) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 

--- a/crates/winscard/src/scard_context.rs
+++ b/crates/winscard/src/scard_context.rs
@@ -310,12 +310,16 @@ impl<'a> ScardContext<'a> {
             let mut compressed_cert = vec![0; smart_card_info.auth_cert_der.len()];
             let compressed = crate::compression::compress_cert(&smart_card_info.auth_cert_der, &mut compressed_cert)?;
 
-            let total_value_len =
-                (compressed.len() + 2 /* unknown flags */ + 2/* uncompressed certificate len */) as u32;
+            let total_value_len = u32::try_from(
+                compressed.len() + 2 /* unknown flags */ + 2, /* uncompressed certificate len */
+            )
+            .map_err(|_| Error::new(ErrorKind::InternalError, "compressed cert too large for u32"))?;
             value.extend_from_slice(&total_value_len.to_le_bytes());
 
             value.extend_from_slice(&[0x01, 0x00]); // flags that specify that the certificate is compressed
-            value.extend_from_slice(&(smart_card_info.auth_cert_der.len() as u16).to_le_bytes()); // uncompressed certificate data len
+            let cert_len = u16::try_from(smart_card_info.auth_cert_der.len())
+                .map_err(|_| Error::new(ErrorKind::InternalError, "cert too large for u16"))?;
+            value.extend_from_slice(&cert_len.to_le_bytes()); // uncompressed certificate data len
             value.extend_from_slice(&compressed_cert);
 
             value

--- a/crates/winscard/src/winscard.rs
+++ b/crates/winscard/src/winscard.rs
@@ -56,13 +56,16 @@ impl TryFrom<u32> for ReaderAction {
 
 impl From<ReaderAction> for u32 {
     fn from(value: ReaderAction) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 
 impl From<ReaderAction> for u64 {
     fn from(value: ReaderAction) -> Self {
-        value as u64
+        u32::from(value).into()
     }
 }
 
@@ -258,7 +261,10 @@ pub enum DeviceTypeId {
 
 impl From<DeviceTypeId> for u32 {
     fn from(value: DeviceTypeId) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 
@@ -295,13 +301,16 @@ impl TryFrom<u32> for ScardScope {
 
 impl From<ScardScope> for u32 {
     fn from(value: ScardScope) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 
 impl From<ScardScope> for u64 {
     fn from(value: ScardScope) -> Self {
-        value as u64
+        u32::from(value).into()
     }
 }
 
@@ -323,13 +332,16 @@ pub enum ShareMode {
 
 impl From<ShareMode> for u32 {
     fn from(value: ShareMode) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 
 impl From<ShareMode> for u64 {
     fn from(value: ShareMode) -> Self {
-        value as u64
+        u32::from(value).into()
     }
 }
 
@@ -420,7 +432,10 @@ impl TryFrom<u32> for State {
 
 impl From<State> for u32 {
     fn from(value: State) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 
@@ -596,7 +611,10 @@ impl TryFrom<u32> for ProviderId {
 
 impl From<ProviderId> for u32 {
     fn from(value: ProviderId) -> Self {
-        value as u32
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
     }
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -134,7 +134,7 @@ fn do_authentication(ntlm: &mut Ntlm, identity: &AuthIdentity, mut stream: &mut 
 pub fn read_message<T: io::Read, A: io::Write>(stream: &mut T, output_buffer: &mut A) -> Result<(), io::Error> {
     let msg_len = stream.read_u16::<LittleEndian>()?;
 
-    let mut buff = vec![0u8; msg_len as usize];
+    let mut buff = vec![0u8; usize::from(msg_len)];
     stream.read_exact(&mut buff)?;
 
     output_buffer.write_all(&buff)?;
@@ -149,7 +149,8 @@ pub fn write_message<T: io::Write>(stream: &mut T, input_buffer: &[u8]) -> Resul
     if !input_buffer.is_empty() {
         println!("Sending the buffer [{} bytes]: {:?}", input_buffer.len(), input_buffer);
 
-        stream.write_u16::<LittleEndian>(input_buffer.len() as u16)?;
+        let msg_len = u16::try_from(input_buffer.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        stream.write_u16::<LittleEndian>(msg_len)?;
         stream.write_all(input_buffer)?;
     }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -45,7 +45,12 @@ fn main() -> Result<(), io::Error> {
     //
     // By agreement, the server places the trailer at the beginning
     // of the message, and the data comes after the trailer.
-    let mut token = vec![0u8; ntlm.query_context_sizes()?.security_trailer as usize];
+    let security_trailer_size: usize = ntlm
+        .query_context_sizes()?
+        .security_trailer
+        .try_into()
+        .map_err(io::Error::other)?;
+    let mut token = vec![0u8; security_trailer_size];
     let mut data = msg.as_bytes().to_vec();
     let mut msg_buffer = vec![
         SecurityBufferRef::token_buf(token.as_mut_slice()),
@@ -114,7 +119,7 @@ fn do_authentication(ntlm: &mut Ntlm, identity: &AuthIdentity, mut stream: &mut 
 pub fn read_message<T: io::Read, A: io::Write>(stream: &mut T, output_buffer: &mut A) -> Result<(), io::Error> {
     let msg_len = stream.read_u16::<LittleEndian>()?;
 
-    let mut buff = vec![0u8; msg_len as usize];
+    let mut buff = vec![0u8; usize::from(msg_len)];
     stream.read_exact(&mut buff)?;
 
     output_buffer.write_all(&buff)?;
@@ -129,7 +134,8 @@ pub fn write_message<T: io::Write>(stream: &mut T, input_buffer: &[u8]) -> Resul
     if !input_buffer.is_empty() {
         println!("Sending the buffer [{} bytes]: {:?}", input_buffer.len(), input_buffer);
 
-        stream.write_u16::<LittleEndian>(input_buffer.len() as u16)?;
+        let msg_len = u16::try_from(input_buffer.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        stream.write_u16::<LittleEndian>(msg_len)?;
         stream.write_all(input_buffer)?;
     }
 

--- a/ffi/src/dpapi/mod.rs
+++ b/ffi/src/dpapi/mod.rs
@@ -207,7 +207,7 @@ pub unsafe extern "system" fn DpapiProtectSecret(
         }
 
         // SAFETY: Memory allocation is safe.
-        let blob_buf = unsafe { libc::malloc(blob_data.len()) as *mut u8 };
+        let blob_buf = unsafe { libc::malloc(blob_data.len()).cast::<u8>() };
         if blob_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL");
             return NTE_NO_MEMORY;
@@ -374,7 +374,9 @@ pub unsafe extern "system" fn DpapiUnprotectSecret(
 
         let secret_data = match secret_data_result {
             Ok(secret_data) => secret_data,
-            Err(Error::Auth(AuthError::Sspi(sspi_error))) => { return sspi_error.error_type as u32 },
+            Err(Error::Auth(AuthError::Sspi(sspi_error))) => {
+                return u32::from(sspi_error.error_type)
+            },
             Err(Error::Gkdi(dpapi::gkdi::GkdiError::BadHresult(hresult))) => { return hresult },
             Err(Error::Gkdi(dpapi::gkdi::GkdiError::IsNotAuthorized)) => { return HRESULT_ERROR_ACCESS_DENIED },
             Err(err) => {
@@ -389,7 +391,7 @@ pub unsafe extern "system" fn DpapiUnprotectSecret(
         }
 
         // SAFETY: Memory allocation is safe.
-        let secret_buf = unsafe { libc::malloc(secret_data.as_ref().len()) as *mut u8 };
+        let secret_buf = unsafe { libc::malloc(secret_data.as_ref().len()).cast::<u8>() };
         if secret_buf.is_null() {
             error!("Failed to allocate memory for the output DPAPI blob: blob buf pointer is NULL.");
             return NTE_NO_MEMORY;
@@ -456,7 +458,7 @@ mod tests {
     #[test]
     fn test_dpapi_protect_secret() {
         let secret = b"secret-to-encrypt";
-        let secret_len = secret.len() as u32;
+        let secret_len: u32 = secret.len().try_into().expect("secret length must fit into u32");
         let sid = "S-1-5-21-1485435871-894665558-560847465-1104\0";
         let server = "win-956cqossjtf.tbt.com\0";
         let username = "t2@tbt.com\0";
@@ -514,7 +516,7 @@ mod tests {
     #[test]
     fn test_dpapi_protect_secret_proxied() {
         let secret = b"secret-to-encrypt";
-        let secret_len = secret.len() as u32;
+        let secret_len: u32 = secret.len().try_into().expect("secret length must fit into u32");
         let sid = "S-1-5-21-1485435871-894665558-560847465-1104\0";
         let server = "win-956cqossjtf.tbt.com\0";
         let username = "t2@tbt.com\0";

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -1,6 +1,7 @@
+use std::ptr;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
-use libc::{c_ulonglong, c_void};
+use libc::c_void;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use sspi::{
     BufferType, DataRepresentation, DecryptionFlags, EncryptionFlags, Error, ErrorKind, SecurityBuffer,
@@ -35,7 +36,9 @@ pub unsafe extern "system" fn FreeCredentialsHandle(ph_credential: PCredHandle) 
     // SAFETY:
     // - `ph_credentials` is guaranteed to be non-null due to the prior check.
     // - `ph_credentials` points to a valid `credentials handle` allocated by the `AcquireCredentialsHandleA/W` function.
-    let cred_handle = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+    let dw_lower = unsafe { (*ph_credential).dw_lower };
+    let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+    let cred_handle: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
     check_null!(cred_handle);
 
     // SAFETY:
@@ -94,7 +97,9 @@ pub unsafe extern "system" fn AcceptSecurityContext(
         // SAFETY:
         // - `ph_credentials` is guaranteed to be non-null due to the prior check.
         // - `ph_credentials` points to a valid `credentials handle` allocated by an SSPI function.
-        let credentials_handle = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+        let dw_lower = unsafe { (*ph_credential).dw_lower };
+        let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+        let credentials_handle: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
 
         // SAFETY: `credentials_handle` is either null or a valid pointer to the `CredentialsHandle` allocated by an SSPI function.
         let transformed_credentials_handle = unsafe { transform_credentials_handle(credentials_handle) };
@@ -133,16 +138,15 @@ pub unsafe extern "system" fn AcceptSecurityContext(
                 // - `p_input` points to a valid `SecBufferDesc` structure.
                 let c_buffers = unsafe { (*p_input).c_buffers };
 
+                let c_buffers_usize = try_execute!(c_buffers.try_into(), ErrorKind::InvalidParameter);
                 // SAFETY:
                 // - `p_buffers` is guaranteed to be non-null due to the prior check.
                 // - The memory region `p_buffers` points to is valid for reads of `c_buffers` element.
-                let raw_buffers = unsafe {
-                    from_raw_parts(p_buffers, c_buffers as usize)
-                };
+                let raw_buffers = unsafe { from_raw_parts(p_buffers, c_buffers_usize) };
                 // SAFETY:
                 // - `raw_buffers` array contains valid `SecBuffer` structures.
                 // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-                Ok(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) })
+                unsafe { p_sec_buffers_to_security_buffers(raw_buffers) }
             });
 
         let mut output_tokens = vec![SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
@@ -172,8 +176,13 @@ pub unsafe extern "system" fn AcceptSecurityContext(
         // SAFETY: `ph_new_context` is convertible to a reference.
         let ph_new_context = unsafe { ph_new_context.as_mut() }.expect("ph_new_context is non-null");
 
-        ph_new_context.dw_lower = sspi_context_ptr.as_ptr() as c_ulonglong;
-        ph_new_context.dw_upper = into_raw_ptr(security_package_name.to_owned()) as c_ulonglong;
+        let dw_lower = sspi_context_ptr.as_ptr().expose_provenance();
+        ph_new_context.dw_lower = try_execute!(dw_lower.try_into(), ErrorKind::InvalidHandle);
+
+        let dw_upper = into_raw_ptr(security_package_name.to_owned()).expose_provenance();
+        ph_new_context.dw_upper = {
+            try_execute!(dw_upper.try_into(), ErrorKind::InvalidHandle)
+        };
         // SAFETY: `pf_context_attr` is guaranteed to be non-null due to the prior check.
         unsafe {
             *pf_context_attr = f_context_req;
@@ -240,7 +249,8 @@ pub unsafe extern "system" fn CompleteAuthToken(
         // SAFETY:
         // - `p_token` is guaranteed to be non-null due to the prior check.
         // - `p_token` points to a valid `SecBufferDesc` structure.
-        let c_buffers = unsafe { (*p_token).c_buffers } as usize;
+        let c_buffers = unsafe { (*p_token).c_buffers };
+        let c_buffers = try_execute!(c_buffers.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:
         // - `p_buffers` is guaranteed to be non-null due to the prior check.
@@ -250,7 +260,7 @@ pub unsafe extern "system" fn CompleteAuthToken(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut buffers = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut buffers = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
 
         sspi_context.complete_auth_token(&mut buffers).map_or_else(
             |err| err.error_type.to_u32().unwrap(),
@@ -300,10 +310,13 @@ pub unsafe extern "system" fn DeleteSecurityContext(mut ph_context: PCtxtHandle)
         // - `ph_context` points to a valid `SecHandle` structure.
         let dw_upper = unsafe { (*ph_context).dw_upper };
         if dw_upper != 0 {
+            let addr = try_execute!(usize::try_from(dw_upper), ErrorKind::InvalidHandle);
+            let upper_ptr: *mut String = ptr::with_exposed_provenance_mut(addr);
+
             // SAFETY:
             // - `dw_upper` is guaranteed to be non-null due to the prior check.
             // - The value behind `dw_upper` pointer is allocated by an SSPI function.
-            let _name: Box<String> = unsafe { Box::from_raw(dw_upper as *mut String) };
+            let _name: Box<String> = unsafe { Box::from_raw(upper_ptr) };
         }
 
         0
@@ -461,7 +474,8 @@ pub unsafe extern "system" fn EncryptMessage(
         // SAFETY:
         // - `p_message` is guaranteed to be non-null due to the prior check.
         // - `p_message` points to a valid `SecBufferDesc` structure.
-        let len = unsafe { (*p_message).c_buffers as usize };
+        let c_buffers = unsafe { (*p_message).c_buffers };
+        let len = try_execute!(c_buffers.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:
         // - `p_buffers` is guaranteed to be non-null due to the prior check.
@@ -548,7 +562,8 @@ pub unsafe extern "system" fn DecryptMessage(
         // SAFETY:
         // - `p_message` is guaranteed to be non-null due to the prior check.
         // - `p_message` points to a valid `SecBufferDesc` structure.
-        let len = unsafe { (*p_message).c_buffers as usize };
+        let c_buffers = unsafe { (*p_message).c_buffers };
+        let len = try_execute!(c_buffers.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:
         // - `p_buffers` is guaranteed to be non-null due to the prior check.
@@ -620,7 +635,7 @@ unsafe fn p_sec_buffers_to_decrypt_buffers(raw_buffers: &[SecBuffer]) -> sspi::R
                 // SAFETY:
                 // - `raw_buffer.pv_buffer` is guaranteed to be non-null due to the prior check.
                 // - The memory region `raw_buffer.pv_buffer` points to is valid for reads of `raw_buffer.cb_buffer` bytes.
-                unsafe { from_raw_parts_mut(raw_buffer.pv_buffer as *mut u8, raw_buffer.cb_buffer.try_into()?) }
+                unsafe { from_raw_parts_mut(raw_buffer.pv_buffer.cast::<u8>(), raw_buffer.cb_buffer.try_into()?) }
             };
             buf.with_data(data)?
         })
@@ -678,7 +693,6 @@ mod tests {
     use std::ptr::null_mut;
     use std::slice::from_raw_parts;
 
-    use libc::c_ulonglong;
     use sspi::credssp::SspiContext;
     use sspi::{EncryptionFlags, Kerberos, SecurityBufferRef, Sspi};
 
@@ -690,9 +704,17 @@ mod tests {
         SecHandle {
             dw_lower: {
                 let sspi_context = SspiHandle::new(SspiContext::Kerberos(kerberos));
-                into_raw_ptr(sspi_context) as c_ulonglong
+                into_raw_ptr(sspi_context)
+                    .expose_provenance()
+                    .try_into()
+                    .expect("ptr address must fit into c_ulonglong")
             },
-            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string()) as c_ulonglong,
+            dw_upper: {
+                into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string())
+                    .expose_provenance()
+                    .try_into()
+                    .expect("ptr address must fit into c_ulonglong")
+            },
         }
     }
 
@@ -758,7 +780,7 @@ mod tests {
         assert_eq!(
             unsafe {
                 from_raw_parts(
-                    buffers[1].pv_buffer as *const u8,
+                    buffers[1].pv_buffer.cast::<u8>(),
                     buffers[1].cb_buffer.try_into().unwrap(),
                 )
             },
@@ -806,10 +828,19 @@ mod tests {
 
         let mut kerberos_client_context = kerberos_sec_handle(kerberos_client);
 
-        let mut token =
-            unsafe { from_raw_parts(buffers[0].pv_buffer as *const u8, buffers[0].cb_buffer as usize) }.to_vec();
-        let mut data =
-            unsafe { from_raw_parts(buffers[1].pv_buffer as *const u8, buffers[1].cb_buffer as usize) }.to_vec();
+        let token_len = buffers[0]
+            .cb_buffer
+            .try_into()
+            .expect("token length must fit into usize");
+        let token_ptr = buffers[0].pv_buffer.cast::<u8>();
+        let mut token = unsafe { from_raw_parts(token_ptr, token_len) }.to_vec();
+
+        let data_len = buffers[1]
+            .cb_buffer
+            .try_into()
+            .expect("data length must fit into usize");
+        let data_ptr = buffers[1].pv_buffer.cast::<u8>();
+        let mut data = unsafe { from_raw_parts(data_ptr, data_len) }.to_vec();
         let mut buffers = [
             SecBuffer {
                 cb_buffer: token.len().try_into().unwrap(),
@@ -835,9 +866,11 @@ mod tests {
         assert_eq!(status, 0);
 
         // Check that the decrypted data is the same as the initial message
-        assert_eq!(
-            unsafe { from_raw_parts(buffers[1].pv_buffer as *const u8, buffers[1].cb_buffer as usize,) },
-            plain_message
-        );
+        let decrypted_len = buffers[1]
+            .cb_buffer
+            .try_into()
+            .expect("decrypted length must fit into usize");
+        let decrypted_ptr = buffers[1].pv_buffer.cast::<u8>();
+        assert_eq!(unsafe { from_raw_parts(decrypted_ptr, decrypted_len) }, plain_message);
     }
 }

--- a/ffi/src/sspi/common.rs
+++ b/ffi/src/sspi/common.rs
@@ -260,7 +260,8 @@ pub unsafe extern "system" fn CompleteAuthToken(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut buffers = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
+        let buffers = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut buffers = try_execute!(buffers);
 
         sspi_context.complete_auth_token(&mut buffers).map_or_else(
             |err| err.error_type.to_u32().unwrap(),

--- a/ffi/src/sspi/credentials_attributes.rs
+++ b/ffi/src/sspi/credentials_attributes.rs
@@ -96,7 +96,7 @@ pub unsafe fn extract_kdc_proxy_settings(p_buffer: NonNull<c_void>) -> Result<Kd
     // - `p_buffer` is guaranteed to be non-null due to the `NonNull` wrapper.
     // - `proxy_server_offset` is valid.
     // - The proxy server is placed in the memory at the offset `proxy_server_offset`.
-    let proxy_server_ptr = unsafe { p_buffer.add(*proxy_server_offset as usize) } as *const u16;
+    let proxy_server_ptr = unsafe { p_buffer.add(usize::from(*proxy_server_offset)) }.cast::<u16>();
 
     if proxy_server_ptr.is_null() {
         return Err(Error::new(
@@ -109,7 +109,10 @@ pub unsafe fn extract_kdc_proxy_settings(p_buffer: NonNull<c_void>) -> Result<Kd
     // - `proxy_server_ptr` is guaranteed to be non-null due to the prior check.
     // - `proxy_server_length` is valid.
     let proxy_server = String::from_utf16(unsafe {
-        from_raw_parts(proxy_server_ptr, *proxy_server_length as usize / size_of::<SecWChar>())
+        from_raw_parts(
+            proxy_server_ptr,
+            usize::from(*proxy_server_length) / size_of::<SecWChar>(),
+        )
     })?;
 
     let client_tls_cred = if *client_tls_cred_offset != 0 && *client_tls_cred_length != 0 {
@@ -117,7 +120,7 @@ pub unsafe fn extract_kdc_proxy_settings(p_buffer: NonNull<c_void>) -> Result<Kd
         // - `p_buffer` is guaranteed to be non-null due to the `NonNull` wrapper.
         // - `client_tls_cred_offset` is valid.
         // - The client TLS if placed in the memory at the offset `client_tls_cred_offset`.
-        let client_tls_cred_ptr = unsafe { p_buffer.add(*client_tls_cred_offset as usize) } as *const u16;
+        let client_tls_cred_ptr = unsafe { p_buffer.add(usize::from(*client_tls_cred_offset)) }.cast::<u16>();
         if client_tls_cred_ptr.is_null() {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
@@ -128,7 +131,7 @@ pub unsafe fn extract_kdc_proxy_settings(p_buffer: NonNull<c_void>) -> Result<Kd
         // SAFETY:
         // - `client_tls_cred_ptr` is guaranteed to be non-null due to the prior check.
         // - `client_tls_cred_length` is valid.
-        let client_tls_cred_data = unsafe { from_raw_parts(client_tls_cred_ptr, *client_tls_cred_length as usize) };
+        let client_tls_cred_data = unsafe { from_raw_parts(client_tls_cred_ptr, usize::from(*client_tls_cred_length)) };
 
         let client_tls_cred = String::from_utf16(client_tls_cred_data)?;
 

--- a/ffi/src/sspi/sec_buffer.rs
+++ b/ffi/src/sspi/sec_buffer.rs
@@ -28,7 +28,7 @@ pub type PSecBufferDesc = *mut SecBufferDesc;
 /// * The input pointer can be null.
 /// * If the input pointer is non-null, then it must point to the valid [SecBufferDesc] structure. Moreover,
 ///   the user have to ensure that the pointer is [convertible to a reference](https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion).
-pub unsafe fn sec_buffer_desc_to_security_buffers(p_input: PSecBufferDesc) -> Vec<SecurityBuffer> {
+pub unsafe fn sec_buffer_desc_to_security_buffers(p_input: PSecBufferDesc) -> Result<Vec<SecurityBuffer>> {
     // SAFETY: `p_input` is either null or a valid pointer to `SecBufferDesc` convertible to a reference.
     if let Some(input) = unsafe { p_input.as_ref() } {
         let p_buffers = input.p_buffers;
@@ -37,16 +37,17 @@ pub unsafe fn sec_buffer_desc_to_security_buffers(p_input: PSecBufferDesc) -> Ve
         let sec_buffers = if p_buffers.is_null() {
             &[]
         } else {
+            let c_buffers_usize = c_buffers.try_into()?;
             // SAFETY:
             // - `p_buffers` is guaranteed to be non-null due to the prior check.
             // - The memory region `p_buffers` points to is valid for reads of `c_buffers` elements.
-            unsafe { from_raw_parts(p_buffers, c_buffers as usize) }
+            unsafe { from_raw_parts(p_buffers, c_buffers_usize) }
         };
 
         // SAFETY: FFI call with no outstanding preconditions.
-        unsafe { p_sec_buffers_to_security_buffers(sec_buffers) }
+        Ok(unsafe { p_sec_buffers_to_security_buffers(sec_buffers)? })
     } else {
-        Vec::new()
+        Ok(Vec::new())
     }
 }
 
@@ -55,24 +56,24 @@ pub unsafe fn sec_buffer_desc_to_security_buffers(p_input: PSecBufferDesc) -> Ve
 /// The `raw_buffers` must be an array of valid `SecBuffer` structures.
 /// Each `SecBuffer` must have a valid `pv_buffer` pointer field that is valid for reads of `cb_buffer` bytes.
 #[allow(clippy::useless_conversion)]
-pub(crate) unsafe fn p_sec_buffers_to_security_buffers(raw_buffers: &[SecBuffer]) -> Vec<SecurityBuffer> {
+pub(crate) unsafe fn p_sec_buffers_to_security_buffers(raw_buffers: &[SecBuffer]) -> Result<Vec<SecurityBuffer>> {
     raw_buffers
         .iter()
-        .map(|raw_buffer| SecurityBuffer {
-            buffer: if raw_buffer.pv_buffer.is_null() {
-                Vec::new()
-            } else {
-                // SAFETY:
-                // - `raw_buffer.pv_buffer` is guaranteed to be non-null due to the prior check.
-                // - The memory region `raw_buffer.pv_buffer` points to is valid for reads of `raw_buffer.cv_buffer` elements.
-                unsafe { from_raw_parts(raw_buffer.pv_buffer, raw_buffer.cb_buffer as usize) }
-                    .iter()
-                    .map(|v| *v as u8)
-                    .collect()
-            },
-            buffer_type: SecurityBufferType::try_from(u32::try_from(raw_buffer.buffer_type).unwrap()).unwrap(),
+        .map(|raw_buffer| {
+            Ok(SecurityBuffer {
+                buffer: if raw_buffer.pv_buffer.is_null() {
+                    Vec::new()
+                } else {
+                    let cb_buffer_usize = raw_buffer.cb_buffer.try_into()?;
+                    // SAFETY:
+                    // - `raw_buffer.pv_buffer` is guaranteed to be non-null due to the prior check.
+                    // - The memory region `raw_buffer.pv_buffer` points to is valid for reads of `raw_buffer.cb_buffer` elements.
+                    unsafe { from_raw_parts(raw_buffer.pv_buffer.cast::<u8>(), cb_buffer_usize) }.to_vec()
+                },
+                buffer_type: SecurityBufferType::try_from(u32::try_from(raw_buffer.buffer_type).unwrap()).unwrap(),
+            })
         })
-        .collect()
+        .collect::<Result<Vec<SecurityBuffer>>>()
 }
 
 /// Copies buffers from `from_buffers` to `to_buffers`.
@@ -101,7 +102,7 @@ pub(crate) unsafe fn copy_to_c_sec_buffer(
         to_buffers[i].buffer_type = buffer.buffer_type.into();
         if allocate || to_buffers[i].pv_buffer.is_null() {
             // SAFETY: Memory allocation is safe.
-            to_buffers[i].pv_buffer = unsafe { libc::malloc(buffer_size) } as *mut c_char;
+            to_buffers[i].pv_buffer = unsafe { libc::malloc(buffer_size) }.cast::<c_char>();
 
             if to_buffers[i].pv_buffer.is_null() {
                 return Err(Error::new(
@@ -111,7 +112,7 @@ pub(crate) unsafe fn copy_to_c_sec_buffer(
             }
         }
 
-        let p_buffer = buffer.buffer.as_ptr() as *const c_char;
+        let p_buffer = buffer.buffer.as_ptr().cast::<c_char>();
         // SAFETY:
         // - `pv_buffer` is guaranteed to be non-null dues to prior check.
         // - The memory region `pv_buffer` points to is valid for writes of `buffer_size` elements.

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use std::mem::size_of;
+use std::mem::{size_of, transmute};
 use std::ptr::{self, NonNull, copy_nonoverlapping};
 use std::slice::from_raw_parts;
 use std::sync::Mutex;
@@ -332,20 +332,18 @@ pub(crate) unsafe fn p_ctxt_handle_to_sspi_context(
 
         // SAFETY: `*context` is convertible to a reference.
         let context = unsafe { (*context).as_mut() }.expect("context should not be null");
-        context.dw_lower = into_raw_ptr(sspi_context) as c_ulonglong;
+
+        context.dw_lower = into_raw_ptr(sspi_context).expose_provenance().try_into()?;
+
         if context.dw_upper == 0 {
-            context.dw_upper = into_raw_ptr(name.to_owned()) as c_ulonglong;
+            context.dw_upper = into_raw_ptr(name.to_owned()).expose_provenance().try_into()?;
         }
     }
 
-    Ok(NonNull::new(ptr::with_exposed_provenance_mut(
-        // SAFETY: `*context` is guaranteed to be non-null due to the prior check.
-        unsafe { &**context }
-            .dw_lower
-            .try_into()
-            .expect("c_ulonglong should be castable to usize"),
-    ))
-    .expect("dw_lower must be initialized"))
+    // SAFETY: `*context` is guaranteed to be non-null due to the prior check.
+    let dw_lower = unsafe { &**context }.dw_lower;
+    let addr = usize::try_from(dw_lower)?;
+    Ok(NonNull::new(ptr::with_exposed_provenance_mut(addr)).expect("dw_lower must be initialized"))
 }
 
 fn verify_security_package(package_name: &str) -> Result<()> {
@@ -409,13 +407,15 @@ pub unsafe extern "system" fn AcquireCredentialsHandleA(
             unsafe { auth_data_to_identity_buffers(&security_package_name, p_auth_data, &mut package_list) }
         );
 
+        let handle = into_raw_ptr(CredentialsHandle {
+            credentials,
+            security_package_name,
+            attributes: CredentialsAttributes::new_with_package_list(package_list),
+        }).expose_provenance();
+        let handle = try_execute!(handle.try_into(), ErrorKind::InvalidHandle);
         // SAFETY: `ph_credentials` is guaranteed to be non-null due to the prior check.
         unsafe {
-            (*ph_credential).dw_lower = into_raw_ptr(CredentialsHandle {
-                credentials,
-                security_package_name,
-                attributes: CredentialsAttributes::new_with_package_list(package_list),
-            }) as c_ulonglong;
+            (*ph_credential).dw_lower = handle;
         }
 
         0
@@ -485,13 +485,15 @@ pub unsafe extern "system" fn AcquireCredentialsHandleW(
             unsafe { auth_data_to_identity_buffers(&security_package_name, p_auth_data, &mut package_list) }
         );
 
+        let handle = into_raw_ptr(CredentialsHandle {
+            credentials,
+            security_package_name,
+            attributes: CredentialsAttributes::new_with_package_list(package_list),
+        }).expose_provenance();
+        let handle = try_execute!(handle.try_into(), ErrorKind::InvalidHandle);
         // SAFETY: `ph_credentials` is guaranteed to be non-null due to the prior check.
         unsafe {
-            (*ph_credential).dw_lower = into_raw_ptr(CredentialsHandle {
-                credentials,
-                security_package_name,
-                attributes: CredentialsAttributes::new_with_package_list(package_list),
-            }) as c_ulonglong;
+            (*ph_credential).dw_lower = handle;
         }
 
         0
@@ -598,7 +600,9 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         debug!(?service_principal, "Target name (SPN)");
 
         // SAFETY: `ph_credentials` is guaranteed to be non-null due to the prior check.
-        let credentials_handle = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+        let dw_lower = unsafe { (*ph_credential).dw_lower };
+        let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+        let credentials_handle: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
 
         // SAFETY: `credentials_handle` is either null or a valid pointer to the `CredentialsHandle` allocated by an SSPI function.
         let transformted_credentials_handle = unsafe { transform_credentials_handle(credentials_handle) };
@@ -622,10 +626,11 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         let sspi_context = unsafe { sspi_context_ptr.as_mut() };
 
         // SAFETY: `p_input` is either null or a pointer to a valid `SecBufferDesc` structure convertible to a reference.
-        let mut input_tokens = unsafe { sec_buffer_desc_to_security_buffers(p_input) };
+        let mut input_tokens = try_execute!(unsafe { sec_buffer_desc_to_security_buffers(p_input) });
 
         // SAFETY: `p_output` is guaranteed to be non-null due to the prior check.
-        let len = unsafe { (*p_output).c_buffers as usize };
+        let len = unsafe { (*p_output).c_buffers };
+        let len = try_execute!(len.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:
         // - `p_output_buffers` is guaranteed to be non-null due to the prior check.
@@ -635,7 +640,7 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut output_tokens = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let mut auth_data = Some(auth_data);
@@ -661,7 +666,8 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         // SAFETY: `ph_new_context` is convertible to a reference.
         let new_context = unsafe { ph_new_context.as_mut() }.expect("ph_new_context is non-null");
 
-        new_context.dw_lower = sspi_context_ptr.as_ptr() as c_ulonglong;
+        let dw_lower = sspi_context_ptr.as_ptr().expose_provenance();
+        new_context.dw_lower = try_execute!(dw_lower.try_into(), ErrorKind::InvalidHandle);
         // SAFETY:
         // `ph_context` is guaranteed to be non-null since it is initialized in the `p_ctxt_handle_to_sspi_context`
         // if it was previously null.
@@ -756,7 +762,9 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         debug!(?service_principal, "Target name (SPN)");
 
         // SAFETY: `ph_credentials` is guaranteed to be non-null due to the prior check.
-        let credentials_handle = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+        let dw_lower = unsafe { (*ph_credential).dw_lower };
+        let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+        let credentials_handle: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
 
         // SAFETY: `credentials_handle` is either null or a valid pointer to the `CredentialsHandle` allocated by an SSPI function.
         let transformted_credentials_handle = unsafe { transform_credentials_handle(credentials_handle) };
@@ -780,10 +788,11 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         let sspi_context = unsafe { sspi_context_ptr.as_mut() };
 
         // SAFETY: `p_input` is either null or a pointer to a valid `SecBufferDesc` structure convertible to a reference.
-        let mut input_tokens = unsafe { sec_buffer_desc_to_security_buffers(p_input) };
+        let mut input_tokens = try_execute!(unsafe { sec_buffer_desc_to_security_buffers(p_input) });
 
         // SAFETY: `p_output` is guaranteed to be non-null due to the prior check.
-        let len = unsafe { (*p_output).c_buffers as usize };
+        let len: usize = unsafe { (*p_output).c_buffers };
+        let len = try_execute!(len.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:
         // - `p_output_buffers` is guaranteed to be non-null due to the prior check.
@@ -793,7 +802,7 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut output_tokens = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let mut auth_data = Some(auth_data);
@@ -821,7 +830,8 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         // SAFETY: `ph_new_context` is convertible to a reference.
         let new_context = unsafe { ph_new_context.as_mut() }.expect("ph_new_context is non-null");
 
-        new_context.dw_lower = sspi_context_ptr.as_ptr() as c_ulonglong;
+        let dw_lower = sspi_context_ptr.as_ptr().expose_provenance();
+        new_context.dw_lower = try_execute!(dw_lower.try_into(), ErrorKind::InvalidHandle);
         // SAFETY:
         // `ph_context` is guaranteed to be non-null since it is initialized in the `p_ctxt_handle_to_sspi_context`
         // if it was previously null.
@@ -1025,7 +1035,7 @@ unsafe fn query_context_attributes_common(
 
                 // SAFETY: `sec_pkg_context_session_key` is non-null because it was cast from a non-null `p_buffer`.
                 unsafe {
-                    (*sec_pkg_context_session_key).session_key_len = session_key_len.try_into().expect("session key length should fit into u32");
+                    (*sec_pkg_context_session_key).session_key_len = try_execute!(session_key_len.try_into(), ErrorKind::InvalidParameter);
                 }
 
                 // SAFETY: Memory allocation is safe.
@@ -1366,7 +1376,9 @@ pub unsafe extern "system" fn SetCredentialsAttributesA(
         // SAFETY:
         // - `ph_credentials` is guaranteed to be non-null due to the prior check.
         // - `ph_credentials` points to a valid `credentials handle` allocated by an SSPI function.
-        let credentials_handle_ptr = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+        let dw_lower = unsafe { (*ph_credential).dw_lower };
+        let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+        let credentials_handle_ptr: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
 
         // SAFETY:
         // - `credentials_handle` a valid pointer to the `CredentialsHandle` allocated by an SSPI function.
@@ -1460,7 +1472,9 @@ pub unsafe extern "system" fn SetCredentialsAttributesW(
         // SAFETY:
         // - `ph_credentials` is guaranteed to be non-null due to the prior check.
         // - `ph_credentials` points to a valid `credentials handle` allocated by an SSPI function.
-        let credentials_handle_ptr = unsafe { (*ph_credential).dw_lower as *mut CredentialsHandle };
+        let dw_lower = unsafe { (*ph_credential).dw_lower };
+        let addr = try_execute!(usize::try_from(dw_lower), ErrorKind::InvalidHandle);
+        let credentials_handle_ptr: *mut CredentialsHandle = ptr::with_exposed_provenance_mut(addr);
 
         // SAFETY:
         // - `credentials_handle` a valid pointer to the `CredentialsHandle` allocated by an SSPI function.
@@ -1604,7 +1618,7 @@ pub unsafe extern "system" fn ChangeAccountPasswordA(
         let p_buffers = unsafe { from_raw_parts(p_output.p_buffers, len) };
         // SAFETY:
         // - `p_buffers` must contain valid [SecBuffer] structures: upheld by the user.
-        let mut output_tokens = unsafe { p_sec_buffers_to_security_buffers(p_buffers) };
+        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(p_buffers) });
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let change_password = ChangePasswordBuilder::new()
@@ -1846,7 +1860,7 @@ mod tests {
     use std::ffi::CStr;
     use std::ptr::{self, null, null_mut};
 
-    use libc::{c_ulonglong, c_void};
+    use libc::c_void;
     use num_traits::ToPrimitive;
     use sspi::SecurityStatus::ContinueNeeded;
     use sspi::{ErrorKind, U16CString, Utf16String, Utf16StringExt};
@@ -1895,16 +1909,18 @@ mod tests {
 
         let mut credentials = SecWinntAuthIdentityExW {
             version: SEC_WINNT_AUTH_IDENTITY_VERSION,
-            length: size_of::<SecWinntAuthIdentityExW>() as u32,
+            length: size_of::<SecWinntAuthIdentityExW>()
+                .try_into()
+                .expect("size of SecWinntAuthIdentityExW is a valid u32"),
             user: user.as_ptr(),
-            user_length: user.len() as u32,
+            user_length: user.len().try_into().expect("user length is a valid u32"),
             domain: domain.as_ptr(),
-            domain_length: domain.len() as u32,
+            domain_length: domain.len().try_into().expect("domain length is a valid u32"),
             password: password.as_ptr(),
-            password_length: password.len() as u32,
+            password_length: password.len().try_into().expect("password length is a valid u32"),
             flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             package_list: pkg_list.as_ptr(),
-            package_list_length: pkg_list.len() as u32,
+            package_list_length: pkg_list.len().try_into().expect("package list length is a valid u32"),
         };
 
         let mut cred_handle = SecHandle {
@@ -1938,7 +1954,7 @@ mod tests {
         let mut target_name = "TERMSRV/test_user@example.com\0".encode_utf16().collect::<Vec<_>>();
         let mut attrs = 0;
 
-        let mut out_buffer = vec![0; cb_max_token as usize];
+        let mut out_buffer = vec![0; cb_max_token.try_into().expect("cb_max_token is a valid usize")];
         let mut out_sec_buffer = SecBuffer {
             cb_buffer: cb_max_token,
             buffer_type: 2,
@@ -2037,7 +2053,7 @@ mod tests {
         let status = unsafe { EnumerateSecurityPackagesW(&mut pc_packages, &mut packages) };
         assert_eq!(status, 0);
 
-        for i in 0..pc_packages as usize {
+        for i in 0..usize::try_from(pc_packages).expect("pc_packages is a valid usize") {
             let pkg_info = unsafe { packages.add(i) };
             let pkg_info = unsafe { pkg_info.as_ref() }.expect("pkg_info is not null");
 
@@ -2063,13 +2079,16 @@ mod tests {
         let domain = "domain".encode_utf16().collect::<Vec<_>>();
         let password = "password".encode_utf16().collect::<Vec<_>>();
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = SecWinntAuthIdentityW {
             user: user.as_ptr(),
-            user_length: user.len() as u32,
+            user_length,
             domain: domain.as_ptr(),
-            domain_length: domain.len() as u32,
+            domain_length,
             password: password.as_ptr(),
-            password_length: password.len() as u32,
+            password_length,
             flags: 0,
         };
 
@@ -2104,7 +2123,7 @@ mod tests {
         let mut target_name = "TERMSRV/some@example.com\0".encode_utf16().collect::<Vec<_>>();
         let mut attrs = 0;
 
-        let mut out_buffer = vec![0; cb_max_token as usize];
+        let mut out_buffer = vec![0; usize::try_from(cb_max_token).expect("cb_max_token is a valid usize")];
         let mut out_sec_buffer = SecBuffer {
             cb_buffer: cb_max_token,
             buffer_type: 2,
@@ -2178,7 +2197,7 @@ mod tests {
         let status = unsafe { EnumerateSecurityPackagesA(&mut pc_packages, &mut packages) };
         assert_eq!(status, 0);
 
-        for i in 0..pc_packages as usize {
+        for i in 0..usize::try_from(pc_packages).expect("pc_packages is a valid usize") {
             let pkg_info = unsafe { packages.add(i) };
             let pkg_info = unsafe { pkg_info.as_ref() }.expect("pkg_info is not null");
 
@@ -2194,13 +2213,16 @@ mod tests {
         let domain = "domain";
         let password = "password";
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = SecWinntAuthIdentityA {
             user: user.as_ptr().cast(),
-            user_length: user.len() as u32,
+            user_length,
             domain: domain.as_ptr().cast(),
-            domain_length: domain.len() as u32,
+            domain_length,
             password: password.as_ptr().cast(),
-            password_length: password.len() as u32,
+            password_length,
             flags: 1,
         };
 
@@ -2235,7 +2257,7 @@ mod tests {
         let mut target_name = String::from("TERMSRV/some@example.com\0");
         let mut attrs = 0;
 
-        let mut out_buffer = vec![0; cb_max_token as usize];
+        let mut out_buffer = vec![0; usize::try_from(cb_max_token).expect("cb_max_token is a valid usize")];
         let mut out_sec_buffer = SecBuffer {
             cb_buffer: cb_max_token,
             buffer_type: 2,
@@ -2289,30 +2311,33 @@ mod tests {
         let domain = "domain".encode_utf16().collect::<Vec<_>>();
         let password = "password".encode_utf16().collect::<Vec<_>>();
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = vec![
             SecWinntAuthIdentityW {
                 user: null(),
                 user_length: 0,
                 domain: domain.as_ptr(),
-                domain_length: domain.len() as u32,
+                domain_length,
                 password: password.as_ptr(),
-                password_length: password.len() as u32,
+                password_length,
                 flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             },
             SecWinntAuthIdentityW {
                 user: user.as_ptr(),
-                user_length: user.len() as u32,
+                user_length,
                 domain: null(),
                 domain_length: 0,
                 password: password.as_ptr(),
-                password_length: password.len() as u32,
+                password_length,
                 flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
             },
             SecWinntAuthIdentityW {
                 user: user.as_ptr(),
-                user_length: user.len() as u32,
+                user_length,
                 domain: domain.as_ptr(),
-                domain_length: domain.len() as u32,
+                domain_length,
                 password: null(),
                 password_length: 0,
                 flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
@@ -2356,13 +2381,16 @@ mod tests {
         let domain = "".encode_utf16().collect::<Vec<_>>();
         let password = "".encode_utf16().collect::<Vec<_>>();
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = SecWinntAuthIdentityW {
             user: user.as_ptr(),
-            user_length: user.len() as u32,
+            user_length,
             domain: domain.as_ptr(),
-            domain_length: domain.len() as u32,
+            domain_length,
             password: password.as_ptr(),
-            password_length: password.len() as u32,
+            password_length,
             flags: SEC_WINNT_AUTH_IDENTITY_UNICODE,
         };
 
@@ -2401,30 +2429,33 @@ mod tests {
         let domain = "domain";
         let password = "password";
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = vec![
             SecWinntAuthIdentityA {
                 user: null(),
                 user_length: 0,
                 domain: domain.as_ptr().cast(),
-                domain_length: domain.len() as u32,
+                domain_length,
                 password: password.as_ptr().cast(),
-                password_length: password.len() as u32,
+                password_length,
                 flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
             },
             SecWinntAuthIdentityA {
                 user: user.as_ptr().cast(),
-                user_length: user.len() as u32,
+                user_length,
                 domain: null(),
                 domain_length: 0,
                 password: password.as_ptr().cast(),
-                password_length: password.len() as u32,
+                password_length,
                 flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
             },
             SecWinntAuthIdentityA {
                 user: user.as_ptr().cast(),
-                user_length: user.len() as u32,
+                user_length,
                 domain: domain.as_ptr().cast(),
-                domain_length: domain.len() as u32,
+                domain_length,
                 password: null(),
                 password_length: 0,
                 flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
@@ -2468,13 +2499,16 @@ mod tests {
         let domain = "";
         let password = "";
 
+        let user_length = user.len().try_into().expect("user length is a valid u32");
+        let domain_length = domain.len().try_into().expect("domain length is a valid u32");
+        let password_length = password.len().try_into().expect("password length is a valid u32");
         let credentials = SecWinntAuthIdentityA {
             user: user.as_ptr().cast(),
-            user_length: user.len() as u32,
+            user_length,
             domain: domain.as_ptr().cast(),
-            domain_length: domain.len() as u32,
+            domain_length,
             password: password.as_ptr().cast(),
-            password_length: password.len() as u32,
+            password_length,
             flags: SEC_WINNT_AUTH_IDENTITY_ANSI,
         };
 
@@ -2517,10 +2551,13 @@ mod tests {
         // Initialize the security handle: simulate the `p_ctxt_handle_to_sspi_context` function.
         // We use Kerberos fake_client because we need established security context to query the session key.
         let sspi_context = SspiHandle::new(SspiContext::Kerberos(kerberos_client));
-        let sspi_context_ptr = into_raw_ptr(sspi_context);
+        let sspi_context_ptr = into_raw_ptr(sspi_context).expose_provenance();
         let mut sec_handle = SecHandle {
-            dw_lower: sspi_context_ptr as c_ulonglong,
-            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string()) as c_ulonglong,
+            dw_lower: sspi_context_ptr.try_into().unwrap(),
+            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string())
+                .expose_provenance()
+                .try_into()
+                .unwrap(),
         };
 
         let mut session_key = SecPkgContextSessionKey {
@@ -2538,7 +2575,15 @@ mod tests {
         assert_eq!(status, 0);
 
         // Print the session key
-        let key = unsafe { from_raw_parts(session_key.session_key, session_key.session_key_len as usize) };
+        let key = unsafe {
+            from_raw_parts(
+                session_key.session_key,
+                session_key
+                    .session_key_len
+                    .try_into()
+                    .expect("session key length is a valid usize"),
+            )
+        };
         println!("Session key length: {}", session_key.session_key_len);
         println!("Session key: {:02x?}", key);
 
@@ -2546,8 +2591,11 @@ mod tests {
         let status = unsafe { FreeContextBuffer(session_key.session_key.cast()) };
         assert_eq!(status, 0);
 
-        let _ = unsafe { Box::from_raw(sec_handle.dw_upper as *mut String) };
-        let _ = unsafe { Box::from_raw(sec_handle.dw_lower as *mut SspiHandle) };
+        let dw_upper_ptr: *mut String = ptr::with_exposed_provenance_mut(sec_handle.dw_upper.try_into().unwrap());
+        let _ = unsafe { Box::from_raw(dw_upper_ptr) };
+
+        let dw_lower_ptr: *mut SspiHandle = ptr::with_exposed_provenance_mut(sec_handle.dw_lower.try_into().unwrap());
+        let _ = unsafe { Box::from_raw(dw_lower_ptr) };
     }
 
     #[test]
@@ -2565,10 +2613,13 @@ mod tests {
         // Initialize the security handle: simulate the `p_ctxt_handle_to_sspi_context` function.
         // We use Kerberos fake_client because we need established security context to query the names.
         let sspi_context = SspiHandle::new(SspiContext::Kerberos(kerberos_client));
-        let sspi_context_ptr = into_raw_ptr(sspi_context);
+        let sspi_context_ptr = into_raw_ptr(sspi_context).expose_provenance();
         let mut sec_handle = SecHandle {
-            dw_lower: sspi_context_ptr as c_ulonglong,
-            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string()) as c_ulonglong,
+            dw_lower: sspi_context_ptr.try_into().unwrap(),
+            dw_upper: into_raw_ptr(sspi::kerberos::PACKAGE_INFO.name.to_string())
+                .expose_provenance()
+                .try_into()
+                .unwrap(),
         };
 
         let mut names_w = SecPkgContextNamesW { user_name: null_mut() };
@@ -2601,7 +2652,10 @@ mod tests {
         let status = unsafe { FreeContextBuffer(names_a.user_name.cast()) };
         assert_eq!(status, 0);
 
-        let _ = unsafe { Box::from_raw(sec_handle.dw_upper as *mut String) };
-        let _ = unsafe { Box::from_raw(sec_handle.dw_lower as *mut SspiHandle) };
+        let dw_upper_ptr: *mut String = ptr::with_exposed_provenance_mut(sec_handle.dw_upper.try_into().unwrap());
+        let _ = unsafe { Box::from_raw(dw_upper_ptr) };
+
+        let dw_lower_ptr: *mut SspiHandle = ptr::with_exposed_provenance_mut(sec_handle.dw_lower.try_into().unwrap());
+        let _ = unsafe { Box::from_raw(dw_lower_ptr) };
     }
 }

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1,5 +1,5 @@
 use std::ffi::CStr;
-use std::mem::{size_of, transmute};
+use std::mem::size_of;
 use std::ptr::{self, NonNull, copy_nonoverlapping};
 use std::slice::from_raw_parts;
 use std::sync::Mutex;
@@ -791,7 +791,7 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         let mut input_tokens = try_execute!(unsafe { sec_buffer_desc_to_security_buffers(p_input) });
 
         // SAFETY: `p_output` is guaranteed to be non-null due to the prior check.
-        let len: usize = unsafe { (*p_output).c_buffers };
+        let len = unsafe { (*p_output).c_buffers };
         let len = try_execute!(len.try_into(), ErrorKind::InvalidParameter);
 
         // SAFETY:

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -626,7 +626,8 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         let sspi_context = unsafe { sspi_context_ptr.as_mut() };
 
         // SAFETY: `p_input` is either null or a pointer to a valid `SecBufferDesc` structure convertible to a reference.
-        let mut input_tokens = try_execute!(unsafe { sec_buffer_desc_to_security_buffers(p_input) });
+        let input_tokens = unsafe { sec_buffer_desc_to_security_buffers(p_input) };
+        let mut input_tokens = try_execute!(input_tokens);
 
         // SAFETY: `p_output` is guaranteed to be non-null due to the prior check.
         let len = unsafe { (*p_output).c_buffers };
@@ -640,7 +641,8 @@ pub unsafe extern "system" fn InitializeSecurityContextA(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
+        let output_tokens = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut output_tokens = try_execute!(output_tokens);
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let mut auth_data = Some(auth_data);
@@ -788,7 +790,8 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         let sspi_context = unsafe { sspi_context_ptr.as_mut() };
 
         // SAFETY: `p_input` is either null or a pointer to a valid `SecBufferDesc` structure convertible to a reference.
-        let mut input_tokens = try_execute!(unsafe { sec_buffer_desc_to_security_buffers(p_input) });
+        let input_tokens = unsafe { sec_buffer_desc_to_security_buffers(p_input) };
+        let mut input_tokens = try_execute!(input_tokens);
 
         // SAFETY: `p_output` is guaranteed to be non-null due to the prior check.
         let len = unsafe { (*p_output).c_buffers };
@@ -802,7 +805,8 @@ pub unsafe extern "system" fn InitializeSecurityContextW(
         // SAFETY:
         // - `raw_buffers` array contains valid `SecBuffer` structures.
         // - Each `SecBuffer` have a valid `pv_buffer` pointer that is valid for reads of `cb_buffer` bytes.
-        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(raw_buffers) });
+        let output_tokens = unsafe { p_sec_buffers_to_security_buffers(raw_buffers) };
+        let mut output_tokens = try_execute!(output_tokens);
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let mut auth_data = Some(auth_data);
@@ -1618,7 +1622,8 @@ pub unsafe extern "system" fn ChangeAccountPasswordA(
         let p_buffers = unsafe { from_raw_parts(p_output.p_buffers, len) };
         // SAFETY:
         // - `p_buffers` must contain valid [SecBuffer] structures: upheld by the user.
-        let mut output_tokens = try_execute!(unsafe { p_sec_buffers_to_security_buffers(p_buffers) });
+        let output_tokens = unsafe { p_sec_buffers_to_security_buffers(p_buffers) };
+        let mut output_tokens = try_execute!(output_tokens);
         output_tokens.iter_mut().for_each(|s| s.buffer.clear());
 
         let change_password = ChangePasswordBuilder::new()

--- a/ffi/src/sspi/sec_pkg_info.rs
+++ b/ffi/src/sspi/sec_pkg_info.rs
@@ -43,18 +43,19 @@ impl From<PackageInfo> for RawSecPkgInfoW {
         unsafe {
             raw_pkg_info = libc::malloc(size);
         }
-        // SAFETY:
         // FIXME(safety): it is illegal to construct a reference to uninitialized data
         // Useful references:
         // - https://doc.rust-lang.org/nomicon/unchecked-uninit.html
         // - https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-a-struct-field-by-field
         // NOTE: this is not the only place that needs to be fixed. An audit is required.
+        let raw_pkg_info_w = raw_pkg_info.cast::<SecPkgInfoW>();
+        // SAFETY: `raw_pkg_info_w` points to allocated memory that is valid for writing.
         unsafe {
-            pkg_info_w = (raw_pkg_info as *mut SecPkgInfoW).as_mut().unwrap();
+            pkg_info_w = raw_pkg_info_w.as_mut().unwrap();
         }
 
         pkg_info_w.f_capabilities = pkg_info.capabilities.bits();
-        pkg_info_w.w_version = KERBEROS_VERSION as u16;
+        pkg_info_w.w_version = u16::from(KERBEROS_VERSION);
         pkg_info_w.w_rpc_id = pkg_info.rpc_id;
         pkg_info_w.cb_max_token = pkg_info.max_token_len.try_into().unwrap();
 
@@ -84,7 +85,7 @@ impl From<PackageInfo> for RawSecPkgInfoW {
         }
         pkg_info_w.comment = comment_ptr.cast();
 
-        Self(raw_pkg_info as *mut SecPkgInfoW)
+        Self(raw_pkg_info.cast::<SecPkgInfoW>())
     }
 }
 
@@ -127,18 +128,19 @@ impl From<PackageInfo> for RawSecPkgInfoA {
         unsafe {
             raw_pkg_info = libc::malloc(size);
         }
-        // SAFETY:
         // FIXME(safety): it is illegal to construct a reference to uninitialized data
         // Useful references:
         // - https://doc.rust-lang.org/nomicon/unchecked-uninit.html
         // - https://doc.rust-lang.org/core/mem/union.MaybeUninit.html#initializing-a-struct-field-by-field
         // NOTE: this is not the only place that needs to be fixed. An audit is required.
+        let raw_pkg_info_a = raw_pkg_info.cast::<SecPkgInfoA>();
+        // SAFETY: `raw_pkg_info_a` points to allocated memory that is valid for writing.
         unsafe {
-            pkg_info_a = (raw_pkg_info as *mut SecPkgInfoA).as_mut().unwrap();
+            pkg_info_a = raw_pkg_info_a.as_mut().unwrap();
         }
 
         pkg_info_a.f_capabilities = pkg_info.capabilities.bits();
-        pkg_info_a.w_version = KERBEROS_VERSION as u16;
+        pkg_info_a.w_version = u16::from(KERBEROS_VERSION);
         pkg_info_a.w_rpc_id = pkg_info.rpc_id;
         pkg_info_a.cb_max_token = pkg_info.max_token_len;
 
@@ -168,7 +170,7 @@ impl From<PackageInfo> for RawSecPkgInfoA {
         }
         pkg_info_a.comment = comment_ptr.cast();
 
-        Self(raw_pkg_info as *mut SecPkgInfoA)
+        Self(raw_pkg_info.cast::<SecPkgInfoA>())
     }
 }
 
@@ -208,8 +210,9 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
 
         let packages = try_execute!(enumerate_security_packages());
 
+        let package_count: u32 = try_execute!(packages.len().try_into(), ErrorKind::InvalidParameter);
         // SAFETY: `pc_packages` is guaranteed to be non-null due to the prior check.
-        unsafe { *pc_packages = packages.len() as u32; }
+        unsafe { *pc_packages = package_count; }
 
         let mut size = size_of::<SecPkgInfoA>() * packages.len();
 
@@ -224,10 +227,10 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
             return ErrorKind::InsufficientMemory.to_u32().unwrap();
         }
 
-        let mut package_ptr = raw_packages as *mut SecPkgInfoA;
+        let mut package_ptr = raw_packages.cast::<SecPkgInfoA>();
 
         // SAFETY: It is safe to cast a pointer because we allocated enough memory to place package name and comment alongside SecPkgInfoA.
-        let mut data_ptr = unsafe { raw_packages.add(size_of::<SecPkgInfoA>() * packages.len()) as *mut SecChar };
+        let mut data_ptr = unsafe { raw_packages.add(size_of::<SecPkgInfoA>() * packages.len()).cast::<SecChar>() };
         for pkg_info in packages {
             // FIXME(safety): it is illegal to construct a reference to uninitialized data
             // Useful references:
@@ -238,7 +241,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesA(
             let pkg_info_a = unsafe { package_ptr.as_mut().unwrap() };
 
             pkg_info_a.f_capabilities = pkg_info.capabilities.bits();
-            pkg_info_a.w_version = KERBEROS_VERSION as u16;
+            pkg_info_a.w_version = u16::from(KERBEROS_VERSION);
             pkg_info_a.w_rpc_id = pkg_info.rpc_id;
             pkg_info_a.cb_max_token = pkg_info.max_token_len;
 
@@ -308,8 +311,9 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
 
         let packages = try_execute!(enumerate_security_packages());
 
+        let package_count: u32 = try_execute!(packages.len().try_into(), ErrorKind::InvalidParameter);
         // SAFETY: `pc_packages` is guaranteed to be non-null due to the prior check.
-        unsafe { *pc_packages = packages.len() as u32; }
+        unsafe { *pc_packages = package_count; }
 
         let mut size = size_of::<SecPkgInfoW>() * packages.len();
         let mut names = Vec::with_capacity(packages.len());
@@ -332,9 +336,9 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
             return ErrorKind::InsufficientMemory.to_u32().unwrap();
         }
 
-        let mut package_ptr = raw_packages as *mut SecPkgInfoW;
+        let mut package_ptr = raw_packages.cast::<SecPkgInfoW>();
         // SAFETY: It is safe to cast a pointer because we allocated enough memory to place package name and comment alongside SecPkgInfoA.
-        let mut data_ptr = unsafe { raw_packages.add(size_of::<SecPkgInfoW>() * packages.len()) as *mut SecWChar };
+        let mut data_ptr = unsafe { raw_packages.add(size_of::<SecPkgInfoW>() * packages.len()).cast::<SecWChar>() };
         for (i, pkg_info) in packages.iter().enumerate() {
             // FIXME(safety): it is illegal to construct a reference to uninitialized data
             // Useful references:
@@ -345,7 +349,7 @@ pub unsafe extern "system" fn EnumerateSecurityPackagesW(
             let pkg_info_w = unsafe { package_ptr.as_mut().unwrap() };
 
             pkg_info_w.f_capabilities = pkg_info.capabilities.bits();
-            pkg_info_w.w_version = KERBEROS_VERSION as u16;
+            pkg_info_w.w_version = u16::from(KERBEROS_VERSION);
             pkg_info_w.w_rpc_id = pkg_info.rpc_id;
             pkg_info_w.cb_max_token = pkg_info.max_token_len;
 
@@ -509,7 +513,7 @@ mod tests {
         assert_eq!(packages_amount, expected_packages_amount);
         assert!(!packages.is_null());
 
-        for i in 0..(packages_amount as usize) {
+        for i in 0..packages_amount.try_into().expect("packages_amount is a valid usize") {
             let pkg_info = unsafe { packages.add(i) };
             let pkg_info = unsafe { pkg_info.as_mut() }.expect("pkg_info is not null");
 
@@ -550,7 +554,7 @@ mod tests {
         assert_eq!(packages_amount, expected_packages_amount);
         assert!(!packages.is_null());
 
-        for i in 0..(packages_amount as usize) {
+        for i in 0..packages_amount.try_into().expect("packages_amount is a valid usize") {
             let pkg_info = unsafe { packages.add(i) };
             let pkg_info = unsafe { pkg_info.as_mut() }.expect("pkg_info is not null");
 

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -520,16 +520,16 @@ pub unsafe fn auth_data_to_identity_buffers_w(
     // SAFETY:
     // - Credentials pointers can be NULL.
     // - If credentials are not NULL, then the caller is responsible for the data validity.
-    let user = unsafe { credentials_str_into_bytes(user.cast(), usize::try_from(user_len)?) };
+    let user = unsafe { credentials_str_into_bytes(user.cast(), usize::try_from(user_len)? * 2) };
     // SAFETY:
     // - Credentials pointers can be NULL.
     // - If credentials are not NULL, then the caller is responsible for the data validity.
-    let domain = unsafe { credentials_str_into_bytes(domain.cast(), usize::try_from(domain_len)?) };
+    let domain = unsafe { credentials_str_into_bytes(domain.cast(), usize::try_from(domain_len)? * 2) };
     let password: Secret<Vec<u8>> =
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        unsafe { credentials_str_into_bytes(password.cast(), usize::try_from(password_len)?) }.into();
+        unsafe { credentials_str_into_bytes(password.cast(), usize::try_from(password_len)? * 2) }.into();
 
     let mut username = user.clone();
     username.extend_from_slice(&[0, 0]);

--- a/ffi/src/sspi/sec_winnt_auth_identity.rs
+++ b/ffi/src/sspi/sec_winnt_auth_identity.rs
@@ -232,7 +232,7 @@ unsafe fn credssp_auth_data_to_identity_buffers(p_auth_data: *const c_void) -> R
                 .to_bytes_with_nul();
 
             let cred_ui_info = CREDUI_INFOW {
-                cbSize: size_of::<CREDUI_INFOW>().try_into().unwrap(),
+                cbSize: size_of::<CREDUI_INFOW>().try_into()?,
                 hwndParent: HWND::default(),
                 pszMessageText: PCWSTR::from_raw(message.as_ptr().cast()),
                 pszCaptionText: PCWSTR::from_raw(caption.as_ptr().cast()),
@@ -376,32 +376,33 @@ pub unsafe fn auth_data_to_identity_buffers_a(
         let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
 
         if !auth_data.package_list.is_null() && auth_data.package_list_length > 0 {
+            let package_list_length = auth_data.package_list_length.try_into()?;
             *package_list = Some(
                 // SAFETY: `auth_data.package_list` is a non-null pointer to a valid buffer valid for reads of `auth_data.package_list_length` bytes.
-                String::from_utf8_lossy(unsafe {
-                    from_raw_parts(auth_data.package_list.cast(), auth_data.package_list_length as usize)
-                })
-                .to_string(),
+                String::from_utf8_lossy(unsafe { from_raw_parts(auth_data.package_list.cast(), package_list_length) })
+                    .to_string(),
             );
         }
 
+        let user_length = auth_data.user_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let username_data = unsafe { credentials_str_into_bytes(auth_data.user, auth_data.user_length as usize) };
+        let username_data = unsafe { credentials_str_into_bytes(auth_data.user, user_length) };
         let user = Utf16String::from_utf8_bytes(username_data)?.to_bytes_le();
 
+        let domain_length = auth_data.domain_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let domain_data = unsafe { credentials_str_into_bytes(auth_data.domain, auth_data.domain_length as usize) };
+        let domain_data = unsafe { credentials_str_into_bytes(auth_data.domain, domain_length) };
         let domain = Utf16String::from_utf8_bytes(domain_data)?.to_bytes_le();
 
+        let password_length = auth_data.password_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let password_data =
-            unsafe { credentials_str_into_bytes(auth_data.password, auth_data.password_length as usize) };
+        let password_data = unsafe { credentials_str_into_bytes(auth_data.password, password_length) };
         let password = Utf16String::from_utf8_bytes(password_data)?.to_bytes_le();
 
         // Try to collect credentials for the emulated/system-provided smart card.
@@ -422,23 +423,25 @@ pub unsafe fn auth_data_to_identity_buffers_a(
         // that points to a valid `SecWinntAuthIdentityA` structure.
         let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
 
+        let user_length = auth_data.user_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let username_data = unsafe { credentials_str_into_bytes(auth_data.user, auth_data.user_length as usize) };
+        let username_data = unsafe { credentials_str_into_bytes(auth_data.user, user_length) };
         let user = Utf16String::from_utf8_bytes(username_data)?.to_bytes_le();
 
+        let domain_length = auth_data.domain_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let domain_data = unsafe { credentials_str_into_bytes(auth_data.domain, auth_data.domain_length as usize) };
+        let domain_data = unsafe { credentials_str_into_bytes(auth_data.domain, domain_length) };
         let domain = Utf16String::from_utf8_bytes(domain_data)?.to_bytes_le();
 
+        let password_length = auth_data.password_length.try_into()?;
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        let password_data =
-            unsafe { credentials_str_into_bytes(auth_data.password, auth_data.password_length as usize) };
+        let password_data = unsafe { credentials_str_into_bytes(auth_data.password, password_length) };
         let password = Utf16String::from_utf8_bytes(password_data)?.to_bytes_le();
 
         // Try to collect credentials for the emulated/system-provided smart card.
@@ -477,57 +480,56 @@ pub unsafe fn auth_data_to_identity_buffers_w(
     //   structure, depending on the `auth_version`.
     let (auth_version, _) = unsafe { get_auth_data_identity_version_and_flags(p_auth_data) };
 
-    let (user, user_len, domain, domain_len, password, password_len) = if auth_version
-        == SEC_WINNT_AUTH_IDENTITY_VERSION
-    {
-        let auth_data = p_auth_data.cast::<SecWinntAuthIdentityExW>();
-        // SAFETY: `auth_data` is not null. We've checked this above.
-        let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
+    let (user, user_len, domain, domain_len, password, password_len) =
+        if auth_version == SEC_WINNT_AUTH_IDENTITY_VERSION {
+            let auth_data = p_auth_data.cast::<SecWinntAuthIdentityExW>();
+            // SAFETY: `auth_data` is not null. We've checked this above.
+            let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
 
-        if !auth_data.package_list.is_null() && auth_data.package_list_length > 0 {
-            let package_list_length = usize::try_from(auth_data.package_list_length).expect("u32 is castable to usize");
+            if !auth_data.package_list.is_null() && auth_data.package_list_length > 0 {
+                let package_list_length = auth_data.package_list_length.try_into()?;
 
-            // SAFETY: `package_list` is not null due to a prior check.
-            let package_list_data = unsafe { from_raw_parts(auth_data.package_list, package_list_length) };
-            *package_list = Some(String::from_utf16(package_list_data)?);
-        }
+                // SAFETY: `package_list` is not null due to a prior check.
+                let package_list_data = unsafe { from_raw_parts(auth_data.package_list, package_list_length) };
+                *package_list = Some(String::from_utf16(package_list_data)?);
+            }
 
-        (
-            auth_data.user,
-            auth_data.user_length,
-            auth_data.domain,
-            auth_data.domain_length,
-            auth_data.password,
-            auth_data.password_length,
-        )
-    } else {
-        let auth_data = p_auth_data.cast::<SecWinntAuthIdentityW>();
-        // SAFETY: `auth_data` is not null. We've checked this above.
-        let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
+            (
+                auth_data.user,
+                auth_data.user_length,
+                auth_data.domain,
+                auth_data.domain_length,
+                auth_data.password,
+                auth_data.password_length,
+            )
+        } else {
+            let auth_data = p_auth_data.cast::<SecWinntAuthIdentityW>();
+            // SAFETY: `auth_data` is not null. We've checked this above.
+            let auth_data = unsafe { auth_data.as_ref() }.expect("auth_data pointer should not be null");
 
-        (
-            auth_data.user,
-            auth_data.user_length,
-            auth_data.domain,
-            auth_data.domain_length,
-            auth_data.password,
-            auth_data.password_length,
-        )
-    };
+            (
+                auth_data.user,
+                auth_data.user_length,
+                auth_data.domain,
+                auth_data.domain_length,
+                auth_data.password,
+                auth_data.password_length,
+            )
+        };
 
     // SAFETY:
     // - Credentials pointers can be NULL.
     // - If credentials are not NULL, then the caller is responsible for the data validity.
-    let user = unsafe { credentials_str_into_bytes(user.cast(), user_len as usize * 2) };
+    let user = unsafe { credentials_str_into_bytes(user.cast(), usize::try_from(user_len)?) };
     // SAFETY:
     // - Credentials pointers can be NULL.
     // - If credentials are not NULL, then the caller is responsible for the data validity.
-    let domain = unsafe { credentials_str_into_bytes(domain.cast(), domain_len as usize * 2) };
+    let domain = unsafe { credentials_str_into_bytes(domain.cast(), usize::try_from(domain_len)?) };
     let password: Secret<Vec<u8>> =
         // SAFETY:
         // - Credentials pointers can be NULL.
         // - If credentials are not NULL, then the caller is responsible for the data validity.
-        unsafe { credentials_str_into_bytes(password.cast(), password_len as usize * 2) }.into();
+        unsafe { credentials_str_into_bytes(password.cast(), usize::try_from(password_len)?) }.into();
 
     let mut username = user.clone();
     username.extend_from_slice(&[0, 0]);
@@ -702,7 +704,7 @@ unsafe fn get_sec_winnt_auth_identity_ex2_size(p_auth_data: *const c_void) -> Re
     // https://github.com/FreeRDP/FreeRDP/blob/master/winpr/libwinpr/sspi/sspi_winpr.c#L473
 
     // SAFETY: Username length is placed after the first 8 bytes, according to the documentation.
-    let user_len_ptr = unsafe { (p_auth_data as *const u16).add(4) };
+    let user_len_ptr = unsafe { (p_auth_data.cast::<u16>()).add(4) };
     if user_len_ptr.is_null() {
         return Err(Error::new(
             ErrorKind::InvalidParameter,
@@ -710,7 +712,7 @@ unsafe fn get_sec_winnt_auth_identity_ex2_size(p_auth_data: *const c_void) -> Re
         ));
     }
     // SAFETY: `user_len_ptr` is guaranteed to be non-null due to the prior check.
-    let user_buffer_len = unsafe { *user_len_ptr as u32 };
+    let user_buffer_len = u32::from(unsafe { *user_len_ptr });
 
     // SAFETY: Domain length is placed after 16 bytes from the username length, according to the documentation.
     let domain_len_ptr = unsafe { user_len_ptr.add(8) };
@@ -721,7 +723,7 @@ unsafe fn get_sec_winnt_auth_identity_ex2_size(p_auth_data: *const c_void) -> Re
         ));
     }
     // SAFETY: `domain_len_ptr` is guaranteed to be non-null due to the prior check.
-    let domain_buffer_len = unsafe { *domain_len_ptr as u32 };
+    let domain_buffer_len = u32::from(unsafe { *domain_len_ptr });
 
     // SAFETY: Packet credentials length is placed after 16 bytes from the domain length
     let creds_len_ptr = unsafe { domain_len_ptr.add(8) };
@@ -732,7 +734,7 @@ unsafe fn get_sec_winnt_auth_identity_ex2_size(p_auth_data: *const c_void) -> Re
         ));
     }
     // SAFETY: `creds_len_ptr` is guaranteed to be non-null due to the prior check.
-    let creds_buffer_len = unsafe { *creds_len_ptr as u32 };
+    let creds_buffer_len = u32::from(unsafe { *creds_len_ptr });
 
     // The resulting size is equal to the header size + buffers size.
     Ok(64 /* size of the SEC_WINNT_AUTH_IDENTITY_EX2 */ + user_buffer_len + domain_buffer_len + creds_buffer_len)
@@ -798,9 +800,9 @@ pub unsafe fn unpack_sec_winnt_auth_identity_ex2_a(p_auth_data: *const c_void) -
         Err(_) => (),
     };
 
-    let mut username = vec![0_u8; username_len as usize];
-    let mut domain = vec![0_u8; domain_len as usize];
-    let mut password = Secret::new(vec![0_u8; password_len as usize]);
+    let mut username = vec![0_u8; username_len.try_into()?];
+    let mut domain = vec![0_u8; domain_len.try_into()?];
+    let mut password = Secret::new(vec![0_u8; password_len.try_into()?]);
 
     // Knowing the actual sizes, we can unpack credentials into prepared buffers.
     //
@@ -1040,9 +1042,9 @@ pub unsafe fn unpack_sec_winnt_auth_identity_ex2_w_sized(
         Err(_) => (),
     };
 
-    let mut username = vec![0_u8; username_len as usize * 2];
-    let mut domain = vec![0_u8; domain_len as usize * 2];
-    let mut password = Secret::new(vec![0_u8; password_len as usize * 2]);
+    let mut username = vec![0_u8; usize::try_from(username_len)? * 2];
+    let mut domain = vec![0_u8; usize::try_from(domain_len)? * 2];
+    let mut password = Secret::new(vec![0_u8; usize::try_from(password_len)? * 2]);
 
     // SAFETY: `p_auth_data` is guaranteed to be non-null due to the prior check.
     let result = unsafe {
@@ -1180,7 +1182,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         }
 
         // SAFETY: Memory allocation is safe.
-        let user = unsafe { libc::malloc(user_length * 2) as *mut SecWChar };
+        let user = unsafe { libc::malloc(user_length * 2).cast::<SecWChar>() };
         if user.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
         }
@@ -1191,7 +1193,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         unsafe { copy_nonoverlapping(psz_user_name, user, user_length) };
 
         // SAFETY: Memory allocation is safe.
-        let domain = unsafe { libc::malloc(domain_length * 2) as *mut SecWChar };
+        let domain = unsafe { libc::malloc(domain_length * 2).cast::<SecWChar>() };
         if domain.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
         }
@@ -1202,7 +1204,7 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
         unsafe { copy_nonoverlapping(psz_domain_name, domain, domain_length) };
 
         // SAFETY: Memory allocation is safe.
-        let password = unsafe { libc::malloc(password_length * 2) as *mut SecWChar };
+        let password = unsafe { libc::malloc(password_length * 2).cast::<SecWChar>() };
         if password.is_null() {
             return ErrorKind::InternalError.to_u32().unwrap();
         }
@@ -1222,8 +1224,9 @@ pub unsafe extern "system" fn SspiEncodeStringsAsAuthIdentity(
             flags: 0,
         };
 
+        let auth_identity_ptr = into_raw_ptr(auth_identity).cast::<c_void>();
         // SAFETY: `pp_auth_identity` is guaranteed to be non-null due to the prior check.
-        unsafe { *pp_auth_identity = into_raw_ptr(auth_identity) as *mut c_void; }
+        unsafe { *pp_auth_identity = auth_identity_ptr; }
 
         0
     }
@@ -1308,21 +1311,34 @@ mod tests {
         let identity = identity.cast::<SecWinntAuthIdentityW>();
         let identity = unsafe { identity.as_mut() }.expect("identity is not null");
 
+        let user_length = identity
+            .user_length
+            .try_into()
+            .expect("user_length should fit into usize");
+        let password_length = identity
+            .password_length
+            .try_into()
+            .expect("password_length should fit into usize");
+        let domain_length = identity
+            .domain_length
+            .try_into()
+            .expect("domain_length should fit into usize");
+
         assert_eq!(
             "user",
-            String::from_utf16(unsafe { from_raw_parts(identity.user, identity.user_length as usize) })
+            String::from_utf16(unsafe { from_raw_parts(identity.user, user_length) })
                 .expect("user is a correct utf-16 string")
         );
 
         assert_eq!(
             "pass",
-            String::from_utf16(unsafe { from_raw_parts(identity.password, identity.password_length as usize) })
+            String::from_utf16(unsafe { from_raw_parts(identity.password, password_length) })
                 .expect("password is a correct utf-16 string")
         );
 
         assert_eq!(
             "domain",
-            String::from_utf16(unsafe { from_raw_parts(identity.domain, identity.domain_length as usize) })
+            String::from_utf16(unsafe { from_raw_parts(identity.domain, domain_length) })
                 .expect("domain is a correct utf-16 string")
         );
 

--- a/ffi/src/sspi/security_tables.rs
+++ b/ffi/src/sspi/security_tables.rs
@@ -124,7 +124,7 @@ pub extern "system" fn InitSecurityInterfaceA() -> PSecurityFunctionTableA {
     crate::logging::setup_logger();
 
     into_raw_ptr(SecurityFunctionTableA {
-        dwVersion: KERBEROS_VERSION as u32,
+        dwVersion: u32::from(KERBEROS_VERSION),
         EnumerateSecurityPackagesA,
         QueryCredentialsAttributesA,
         AcquireCredentialsHandleA,
@@ -167,7 +167,7 @@ pub extern "system" fn InitSecurityInterfaceW() -> PSecurityFunctionTableW {
     crate::logging::setup_logger();
 
     into_raw_ptr(SecurityFunctionTableW {
-        dwVersion: KERBEROS_VERSION as u32,
+        dwVersion: u32::from(KERBEROS_VERSION),
         EnumerateSecurityPackagesW,
         QueryCredentialsAttributesW,
         AcquireCredentialsHandleW,

--- a/ffi/src/sspi/win_scard_cert.rs
+++ b/ffi/src/sspi/win_scard_cert.rs
@@ -43,7 +43,12 @@ unsafe fn find_raw_cert_by_thumbprint(thumbprint: &[u8], cert_store: HCERTSTORE)
     while let Some(curr_certificate) = certificate {
         let cert_der = {
             // SAFETY: `certificate` is a valid certificate handle obtained from the Windows certificate store.
-            unsafe { from_raw_parts(curr_certificate.pbCertEncoded, curr_certificate.cbCertEncoded as usize) }
+            unsafe {
+                from_raw_parts(
+                    curr_certificate.pbCertEncoded,
+                    curr_certificate.cbCertEncoded.try_into()?,
+                )
+            }
         };
         let mut sha1 = Sha1::new();
         sha1.update(cert_der);
@@ -181,7 +186,7 @@ unsafe fn get_reader_name(crypt_context_handle: HCRYPTPROV) -> Result<String> {
         ));
     }
 
-    let mut reader_buf = vec![0; reader_buf_len as usize];
+    let mut reader_buf = vec![0; reader_buf_len.try_into()?];
     // SAFETY:
     // - `crypt_context_handle` is valid context handle (upheld by the caller).
     // - `reader_buff_len` is a local variable.
@@ -240,7 +245,7 @@ unsafe fn get_key_container_certificate(crypt_context_handle: HCRYPTPROV) -> Res
         ));
     }
 
-    let mut cert_data = vec![0; cert_data_len as usize];
+    let mut cert_data = vec![0; cert_data_len.try_into()?];
     if let Err(err) =
         // SAFETY:
         // - `key` is a valid key handle obtained via successful `CryptGetUserKey` call above.
@@ -329,7 +334,7 @@ pub fn finalize_smart_card_info(cert_serial_number: &[u8]) -> Result<SmartCardIn
             break;
         }
 
-        let mut key_container_name = vec![0; key_container_name_len as usize];
+        let mut key_container_name = vec![0; key_container_name_len.try_into()?];
 
         // SAFETY:
         // - `crypt_context_handle` is obtained from the successful `CryptAcquireContextW` function call.

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) unsafe fn credentials_str_into_bytes(raw_buffer: *const c_char, len: 
         // - `raw_buffer` is guaranteed to be non-null due to the prior check.
         // - `raw_buffer` is valid for reads for `len` many bytes.
         // - `len` does not exceed `isize::MAX`.
-        unsafe { from_raw_parts(raw_buffer as *const u8, len) }.to_vec()
+        unsafe { from_raw_parts(raw_buffer.cast::<u8>(), len) }.to_vec()
     } else {
         Vec::new()
     }

--- a/ffi/src/winscard/buf_alloc.rs
+++ b/ffi/src/winscard/buf_alloc.rs
@@ -86,7 +86,7 @@ pub(super) unsafe fn build_buf_request_type_wide<'data>(
         // SAFETY:
         // - `p_buf` is guaranteed to be non-null due to the prior check.
         // - `p_buf` is valid for both reads and writes for `pcb_buf` many bytes, and it is properly aligned.
-        RequestedBufferType::Buf(unsafe { from_raw_parts_mut(p_buf as *mut u8, len) })
+        RequestedBufferType::Buf(unsafe { from_raw_parts_mut(p_buf.cast::<u8>(), len) })
     })
 }
 
@@ -166,7 +166,8 @@ pub(super) unsafe fn save_out_buf_wide(out_buf: OutBuffer<'_>, p_buf: LpWStr, pc
             //
             // SAFETY: The `p_buf` is guaranteed to be non-null due to the prior check.
             unsafe {
-                *(p_buf as *mut *mut u8) = data.as_mut_ptr();
+                let p_buf_typed = p_buf.cast::<*mut u8>();
+                *p_buf_typed = data.as_mut_ptr();
             }
             // SAFETY: The `p_buf` is guaranteed to be non-null due to the prior check.
             unsafe {

--- a/ffi/src/winscard/piv.rs
+++ b/ffi/src/winscard/piv.rs
@@ -53,7 +53,10 @@ pub enum SlotId {
 impl SlotId {
     /// Returns [u8] representation of the slot.
     pub fn as_u8(&self) -> u8 {
-        *self as u8
+        #[expect(clippy::as_conversions, reason = "primitive enum cast")]
+        {
+            *self as u8
+        }
     }
 
     /// Determines the slot id based on the slot certificate label.

--- a/ffi/src/winscard/scard.rs
+++ b/ffi/src/winscard/scard.rs
@@ -52,7 +52,7 @@ unsafe fn connect(
 
     let scard = WinScardHandle::new(handle, context);
 
-    let raw_card_handle = into_raw_ptr(scard) as ScardHandle;
+    let raw_card_handle: ScardHandle = into_raw_ptr(scard).expose_provenance();
 
     // SAFETY: `context` is a valid context handle.
     let context = unsafe { raw_scard_context_handle_to_scard_context_handle(context) }?;
@@ -519,13 +519,9 @@ pub unsafe extern "system" fn SCardTransmit(
         unsafe { scard_handle_to_winscard(handle) }
     );
 
+    let len = try_execute!(cb_send_length.try_into(), ErrorKind::InsufficientBuffer);
     // SAFETY: The `pb_send_buffer` parameter cannot be null (checked above).
-    let input_apdu = unsafe {
-        from_raw_parts(
-            pb_send_buffer,
-            try_execute!(cb_send_length.try_into(), ErrorKind::InsufficientBuffer),
-        )
-    };
+    let input_apdu = unsafe { from_raw_parts(pb_send_buffer, len) };
 
     let out_data = try_execute!(scard.transmit(input_apdu));
 
@@ -557,9 +553,10 @@ pub unsafe extern "system" fn SCardTransmit(
         );
     }
 
+    let len = try_execute!(out_apdu_len.try_into(), ErrorKind::InsufficientBuffer);
     // SAFETY: `pcb_recv_length` is guaranteed to be non-null due to the prior check.
     unsafe {
-        *pcb_recv_length = try_execute!(out_apdu_len.try_into(), ErrorKind::InsufficientBuffer);
+        *pcb_recv_length = len;
     }
 
     ErrorKind::Success.into()
@@ -602,29 +599,23 @@ pub unsafe extern "system" fn SCardControl(
     );
 
     let in_buffer = if !lp_in_buffer.is_null() {
+        let ptr = lp_in_buffer.cast::<u8>();
+        let len = try_execute!(cb_in_buffer_size.try_into(), ErrorKind::InsufficientBuffer);
         // SAFETY:
         // - `lp_in_buffer` is guaranteed to be non-null due to the prior check.
         // - `lp_in_buffer` is valid for reads for `cb_in_buffer_size` many bytes.
-        unsafe {
-            from_raw_parts(
-                lp_in_buffer as *const u8,
-                try_execute!(cb_in_buffer_size.try_into(), ErrorKind::InsufficientBuffer),
-            )
-        }
+        unsafe { from_raw_parts(ptr, len) }
     } else {
         &[]
     };
 
     if !lp_out_buffer.is_null() {
+        let out_ptr = lp_out_buffer.cast::<u8>();
+        let len = try_execute!(cb_out_buffer_size.try_into(), ErrorKind::InvalidParameter);
         // SAFETY:
         // - `lp_out_buffer` is guaranteed to be non-null due to the prior check.
         // - `lp_out_buffer` is valid for reads for `cb_out_buffer_size` many bytes.
-        let lp_out_buffer = unsafe {
-            from_raw_parts_mut(
-                lp_out_buffer as *mut u8,
-                try_execute!(cb_out_buffer_size.try_into(), ErrorKind::InvalidParameter),
-            )
-        };
+        let lp_out_buffer = unsafe { from_raw_parts_mut(out_ptr, len) };
 
         let out_bytes_count = try_execute!(scard.control_with_output(dw_control_code, in_buffer, lp_out_buffer));
         if !lp_bytes_returned.is_null() {
@@ -711,10 +702,11 @@ pub unsafe extern "system" fn SCardSetAttrib(
     check_handle!(handle);
     check_null!(pb_attr);
 
+    let len = try_execute!(cb_attr_len.try_into(), ErrorKind::InvalidParameter);
     // SAFETY:
     // - `pb_attr` is guaranteed to be non-null due to the prior check.
     // - `pb_attr` is valid for reads for `cb_attr_len` many bytes.
-    let attr_data = unsafe { from_raw_parts(pb_attr, cb_attr_len.try_into().unwrap()) };
+    let attr_data = unsafe { from_raw_parts(pb_attr, len) };
     let attr_id = try_execute!(AttributeId::from_u32(dw_attr_id).ok_or_else(|| Error::new(
         ErrorKind::InvalidParameter,
         format!("Invalid attribute id: {dw_attr_id}")

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -110,6 +110,7 @@ pub unsafe extern "system" fn SCardEstablishContext(
     let scard_context = WinScardContextHandle::with_scard_context(scard_context);
 
     let raw_ptr = into_raw_ptr(scard_context).expose_provenance();
+    #[allow(clippy::useless_conversion)]
     let raw_ptr = try_execute!(raw_ptr.try_into(), ErrorKind::InvalidHandle);
     info!(new_established_context = ?raw_ptr);
     // SAFETY: The `context` is guaranteed to be non-null due to the prior check.

--- a/ffi/src/winscard/scard_context.rs
+++ b/ffi/src/winscard/scard_context.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::ffi::CStr;
+use std::ptr;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::{LazyLock, Mutex};
 
@@ -108,7 +109,8 @@ pub unsafe extern "system" fn SCardEstablishContext(
 
     let scard_context = WinScardContextHandle::with_scard_context(scard_context);
 
-    let raw_ptr = into_raw_ptr(scard_context) as ScardContext;
+    let raw_ptr = into_raw_ptr(scard_context).expose_provenance();
+    let raw_ptr = try_execute!(raw_ptr.try_into(), ErrorKind::InvalidHandle);
     info!(new_established_context = ?raw_ptr);
     // SAFETY: The `context` is guaranteed to be non-null due to the prior check.
     unsafe {
@@ -134,11 +136,12 @@ pub unsafe extern "system" fn SCardReleaseContext(context: ScardContext) -> Scar
     check_handle!(context);
 
     if is_present(context) {
+        let context_ptr: *mut WinScardContextHandle = ptr::with_exposed_provenance_mut(context);
         // SAFETY:
         // - `context` is guaranteed to be non-null due to the prior check.
         // - `context` is allocated by `SCardEstablishContext` function.
         //   It guarantees that the pointer was allocated using `Box::into_raw`.
-        let _ = unsafe { Box::from_raw(context as *mut WinScardContextHandle) };
+        let _ = unsafe { Box::from_raw(context_ptr) };
         release_context(context);
 
         info!("Scard context has been successfully released");
@@ -844,7 +847,10 @@ static START_EVENT_HANDLE: LazyLock<Handle> = LazyLock::new(|| {
         })
         .unwrap_or_default();
 
-    handle.0.expose_provenance() as isize
+    #[expect(clippy::as_conversions, reason = "raw pointer to integer handle cast")]
+    {
+        handle.0.expose_provenance() as isize
+    }
 });
 
 /// The `SCardAccessStartedEvent` function returns an event handle when an event signals that the smart
@@ -1018,15 +1024,11 @@ pub unsafe extern "system" fn SCardGetStatusChangeA(
         unsafe { scard_context_to_winscard_context(context) }
     );
 
+    let len = try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer);
     // SAFETY:
     // - `rg_reader_state` is guaranteed to be non-null due to the prior check.
     // - `rh_reader_state` is valid for both reads and writes for `c_readers` many bytes.
-    let c_reader_states = unsafe {
-        from_raw_parts_mut(
-            rg_reader_states,
-            try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer),
-        )
-    };
+    let c_reader_states = unsafe { from_raw_parts_mut(rg_reader_states, len) };
     let mut reader_states = try_execute!(
         c_reader_states
             .iter()
@@ -1039,7 +1041,7 @@ pub unsafe extern "system" fn SCardGetStatusChangeA(
                     // - The memory region `c_reader.sz_reader` contains a valid null-terminator at the end of string.
                     // - The memory region `c_reader.sz_reader` points to is valid for reads of bytes up to and including null-terminator.
                     reader_name: unsafe { CStr::from_ptr(c_reader.sz_reader.cast()) }.to_string_lossy(),
-                    user_data: c_reader.pv_user_data as usize,
+                    user_data: c_reader.pv_user_data.expose_provenance(),
                     current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
                     event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
                     atr_len: c_reader.cb_atr.try_into()?,
@@ -1090,15 +1092,11 @@ pub unsafe extern "system" fn SCardGetStatusChangeW(
         unsafe { scard_context_to_winscard_context(context) }
     );
 
+    let len = try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer);
     // SAFETY:
     // - `rg_reader_state` is guaranteed to be non-null due to the prior check.
     // - `rh_reader_state` is valid for both reads and writes for `c_readers` many bytes.
-    let c_reader_states = unsafe {
-        from_raw_parts_mut(
-            rg_reader_states,
-            try_execute!(c_readers.try_into(), ErrorKind::InsufficientBuffer),
-        )
-    };
+    let c_reader_states = unsafe { from_raw_parts_mut(rg_reader_states, len) };
     let mut reader_states = try_execute!(
         c_reader_states
             .iter()
@@ -1116,7 +1114,7 @@ pub unsafe extern "system" fn SCardGetStatusChangeW(
                             .to_string()
                             .map_err(Error::from)?,
                     ),
-                    user_data: c_reader.pv_user_data as usize,
+                    user_data: c_reader.pv_user_data.expose_provenance(),
                     current_state: CurrentState::from_bits(c_reader.dw_current_state).unwrap_or_default(),
                     event_state: CurrentState::from_bits(c_reader.dw_event_state).unwrap_or_default(),
                     atr_len: c_reader.cb_atr.try_into()?,

--- a/ffi/src/winscard/scard_handle.rs
+++ b/ffi/src/winscard/scard_handle.rs
@@ -75,11 +75,12 @@ impl WinScardContextHandle {
     #[instrument(level = "debug", ret)]
     pub(super) fn allocate_buffer(&mut self, size: usize) -> WinScardResult<*mut u8> {
         // SAFETY: Memory allocation is safe. Moreover, we check for the null value below.
-        let buff = unsafe { libc::malloc(size) as *mut u8 };
+        let buff = unsafe { libc::malloc(size).cast::<u8>() };
         if buff.is_null() {
             return Err(Error::new(ErrorKind::NoMemory, format!("cannot allocate {size} bytes")));
         }
-        self.allocations.push(buff as usize);
+        let addr = buff.expose_provenance();
+        self.allocations.push(addr);
 
         Ok(buff)
     }
@@ -92,9 +93,10 @@ impl WinScardContextHandle {
         if let Some(index) = self.allocations.iter().position(|x| *x == buff) {
             self.allocations.remove(index);
 
+            let buff = ptr::with_exposed_provenance_mut(buff);
             // SAFETY: The `allocations` collection contains only allocated memory pointers, so it's
             // safe to deallocate them using the `libc::free` function.
-            unsafe { libc::free(ptr::with_exposed_provenance_mut(buff)) }
+            unsafe { libc::free(buff) }
 
             true
         } else {
@@ -268,15 +270,17 @@ impl Drop for WinScardContextHandle {
         // [SCardReleaseContext](https://learn.microsoft.com/en-us/windows/win32/api/winscard/nf-winscard-scardreleasecontext)
         // ...freeing any resources allocated under that context, including SCARDHANDLE objects
         for scard in &self.scards {
+            let raw = ptr::with_exposed_provenance_mut::<WinScardHandle>(*scard);
             // SAFETY: The `WinScardContextHandle` contains only valid scard handles,
             // so it's safe to cast them to `WinScardHandle` pointer.
-            let _ = unsafe { Box::from_raw(*scard as *mut WinScardHandle) };
+            let _ = unsafe { Box::from_raw(raw) };
         }
         // ...and memory allocated using the SCARD_AUTOALLOCATE length designator.
         for buff in &self.allocations {
+            let buff = ptr::with_exposed_provenance_mut(*buff);
             // SAFETY: `WinScardContextHandle` contains only allocated memory pointers.
             unsafe {
-                libc::free(ptr::with_exposed_provenance_mut(*buff));
+                libc::free(buff);
             }
         }
     }
@@ -435,10 +439,11 @@ pub(super) unsafe fn scard_handle_to_winscard<'a>(handle: ScardHandle) -> WinSca
         return Err(Error::new(ErrorKind::InvalidHandle, "scard handle cannot be zero"));
     }
 
+    let handle_ptr: *mut WinScardHandle = ptr::with_exposed_provenance_mut(handle);
     // SAFETY:
     // - `handle` is guaranteed to be non-null due to the prior check.
     // - `handle` is a valid raw scard handle.
-    if let Some(scard) = unsafe { (handle as *mut WinScardHandle).as_mut() } {
+    if let Some(scard) = unsafe { handle_ptr.as_mut() } {
         Ok(scard.scard.as_mut())
     } else {
         Err(Error::new(
@@ -463,10 +468,11 @@ pub(super) unsafe fn raw_scard_handle_to_scard_handle<'a>(
         ));
     }
 
+    let h_card_ptr: *mut WinScardHandle = ptr::with_exposed_provenance_mut(h_card);
     // SAFETY:
     // - `h_card` is guaranteed to be non-null due to the prior check.
     // - `h_card` is a valid raw scard handle.
-    unsafe { (h_card as *mut WinScardHandle).as_mut() }
+    unsafe { h_card_ptr.as_mut() }
         .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
 }
 
@@ -485,10 +491,11 @@ pub(super) unsafe fn raw_scard_context_handle_to_scard_context_handle<'a>(
         ));
     }
 
+    let h_context_ptr: *mut WinScardContextHandle = ptr::with_exposed_provenance_mut(h_context);
     // SAFETY:
     // - `h_context` is guaranteed to be non-null due to the prior check.
     // - `h_context` is a valid raw scard context handle.
-    unsafe { (h_context as *mut WinScardContextHandle).as_mut() }
+    unsafe { h_context_ptr.as_mut() }
         .ok_or_else(|| Error::new(ErrorKind::InvalidHandle, "raw scard context handle is invalid"))
 }
 
@@ -507,10 +514,11 @@ pub(super) unsafe fn scard_context_to_winscard_context<'a>(
         ));
     }
 
+    let handle_ptr: *mut WinScardContextHandle = ptr::with_exposed_provenance_mut(handle);
     // SAFETY:
     // - `handle` is guaranteed to be non-null due to the prior check.
     // - `handle` is a valid raw scard context handle.
-    if let Some(context) = unsafe { (handle as *mut WinScardContextHandle).as_mut() } {
+    if let Some(context) = unsafe { handle_ptr.as_mut() } {
         Ok(context.scard_context.as_mut())
     } else {
         Err(Error::new(
@@ -561,7 +569,9 @@ pub(super) unsafe fn copy_io_request_to_scard_io_request(
     }
 
     // SAFETY: According to the documentation, the `pci_buffer` data is placed right after the `ScardIoRequest` structure.
-    let pci_buffer_ptr = unsafe { (scard_io_request as *mut u8).add(size_of::<ScardIoRequest>()) };
+    // SAFETY: `scard_io_request` is a valid non-null pointer to a `ScardIoRequest` and per the
+    // documentation the pci data immediately follows the struct in memory.
+    let pci_buffer_ptr = unsafe { (scard_io_request.cast::<u8>()).add(size_of::<ScardIoRequest>()) };
     // SAFETY: According to the documentation, it's safe to create a slice of the pci data.
     let pci_buffer = unsafe { from_raw_parts_mut(pci_buffer_ptr, pci_info_len) };
     pci_buffer.copy_from_slice(&io_request.pci_info);

--- a/ffi/src/winscard/system_scard/context.rs
+++ b/ffi/src/winscard/system_scard/context.rs
@@ -484,12 +484,22 @@ fn init_scard_cache(scard_logon_params: &ScardLogonParams) -> WinScardResult<BTr
     /// from a Microsoft legacy Cryptographic Storage Provider (CSP) can be used.
     ///
     /// We need the [KeySpec] value to build scard cache items correctly.
+    #[derive(Clone, Copy)]
     #[repr(u8)]
     enum KeySpec {
         /// RSA key that can be used for signing and decryption.
         AtKeyExchange = 1,
         /// RSA signature only key.
         AtSignature = 2,
+    }
+
+    impl KeySpec {
+        fn as_u8(&self) -> u8 {
+            #[expect(clippy::as_conversions, reason = "enum discriminant is a valid u8 value")]
+            {
+                *self as u8
+            }
+        }
     }
 
     cache.insert("ykmd_cardcf".to_owned(), CACHE_ITEM_HEADER.to_vec());
@@ -546,7 +556,7 @@ fn init_scard_cache(scard_logon_params: &ScardLogonParams) -> WinScardResult<BTr
             SlotId::KeyManagement => KeySpec::AtKeyExchange,
             SlotId::CardAuthentication => KeySpec::AtKeyExchange,
         };
-        value.push(key_spec as u8);
+        value.push(key_spec.as_u8());
 
         value.extend_from_slice(&[0x00, 0x08]); // KeySize.
         value.push(0x03); // Flags.
@@ -1211,7 +1221,7 @@ impl WinScardContext for SystemScardContext {
                         self.h_context,
                         c_card_name.as_ptr().cast(),
                         provider_id.into(),
-                        ((&mut data) as *mut *mut u8).cast(),
+                        std::ptr::addr_of_mut!(data).cast(),
                         &mut data_len,
                     )
                 },

--- a/src/ber/mod.rs
+++ b/src/ber/mod.rs
@@ -7,13 +7,24 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 #[repr(u8)]
 #[allow(unused)]
+#[derive(Clone, Copy)]
 pub(crate) enum Pc {
     Primitive = 0x00,
     Construct = 0x20,
 }
 
+impl Pc {
+    fn as_u8(&self) -> u8 {
+        #[expect(clippy::as_conversions, reason = "enum repr cast in as_u8 helper")]
+        {
+            *self as u8
+        }
+    }
+}
+
 #[repr(u8)]
 #[allow(unused)]
+#[derive(Clone, Copy)]
 enum Class {
     Universal = 0x00,
     Application = 0x40,
@@ -21,8 +32,18 @@ enum Class {
     Private = 0xC0,
 }
 
+impl Class {
+    fn as_u8(&self) -> u8 {
+        #[expect(clippy::as_conversions, reason = "enum repr cast in as_u8 helper")]
+        {
+            *self as u8
+        }
+    }
+}
+
 #[repr(u8)]
 #[allow(unused)]
+#[derive(Clone, Copy)]
 enum Tag {
     Mask = 0x1F,
     Boolean = 0x01,
@@ -32,6 +53,15 @@ enum Tag {
     ObjectIdentifier = 0x06,
     Enumerated = 0x0A,
     Sequence = 0x10,
+}
+
+impl Tag {
+    fn as_u8(&self) -> u8 {
+        #[expect(clippy::as_conversions, reason = "enum repr cast in as_u8 helper")]
+        {
+            *self as u8
+        }
+    }
 }
 
 const TAG_MASK: u8 = 0x1F;
@@ -76,7 +106,8 @@ pub(crate) fn write_sequence_tag(mut stream: impl io::Write, length: u16) -> io:
 pub(crate) fn read_sequence_tag(mut stream: impl io::Read) -> io::Result<u16> {
     let identifier = stream.read_u8()?;
 
-    if identifier != Class::Universal as u8 | Pc::Construct as u8 | (TAG_MASK & Tag::Sequence as u8) {
+    let expected = Class::Universal.as_u8() | Pc::Construct.as_u8() | (TAG_MASK & Tag::Sequence.as_u8());
+    if identifier != expected {
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid sequence tag identifier",
@@ -87,7 +118,7 @@ pub(crate) fn read_sequence_tag(mut stream: impl io::Read) -> io::Result<u16> {
 }
 
 pub(crate) fn write_contextual_tag(mut stream: impl io::Write, tagnum: u8, length: u16, pc: Pc) -> io::Result<usize> {
-    let identifier = Class::ContextSpecific as u8 | pc as u8 | (TAG_MASK & tagnum);
+    let identifier = Class::ContextSpecific.as_u8() | pc.as_u8() | (TAG_MASK & tagnum);
     stream.write_u8(identifier)?;
 
     write_length(stream, length).map(|length| length + 1)
@@ -96,7 +127,8 @@ pub(crate) fn write_contextual_tag(mut stream: impl io::Write, tagnum: u8, lengt
 pub(crate) fn read_contextual_tag(mut stream: impl io::Read, tagnum: u8, pc: Pc) -> io::Result<u16> {
     let identifier = stream.read_u8()?;
 
-    if identifier != Class::ContextSpecific as u8 | pc as u8 | (TAG_MASK & tagnum) {
+    let expected_tag = Class::ContextSpecific.as_u8() | pc.as_u8() | (TAG_MASK & tagnum);
+    if identifier != expected_tag {
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid contextual tag identifier",
@@ -126,18 +158,18 @@ pub(crate) fn write_integer(mut stream: impl io::Write, value: u32) -> io::Resul
 
     if value < 0x80 {
         write_length(&mut stream, 1)?;
-        stream.write_u8(value as u8)?;
+        stream.write_u8(value.try_into().expect("value < 0x80 should fit into u8"))?;
 
         Ok(3)
     } else if value < 0x8000 {
         write_length(&mut stream, 2)?;
-        stream.write_u16::<BigEndian>(value as u16)?;
+        stream.write_u16::<BigEndian>(value.try_into().expect("value < 0x8000 should fit into u16"))?;
 
         Ok(4)
     } else if value < 0x0080_0000 {
         write_length(&mut stream, 3)?;
-        stream.write_u8((value >> 16) as u8)?;
-        stream.write_u16::<BigEndian>((value & 0xFFFF) as u16)?;
+        stream.write_u8((value >> 16).try_into().expect("high byte should fit into u8"))?;
+        stream.write_u16::<BigEndian>((value & 0xFFFF).try_into().expect("low bytes should fit into u16"))?;
 
         Ok(5)
     } else {
@@ -174,7 +206,7 @@ pub(crate) fn write_sequence_octet_string(mut stream: impl io::Write, tagnum: u8
     let tag_len = write_contextual_tag(
         &mut stream,
         tagnum,
-        sizeof_octet_string(value.len() as u16),
+        sizeof_octet_string(u16::try_from(value.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?),
         Pc::Construct,
     )?;
     let string_len = write_octet_string(&mut stream, value)?;
@@ -183,7 +215,10 @@ pub(crate) fn write_sequence_octet_string(mut stream: impl io::Write, tagnum: u8
 }
 
 pub(crate) fn write_octet_string(mut stream: impl io::Write, value: &[u8]) -> io::Result<usize> {
-    let tag_size = write_octet_string_tag(&mut stream, value.len() as u16)?;
+    let tag_size = write_octet_string_tag(
+        &mut stream,
+        u16::try_from(value.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
+    )?;
     stream.write_all(value)?;
     Ok(tag_size + value.len())
 }
@@ -199,7 +234,7 @@ pub(crate) fn read_octet_string_tag(mut stream: impl io::Read) -> io::Result<u16
 }
 
 fn write_universal_tag(mut stream: impl io::Write, tag: Tag, pc: Pc) -> io::Result<usize> {
-    let identifier = Class::Universal as u8 | pc as u8 | (TAG_MASK & tag as u8);
+    let identifier = Class::Universal.as_u8() | pc.as_u8() | (TAG_MASK & tag.as_u8());
     stream.write_u8(identifier)?;
 
     Ok(1)
@@ -208,7 +243,8 @@ fn write_universal_tag(mut stream: impl io::Write, tag: Tag, pc: Pc) -> io::Resu
 fn read_universal_tag(mut stream: impl io::Read, tag: Tag, pc: Pc) -> io::Result<()> {
     let identifier = stream.read_u8()?;
 
-    if identifier != Class::Universal as u8 | pc as u8 | (TAG_MASK & tag as u8) {
+    let expected_id = Class::Universal.as_u8() | pc.as_u8() | (TAG_MASK & tag.as_u8());
+    if identifier != expected_id {
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "invalid universal tag identifier",
@@ -226,11 +262,11 @@ fn write_length(mut stream: impl io::Write, length: u16) -> io::Result<usize> {
         Ok(3)
     } else if length > 0x7F {
         stream.write_u8(0x80 ^ 0x1)?;
-        stream.write_u8(length as u8)?;
+        stream.write_u8(length.try_into().expect("length <= 0xFF should fit into u8"))?;
 
         Ok(2)
     } else {
-        stream.write_u8(length as u8)?;
+        stream.write_u8(length.try_into().expect("length <= 0x7F should fit into u8"))?;
 
         Ok(1)
     }

--- a/src/channel_bindings.rs
+++ b/src/channel_bindings.rs
@@ -30,8 +30,10 @@ impl ChannelBindings {
 
         let initiator_addr_type = u32::from_le_bytes(data[0..4].try_into().unwrap());
 
-        let initiator_len = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
-        let initiator_offset = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        let initiator_len: usize = u32::from_le_bytes(data[4..8].try_into().unwrap()).try_into()?;
+
+        let initiator_offset: usize = u32::from_le_bytes(data[8..12].try_into().unwrap()).try_into()?;
+
         if initiator_offset + initiator_len > data.len() {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
@@ -49,10 +51,26 @@ impl ChannelBindings {
             Vec::new()
         };
 
-        let acceptor_addr_type = u32::from_le_bytes(data[12..16].try_into().unwrap());
+        let acceptor_addr_type = u32::from_le_bytes(
+            data[12..16]
+                .try_into()
+                .expect("data[12..16] is castable to [u8; 4] because of prior check"),
+        );
 
-        let acceptor_len = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
-        let acceptor_offset = u32::from_le_bytes(data[20..24].try_into().unwrap()) as usize;
+        let acceptor_len: usize = u32::from_le_bytes(
+            data[16..20]
+                .try_into()
+                .expect("data[16..20] is castable to [u8; 4] because of prior check"),
+        )
+        .try_into()?;
+
+        let acceptor_offset: usize = u32::from_le_bytes(
+            data[20..24]
+                .try_into()
+                .expect("data[20..24] is castable to [u8; 4] because of prior check"),
+        )
+        .try_into()?;
+
         if acceptor_offset + acceptor_len > data.len() {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
@@ -70,8 +88,20 @@ impl ChannelBindings {
             Vec::new()
         };
 
-        let application_len = u32::from_le_bytes(data[24..28].try_into().unwrap()) as usize;
-        let application_offset = u32::from_le_bytes(data[28..32].try_into().unwrap()) as usize;
+        let application_len: usize = u32::from_le_bytes(
+            data[24..28]
+                .try_into()
+                .expect("data[24..28] is castable to [u8; 4] because of prior check"),
+        )
+        .try_into()?;
+
+        let application_offset: usize = u32::from_le_bytes(
+            data[28..32]
+                .try_into()
+                .expect("data[28..32] is castable to [u8; 4] because of prior check"),
+        )
+        .try_into()?;
+
         if application_offset + application_len > data.len() {
             return Err(Error::new(
                 ErrorKind::InvalidParameter,
@@ -115,11 +145,11 @@ mod tests {
 
         let channel_bindings_token = [1, 2, 3, 4];
         let application_offset = 32_u32;
-        let application_len = channel_bindings_token.len();
+        let application_len = u32::try_from(channel_bindings_token.len()).unwrap();
 
         let mut buffer = [0; 36];
 
-        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[24..28].copy_from_slice(&application_len.to_le_bytes());
         buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
         buffer[32..].copy_from_slice(&channel_bindings_token);
 
@@ -140,11 +170,11 @@ mod tests {
         let channel_bindings_token = [1, 2, 3, 4];
         let application_offset = 32_u32;
         // invalid len
-        let application_len = channel_bindings_token.len() + 2;
+        let application_len = u32::try_from(channel_bindings_token.len() + 2).unwrap();
 
         let mut buffer = [0; 36];
 
-        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[24..28].copy_from_slice(&application_len.to_le_bytes());
         buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
         buffer[32..].copy_from_slice(&channel_bindings_token);
 
@@ -158,11 +188,11 @@ mod tests {
         let channel_bindings_token = [1, 2, 3, 4];
         // invalid offset
         let application_offset = 32_u32 + 3;
-        let application_len = channel_bindings_token.len();
+        let application_len = u32::try_from(channel_bindings_token.len()).unwrap();
 
         let mut buffer = [0; 36];
 
-        buffer[24..28].copy_from_slice(&(application_len as u32).to_le_bytes());
+        buffer[24..28].copy_from_slice(&application_len.to_le_bytes());
         buffer[28..32].copy_from_slice(&application_offset.to_le_bytes());
         buffer[32..].copy_from_slice(&channel_bindings_token);
 

--- a/src/credssp/mod.rs
+++ b/src/credssp/mod.rs
@@ -1422,6 +1422,10 @@ fn integer_increment_le(buffer: &mut [u8]) {
 }
 
 fn construct_error(e: &Error) -> NStatusCode {
+    #[expect(
+        clippy::as_conversions,
+        reason = "enum repr cast for error_type to i64, then truncating cast to u32 for NTSTATUS code construction"
+    )]
     let code = ((e.error_type as i64 & 0x0000_FFFF) | (0x7 << 16) | 0xC000_0000) as u32;
     NStatusCode(code)
 }

--- a/src/credssp/sspi_cred_ssp/tls_connection.rs
+++ b/src/credssp/sspi_cred_ssp/tls_connection.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 // type + version + length
-pub(super) const TLS_PACKET_HEADER_LEN: usize = 1 /* ContentType */ + 2 /* ProtocolVersion */ + 2 /* length: uint16 */;
+pub(super) const TLS_PACKET_HEADER_LEN: u8 = 1 /* ContentType */ + 2 /* ProtocolVersion */ + 2 /* length: uint16 */;
 
 // The Secure Sockets Layer (SSL) Protocol Version 3.0
 // https://datatracker.ietf.org/doc/html/rfc6101#page-14
@@ -174,9 +174,10 @@ impl TlsConnection {
         connection: &Connection,
         payload: &'data mut [u8],
     ) -> Result<FindTlsPacketResult<'data>> {
-        if payload.len() < TLS_PACKET_HEADER_LEN {
+        let header_len = usize::from(TLS_PACKET_HEADER_LEN);
+        if payload.len() < header_len {
             // We need at least TLS_PACKET_HEADER_LEN bytes to recognize the TLS packet, its type, and length.
-            return Ok(FindTlsPacketResult::Missing(TLS_PACKET_HEADER_LEN));
+            return Ok(FindTlsPacketResult::Missing(header_len));
         }
 
         // In the decryption stage, we accept only TLS packets with TLS_APPLICATION_CONTENT_TYPE specified.
@@ -213,10 +214,10 @@ impl TlsConnection {
         // Safe: payload length is checked above.
         let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
 
-        let tls_packet_len = TLS_PACKET_HEADER_LEN + encrypted_application_data_len;
+        let tls_packet_len = header_len + encrypted_application_data_len;
         if payload.len() < tls_packet_len {
             return Ok(FindTlsPacketResult::Missing(
-                TLS_PACKET_HEADER_LEN + encrypted_application_data_len - payload.len(),
+                header_len + encrypted_application_data_len - payload.len(),
             ));
         }
 
@@ -230,9 +231,9 @@ impl TlsConnection {
     // * extra.
     // See the [TlsTrafficParts] documentation for a more detailed explanation of those buffers.
     fn split_tls_traffic<'a>(connection: &Connection, payload: &'a mut [u8]) -> Result<TlsTrafficParts<'a>> {
-        const TLS_PACKET_PREFIX_LEN: usize = TLS_PACKET_HEADER_LEN + TLS_PACKET_SEQUENCE_NUMBER_LEN;
+        let tls_packet_prefix_len = usize::from(TLS_PACKET_HEADER_LEN) + TLS_PACKET_SEQUENCE_NUMBER_LEN;
 
-        if payload.len() < TLS_PACKET_PREFIX_LEN {
+        if payload.len() < tls_packet_prefix_len {
             return Err(Error::new(ErrorKind::InvalidToken, "Input TLS buffer is too short."));
         }
 
@@ -270,12 +271,12 @@ impl TlsConnection {
         // Safe: payload length is checked above.
         let encrypted_application_data_len = usize::from(u16::from_be_bytes(payload[3..5].try_into().unwrap()));
 
-        if payload.len() < TLS_PACKET_HEADER_LEN + encrypted_application_data_len {
+        if payload.len() < usize::from(TLS_PACKET_HEADER_LEN) + encrypted_application_data_len {
             return Err(Error::new(ErrorKind::InvalidToken, "Input TLS buffer is too short."));
         }
 
         // Safe: payload length is checked above.
-        let (header, rest) = payload.split_at_mut(TLS_PACKET_PREFIX_LEN);
+        let (header, rest) = payload.split_at_mut(tls_packet_prefix_len);
         // `encrypted_application_data_len` is a len of the encrypted data with the sequence number.
         // But here we need the encrypted data *WITHOUT* a sequence number, so we subtract TLS_PACKET_SEQUENCE_NUMBER_LEN
         // from the overall data length.
@@ -295,12 +296,13 @@ impl TlsConnection {
     pub(super) fn decrypt_tls<'a>(&mut self, payload: &'a mut [u8]) -> Result<DecryptionResult<'a>> {
         match self {
             TlsConnection::Rustls(tls_connection) => {
-                let mut tls_packet = match TlsConnection::find_tls_data_to_decrypt(tls_connection, payload)? {
-                    FindTlsPacketResult::TlsPacket(data) => data as &[u8],
+                let mut tls_packet: &[u8] = match TlsConnection::find_tls_data_to_decrypt(tls_connection, payload)? {
+                    FindTlsPacketResult::TlsPacket(data) => data,
                     FindTlsPacketResult::Missing(needed_bytes_amount) => {
                         return Ok(DecryptionResult::IncompleteMessage(needed_bytes_amount));
                     }
                 };
+
                 let mut plain_data = Vec::with_capacity(tls_packet.len());
 
                 while !tls_packet.is_empty() {
@@ -383,7 +385,7 @@ impl TlsConnection {
                 };
 
                 Ok(StreamSizes {
-                    header: TLS_PACKET_HEADER_LEN as u32,
+                    header: u32::from(TLS_PACKET_HEADER_LEN),
                     // trailer = tls mac + padding
                     // this value is taken from the win schannel
                     trailer: 0x2c,

--- a/src/credssp/ts_request/mod.rs
+++ b/src/credssp/ts_request/mod.rs
@@ -11,7 +11,7 @@ use widestring::Utf16String;
 
 use super::CredSspMode;
 use crate::utf16string::ZeroizedUtf16String;
-use crate::{AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind, Utf16StringExt, ber};
+use crate::{AuthIdentityBuffers, CredentialsBuffers, Error, ErrorKind, Result, Utf16StringExt, ber};
 
 pub(super) const TS_REQUEST_VERSION: u32 = 6;
 
@@ -85,14 +85,15 @@ impl TsRequest {
 
         ber::read_contextual_tag(&mut stream, 0, ber::Pc::Construct)?;
 
-        let version = ber::read_integer(&mut stream)? as u32;
+        let version = u32::try_from(ber::read_integer(&mut stream)?)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let nego_tokens = if ber::read_contextual_tag_or_unwind(&mut stream, 1, ber::Pc::Construct)?.is_some() {
             ber::read_sequence_tag(&mut stream)?;
             ber::read_sequence_tag(&mut stream)?;
             ber::read_contextual_tag(&mut stream, 0, ber::Pc::Construct)?;
             let length = ber::read_octet_string_tag(&mut stream)?;
-            let mut nego_tokens = vec![0x00; length as usize];
+            let mut nego_tokens = vec![0x00; length.into()];
             stream.read_exact(&mut nego_tokens)?;
 
             Some(nego_tokens)
@@ -102,7 +103,7 @@ impl TsRequest {
 
         let auth_info = if ber::read_contextual_tag_or_unwind(&mut stream, 2, ber::Pc::Construct)?.is_some() {
             let length = ber::read_octet_string_tag(&mut stream)?;
-            let mut auth_info = vec![0x00; length as usize];
+            let mut auth_info = vec![0x00; length.into()];
             stream.read_exact(&mut auth_info)?;
 
             Some(auth_info)
@@ -112,7 +113,7 @@ impl TsRequest {
 
         let pub_key_auth = if ber::read_contextual_tag_or_unwind(&mut stream, 3, ber::Pc::Construct)?.is_some() {
             let length = ber::read_octet_string_tag(&mut stream)?;
-            let mut pub_key_auth = vec![0x00; length as usize];
+            let mut pub_key_auth = vec![0x00; length.into()];
             stream.read_exact(&mut pub_key_auth)?;
 
             Some(pub_key_auth)
@@ -123,7 +124,8 @@ impl TsRequest {
         let error_code =
             if version >= 3 && ber::read_contextual_tag_or_unwind(&mut stream, 4, ber::Pc::Construct)?.is_some() {
                 let read_error_code = ber::read_integer(&mut stream)?;
-                let error_code = read_error_code as u32;
+                let error_code =
+                    u32::try_from(read_error_code).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
                 Some(NStatusCode(error_code))
             } else {
@@ -133,7 +135,7 @@ impl TsRequest {
         let client_nonce =
             if version >= 5 && ber::read_contextual_tag_or_unwind(&mut stream, 5, ber::Pc::Construct)?.is_some() {
                 let length = ber::read_octet_string_tag(&mut stream)?;
-                if length != NONCE_SIZE as u16 {
+                if usize::from(length) != NONCE_SIZE {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("Got ClientNonce with invalid length: {length}"),
@@ -164,7 +166,7 @@ impl TsRequest {
     ///
     /// * `buffer` - an output buffer
     pub fn encode_ts_request(&self, mut buffer: impl io::Write) -> io::Result<()> {
-        let len = self.ts_request_len();
+        let len = self.ts_request_len()?;
 
         ber::write_sequence_tag(&mut buffer, len)?;
         /* [0] version */
@@ -173,19 +175,18 @@ impl TsRequest {
 
         /* [1] negoTokens (NegoData) */
         if let Some(ref nego_tokens) = self.nego_tokens {
+            let length = ber::sizeof_sequence_octet_string(
+                u16::try_from(nego_tokens.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
+            );
+
             ber::write_contextual_tag(
                 &mut buffer,
                 1,
-                ber::sizeof_sequence(ber::sizeof_sequence(ber::sizeof_sequence_octet_string(
-                    nego_tokens.len() as u16,
-                ))),
+                ber::sizeof_sequence(ber::sizeof_sequence(length)),
                 ber::Pc::Construct,
             )?;
-            ber::write_sequence_tag(
-                &mut buffer,
-                ber::sizeof_sequence(ber::sizeof_sequence_octet_string(nego_tokens.len() as u16)),
-            )?; /* SEQUENCE OF NegoDataItem */
-            ber::write_sequence_tag(&mut buffer, ber::sizeof_sequence_octet_string(nego_tokens.len() as u16))?; /* NegoDataItem */
+            ber::write_sequence_tag(&mut buffer, ber::sizeof_sequence(length))?; /* SEQUENCE OF NegoDataItem */
+            ber::write_sequence_tag(&mut buffer, length)?; /* NegoDataItem */
             ber::write_sequence_octet_string(&mut buffer, 0, nego_tokens)?; /* OCTET STRING */
         }
 
@@ -219,11 +220,11 @@ impl TsRequest {
         Ok(())
     }
 
-    pub fn buffer_len(&self) -> u16 {
-        ber::sizeof_sequence(self.ts_request_len())
+    pub fn buffer_len(&self) -> Result<u16> {
+        Ok(ber::sizeof_sequence(self.ts_request_len()?))
     }
 
-    pub fn check_error(&self) -> crate::Result<()> {
+    pub fn check_error(&self) -> Result<()> {
         match self.error_code {
             Some(error_code) if error_code != NStatusCode::SUCCESS => Err(Error::new_with_nstatus(
                 ErrorKind::InvalidToken,
@@ -234,27 +235,27 @@ impl TsRequest {
         }
     }
 
-    fn ts_request_len(&self) -> u16 {
+    fn ts_request_len(&self) -> io::Result<u16> {
         let (error_code_len, error_code_context_len) = get_error_code_len(self.version, self.error_code);
         let client_nonce_len = if self.client_nonce.is_some() && self.version >= 5 {
             NONCE_FIELD_LEN
         } else {
             0
         };
-        let fields_len = get_nego_tokens_len(&self.nego_tokens)
-            + get_field_len(&self.pub_key_auth)
-            + get_field_len(&self.auth_info)
+        let fields_len = get_nego_tokens_len(&self.nego_tokens)?
+            + get_field_len(&self.pub_key_auth)?
+            + get_field_len(&self.auth_info)?
             + client_nonce_len
             + error_code_context_len
             + error_code_len;
 
-        fields_len + ber::sizeof_integer(2) + ber::sizeof_contextual_tag(3)
+        Ok(fields_len + ber::sizeof_integer(2) + ber::sizeof_contextual_tag(3))
     }
 }
 
 #[instrument(ret, level = "debug")]
 #[cfg(feature = "scard")]
-fn write_smart_card_credentials(credentials: &crate::SmartCardIdentityBuffers) -> crate::Result<Vec<u8>> {
+fn write_smart_card_credentials(credentials: &crate::SmartCardIdentityBuffers) -> Result<Vec<u8>> {
     use picky_asn1::wrapper::{ExplicitContextTag2, ExplicitContextTag3, ExplicitContextTag4, Optional};
     use picky_krb::constants::cred_ssp::AT_KEYEXCHANGE;
     use picky_krb::credssp::{TsCspDataDetail, TsSmartCardCreds};
@@ -290,7 +291,7 @@ fn write_smart_card_credentials(credentials: &crate::SmartCardIdentityBuffers) -
 }
 
 #[instrument(level = "trace", ret)]
-pub fn write_ts_credentials(credentials: &CredentialsBuffers, cred_ssp_mode: CredSspMode) -> crate::Result<Vec<u8>> {
+pub fn write_ts_credentials(credentials: &CredentialsBuffers, cred_ssp_mode: CredSspMode) -> Result<Vec<u8>> {
     let (creds_type, encoded_credentials) = match credentials {
         CredentialsBuffers::AuthIdentity(creds) => {
             (TS_PASSWORD_CREDS, write_password_credentials(creds, cred_ssp_mode)?)
@@ -324,11 +325,11 @@ fn write_password_credentials(credentials: &AuthIdentityBuffers, cred_ssp_mode: 
         CredSspMode::CredentialLess => &empty_identity,
     };
 
-    let ts_credentials_len = sizeof_ts_credentials(identity);
+    let ts_credentials_len = sizeof_ts_credentials(identity)?;
     let ts_credentials_sequence_len = ber::sizeof_sequence(ts_credentials_len);
-    let password_credentials_len = sizeof_ts_password_creds(identity);
+    let password_credentials_len = sizeof_ts_password_creds(identity)?;
 
-    let mut buffer = Vec::with_capacity(ts_credentials_sequence_len as usize);
+    let mut buffer = Vec::with_capacity(ts_credentials_sequence_len.into());
 
     /* TSPasswordCreds (SEQUENCE) */
     ber::write_sequence_tag(&mut buffer, password_credentials_len)?;
@@ -342,7 +343,7 @@ fn write_password_credentials(credentials: &AuthIdentityBuffers, cred_ssp_mode: 
     Ok(buffer)
 }
 
-fn read_password_credentials(data: impl AsRef<[u8]>) -> crate::Result<AuthIdentityBuffers> {
+fn read_password_credentials(data: impl AsRef<[u8]>) -> Result<AuthIdentityBuffers> {
     let password_creds: TsPasswordCreds = picky_asn1_der::from_bytes(data.as_ref())?;
 
     let TsPasswordCreds {
@@ -358,7 +359,7 @@ fn read_password_credentials(data: impl AsRef<[u8]>) -> crate::Result<AuthIdenti
     })
 }
 
-pub fn read_ts_credentials(mut buffer: impl Read) -> crate::Result<CredentialsBuffers> {
+pub fn read_ts_credentials(mut buffer: impl Read) -> Result<CredentialsBuffers> {
     let ts_credentials: TsCredentials = picky_asn1_der::from_reader(&mut buffer)?;
 
     match ts_credentials.cred_type.0.0.first() {
@@ -380,31 +381,55 @@ pub fn read_ts_credentials(mut buffer: impl Read) -> crate::Result<CredentialsBu
     }
 }
 
-fn sizeof_ts_credentials(identity: &AuthIdentityBuffers) -> u16 {
-    ber::sizeof_integer(1)
+fn sizeof_ts_credentials(identity: &AuthIdentityBuffers) -> io::Result<u16> {
+    Ok(ber::sizeof_integer(1)
         + ber::sizeof_contextual_tag(ber::sizeof_integer(1))
-        + ber::sizeof_sequence_octet_string(ber::sizeof_sequence(sizeof_ts_password_creds(identity)))
+        + ber::sizeof_sequence_octet_string(ber::sizeof_sequence(sizeof_ts_password_creds(identity)?)))
 }
 
-fn sizeof_ts_password_creds(identity: &AuthIdentityBuffers) -> u16 {
-    ber::sizeof_sequence_octet_string(identity.domain.as_bytes_le().len() as u16)
-        + ber::sizeof_sequence_octet_string(identity.user.as_bytes_le().len() as u16)
-        + ber::sizeof_sequence_octet_string(identity.password.as_ref().0.as_bytes_le().len() as u16)
+fn sizeof_ts_password_creds(identity: &AuthIdentityBuffers) -> io::Result<u16> {
+    let domain_len = identity
+        .domain
+        .as_bytes_le()
+        .len()
+        .try_into()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let user_len = identity
+        .user
+        .as_bytes_le()
+        .len()
+        .try_into()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let password_len = identity
+        .password
+        .as_ref()
+        .0
+        .as_bytes_le()
+        .len()
+        .try_into()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    Ok(ber::sizeof_sequence_octet_string(domain_len)
+        + ber::sizeof_sequence_octet_string(user_len)
+        + ber::sizeof_sequence_octet_string(password_len))
 }
 
-fn get_nego_tokens_len(nego_tokens: &Option<Vec<u8>>) -> u16 {
+fn get_nego_tokens_len(nego_tokens: &Option<Vec<u8>>) -> io::Result<u16> {
     match nego_tokens {
         Some(nego_tokens) => {
-            let nego_len = nego_tokens.len() as u16;
+            let nego_len = nego_tokens
+                .len()
+                .try_into()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
             let mut len = ber::sizeof_octet_string(nego_len);
             len += ber::sizeof_contextual_tag(len);
             len += ber::sizeof_sequence_tag(len);
             len += ber::sizeof_sequence_tag(len);
             len += ber::sizeof_contextual_tag(len);
 
-            len
+            Ok(len)
         }
-        None => 0,
+        None => Ok(0),
     }
 }
 
@@ -420,16 +445,19 @@ fn get_error_code_len(version: u32, error_code: impl Into<Option<NStatusCode>>) 
     }
 }
 
-fn get_field_len(field: &Option<Vec<u8>>) -> u16 {
+fn get_field_len(field: &Option<Vec<u8>>) -> io::Result<u16> {
     match field {
         Some(field) => {
-            let field_len = field.len() as u16;
+            let field_len: u16 = field
+                .len()
+                .try_into()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
             let mut len = ber::sizeof_octet_string(field_len);
             len += ber::sizeof_contextual_tag(len);
 
-            len
+            Ok(len)
         }
-        None => 0,
+        None => Ok(0),
     }
 }
 
@@ -553,7 +581,7 @@ impl fmt::Display for NStatusCode {
 impl TryFrom<windows::core::HRESULT> for NStatusCode {
     type Error = &'static str;
 
-    fn try_from(hresult: windows::core::HRESULT) -> Result<Self, Self::Error> {
+    fn try_from(hresult: windows::core::HRESULT) -> std::result::Result<Self, Self::Error> {
         // More info: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a
         const NSTATUS_BIT: i32 = 0x1000_0000;
 

--- a/src/credssp/ts_request/test.rs
+++ b/src/credssp/ts_request/test.rs
@@ -378,10 +378,10 @@ fn ntlm_encode_first_phase_with_nego_token_and_client_nonce() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -400,10 +400,10 @@ fn ntlm_encode_second_phase_with_nego_token_and_client_nonce() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -422,10 +422,10 @@ fn ntlm_encode_third_phase_with_nego_token_and_pub_key_auth_and_client_nonce() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -444,10 +444,10 @@ fn ntlm_encode_fourth_phase_with_pub_key_auth_and_client_nonce() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -466,10 +466,10 @@ fn ntlm_encode_fiveth_phase_with_auth_info_and_client_nonce() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -488,10 +488,10 @@ fn ntlm_encode_with_error_code() {
         version: TS_REQUEST_VERSION,
     };
 
-    let ts_request_len = ts_request.buffer_len();
-    assert_eq!(ts_request_len as usize, expected_buffer.len());
+    let ts_request_len = ts_request.buffer_len().unwrap();
+    assert_eq!(usize::from(ts_request_len), expected_buffer.len());
 
-    let mut buffer = Vec::with_capacity(ts_request_len as usize);
+    let mut buffer = Vec::with_capacity(ts_request_len.into());
     ts_request.encode_ts_request(&mut buffer).unwrap();
 
     assert_eq!(buffer.as_slice(), expected_buffer.as_ref());
@@ -598,7 +598,7 @@ fn buffer_len_correct_returns_len() {
     let buffer = NTLM_3_PHASE_TS_REQUEST;
     let ts_request = TsRequest::from_buffer(buffer.as_ref()).unwrap();
 
-    assert_eq!(buffer.len() as u16, ts_request.buffer_len());
+    assert_eq!(buffer.len(), ts_request.buffer_len().unwrap().into());
 }
 
 #[test]
@@ -611,5 +611,5 @@ fn buffer_len_correct_returns_len_with_garbage() {
 
     let ts_request = TsRequest::from_buffer(buffer.as_ref()).unwrap();
 
-    assert_eq!((buffer.len() - garbage_len) as u16, ts_request.buffer_len());
+    assert_eq!((buffer.len() - garbage_len), ts_request.buffer_len().unwrap().into());
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -34,27 +34,42 @@ pub(crate) fn compute_md5(data: &[u8]) -> [u8; HASH_SIZE] {
     result
 }
 
-pub(crate) fn compute_md5_channel_bindings_hash(channel_bindings: &ChannelBindings) -> [u8; HASH_SIZE] {
+pub(crate) fn compute_md5_channel_bindings_hash(channel_bindings: &ChannelBindings) -> crate::Result<[u8; HASH_SIZE]> {
     let mut context = Md5::new();
     let mut result = [0x00; HASH_SIZE];
 
-    let initiator_len = channel_bindings.initiator.len() as u32;
+    let initiator_len: u32 = channel_bindings.initiator.len().try_into().map_err(|_| {
+        crate::Error::new(
+            crate::ErrorKind::InvalidParameter,
+            "channel binding initiator length overflow",
+        )
+    })?;
     context.update(channel_bindings.initiator_addr_type.to_le_bytes());
     context.update(initiator_len.to_le_bytes());
     context.update(&channel_bindings.initiator);
 
-    let acceptor_len = channel_bindings.acceptor.len() as u32;
+    let acceptor_len: u32 = channel_bindings.acceptor.len().try_into().map_err(|_| {
+        crate::Error::new(
+            crate::ErrorKind::InvalidParameter,
+            "channel binding acceptor length overflow",
+        )
+    })?;
     context.update(channel_bindings.acceptor_addr_type.to_le_bytes());
     context.update(acceptor_len.to_le_bytes());
     context.update(&channel_bindings.acceptor);
 
-    let application_data_len = channel_bindings.application_data.len() as u32;
+    let application_data_len: u32 = channel_bindings.application_data.len().try_into().map_err(|_| {
+        crate::Error::new(
+            crate::ErrorKind::InvalidParameter,
+            "channel binding application data length overflow",
+        )
+    })?;
     context.update(application_data_len.to_le_bytes());
     context.update(&channel_bindings.application_data);
 
     result.clone_from_slice(&context.finalize());
 
-    result
+    Ok(result)
 }
 
 pub(crate) fn compute_sha256(data: &[u8]) -> [u8; SHA256_SIZE] {

--- a/src/crypto/rc4.rs
+++ b/src/crypto/rc4.rs
@@ -12,11 +12,11 @@ impl Rc4 {
         // key scheduling
         let mut state = State::default();
         for (i, item) in state.iter_mut().enumerate().take(256) {
-            *item = i as u8;
+            *item = i.try_into().expect("state array is 256 bytes");
         }
         let mut j = 0usize;
         for i in 0..256 {
-            j = (j + state[i] as usize + key[i % key.len()] as usize) % 256;
+            j = (j + usize::from(state[i]) + usize::from(key[i % key.len()])) % 256;
             state.swap(i, j);
         }
 
@@ -28,9 +28,9 @@ impl Rc4 {
         let mut output = Vec::with_capacity(message.len());
         while output.capacity() > output.len() {
             self.i = (self.i + 1) % 256;
-            self.j = (self.j + self.state[self.i] as usize) % 256;
+            self.j = (self.j + usize::from(self.state[self.i])) % 256;
             self.state.swap(self.i, self.j);
-            let idx_k = (self.state[self.i] as usize + self.state[self.j] as usize) % 256;
+            let idx_k = (usize::from(self.state[self.i]) + usize::from(self.state[self.j])) % 256;
             let k = self.state[idx_k];
             let idx_msg = output.len();
             output.push(k ^ message[idx_msg]);

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -203,9 +203,10 @@ cfg_if::cfg_if! {
                 if rdata.len() < 6 {
                     return Err(SrvRecordParseError::RdataTooShort);
                 }
-                let priority = u16::from_be_bytes(rdata[0..2].try_into()?);
-                let weight = u16::from_be_bytes(rdata[2..4].try_into()?);
-                let port = u16::from_be_bytes(rdata[4..6].try_into()?);
+
+                let priority = u16::from_be_bytes(rdata[0..2].try_into().map_err(|_| SrvRecordParseError::RdataTooShort)?);
+                let weight = u16::from_be_bytes(rdata[2..4].try_into().map_err(|_| SrvRecordParseError::RdataTooShort)?);
+                let port = u16::from_be_bytes(rdata[4..6].try_into().map_err(|_| SrvRecordParseError::RdataTooShort)?);
                 // A malformed name (truncated label, oversized label, missing root terminator)
                 // is rejected here rather than silently accepted as a partial hostname.
                 let target = dns_decode_target_data_to_string(&rdata[6..])?;

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
                     // SAFETY: `query_results.Data` is guaranteed to contain `SRV` because
                     // of arguments to `DnsQuery_W`.
                     let p_name_target = unsafe { query_results.Data.Srv.pNameTarget };
-                    let name_target = PWSTR::from_raw(p_name_target.as_ptr() as *mut u16);
+                    let name_target = PWSTR::from_raw(p_name_target.as_ptr().cast::<u16>());
                     // SAFETY: `name_target` is guaranteed to be correct at this point.
                     let name_target = unsafe {name_target.to_string()};
 
@@ -48,7 +48,7 @@ cfg_if::cfg_if! {
 
             // SAFETY: `p_query_results` is not null.
             unsafe {
-                DnsFree(Some(p_query_results as *const c_void), DnsFreeRecordList);
+                DnsFree(Some(p_query_results.cast::<c_void>()), DnsFreeRecordList);
             }
 
             records
@@ -203,9 +203,9 @@ cfg_if::cfg_if! {
                 if rdata.len() < 6 {
                     return Err(SrvRecordParseError::RdataTooShort);
                 }
-                let priority = u16::from_be_bytes(rdata[0..2].try_into().unwrap());
-                let weight = u16::from_be_bytes(rdata[2..4].try_into().unwrap());
-                let port = u16::from_be_bytes(rdata[4..6].try_into().unwrap());
+                let priority = u16::from_be_bytes(rdata[0..2].try_into()?);
+                let weight = u16::from_be_bytes(rdata[2..4].try_into()?);
+                let port = u16::from_be_bytes(rdata[4..6].try_into()?);
                 // A malformed name (truncated label, oversized label, missing root terminator)
                 // is rejected here rather than silently accepted as a partial hostname.
                 let target = dns_decode_target_data_to_string(&rdata[6..])?;
@@ -247,7 +247,7 @@ cfg_if::cfg_if! {
 
             let mut i = 0;
             while i < v.len() {
-                let size = v[i] as usize;
+                let size = usize::from(v[i]);
                 if size == 0 {
                     // Root label: the name is complete and correctly terminated.
                     return Ok(names.join("."));
@@ -511,25 +511,27 @@ pub(crate) fn detect_kdc_hosts_from_dns(domain: &str) -> Vec<String> {
 #[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
 mod apple_srv_tests {
     use super::{DnsSrvRecord, SrvRecordParseError};
+    use crate::Result;
 
     /// Builds SRV RDATA: priority, weight, port, then `target` as length-prefixed DNS labels
     /// terminated by the root label.
-    fn srv_rdata(priority: u16, weight: u16, port: u16, target: &str) -> Vec<u8> {
+    fn srv_rdata(priority: u16, weight: u16, port: u16, target: &str) -> Result<Vec<u8>> {
         let mut rdata = Vec::new();
         rdata.extend_from_slice(&priority.to_be_bytes());
         rdata.extend_from_slice(&weight.to_be_bytes());
         rdata.extend_from_slice(&port.to_be_bytes());
         for label in target.split('.').filter(|label| !label.is_empty()) {
-            rdata.push(label.len() as u8);
+            rdata.push(label.len().try_into()?);
             rdata.extend_from_slice(label.as_bytes());
         }
         rdata.push(0); // root label
-        rdata
+
+        Ok(rdata)
     }
 
     #[test]
     fn parses_well_formed_srv_record() {
-        let rdata = srv_rdata(1, 2, 88, "dc.example.com");
+        let rdata = srv_rdata(1, 2, 88, "dc.example.com").expect("failed to build SRV rdata");
         let record = DnsSrvRecord::from_rdata(&rdata).expect("valid SRV record should parse");
         assert_eq!(record.priority, 1);
         assert_eq!(record.weight, 2);

--- a/src/kerberos/client/extractors.rs
+++ b/src/kerberos/client/extractors.rs
@@ -168,7 +168,7 @@ pub fn extract_status_code_from_krb_priv_response(
     let encryption_type = encryption_params
         .encryption_type
         .clone()
-        .unwrap_or(CipherSuite::try_from(
+        .unwrap_or(CipherSuite::try_from(usize::from(
             *krb_priv
                 .0
                 .enc_part
@@ -177,8 +177,8 @@ pub fn extract_status_code_from_krb_priv_response(
                 .0
                 .0
                 .first()
-                .unwrap_or(&((&DEFAULT_ENCRYPTION_TYPE).into())) as usize,
-        )?);
+                .unwrap_or(&((&DEFAULT_ENCRYPTION_TYPE).into())),
+        ))?);
 
     let cipher = encryption_type.cipher();
 

--- a/src/kerberos/client/generators.rs
+++ b/src/kerberos/client/generators.rs
@@ -634,7 +634,7 @@ pub fn generate_authenticator(options: GenerateAuthenticatorOptions<'_>) -> Resu
             }
             // [Authenticator Checksum](https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1)
             // 4..19 - Channel binding information (19 inclusive).
-            checksum_value[4..20].copy_from_slice(&compute_md5_channel_bindings_hash(channel_bindings));
+            checksum_value[4..20].copy_from_slice(&compute_md5_channel_bindings_hash(channel_bindings)?);
         }
         Optional::from(Some(ExplicitContextTag3::from(Checksum {
             cksumtype: ExplicitContextTag0::from(IntegerAsn1::from(checksum_type)),

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -250,7 +250,7 @@ pub async fn initialize_security_context<'a>(
 
             let (encryption_type, salt) = extract_encryption_params_from_as_rep(&as_rep)?;
 
-            let encryption_type = CipherSuite::try_from(encryption_type as usize)?;
+            let encryption_type = CipherSuite::try_from(usize::from(encryption_type))?;
 
             client.encryption_params.encryption_type = Some(encryption_type);
 

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -57,12 +57,12 @@ pub const DEFAULT_ENCRYPTION_TYPE: CipherSuite = CipherSuite::Aes256CtsHmacSha19
 /// The RRC field is 12 if no encryption is requested or 28 if encryption is requested
 pub const RRC: u16 = 28;
 // wrap token header len
-pub const MAX_SIGNATURE: usize = 16;
+pub const MAX_SIGNATURE: u8 = 16;
 /// Required `TOKEN` buffer length during data encryption (`encrypt_message` method call).
 ///
 /// **Note**: Actual security trailer len is `SECURITY_TRAILER` + `EC`. The `EC` field is negotiated
 // during the authentication process.
-pub const SECURITY_TRAILER: usize = 60;
+pub const SECURITY_TRAILER: u8 = 60;
 
 /// [3.4.5.4.1 Kerberos Binding of GSS_WrapEx()](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/e94b3acd-8415-4d0d-9786-749d0c39d550)
 ///
@@ -301,7 +301,7 @@ impl Sspi for Kerberos {
 
         let key_usage = self.encryption_params.sspi_encrypt_key_usage;
 
-        let mut wrap_token = WrapToken::with_seq_number(seq_number as u64);
+        let mut wrap_token = WrapToken::with_seq_number(seq_number.into());
         if self.server.is_some() {
             // [Flags Field](https://datatracker.ietf.org/doc/html/rfc4121#section-4.2.2):
             //
@@ -368,7 +368,8 @@ impl Sspi for Kerberos {
         let security_trailer_len = self.query_context_sizes()?.security_trailer.try_into()?;
 
         let (token, data) = if raw_wrap_token.len() < security_trailer_len {
-            (raw_wrap_token.as_slice(), &[] as &[u8])
+            let empty_data: &[u8] = &[];
+            (raw_wrap_token.as_slice(), empty_data)
         } else {
             raw_wrap_token.split_at(security_trailer_len)
         };
@@ -518,9 +519,9 @@ impl Sspi for Kerberos {
 
         Ok(ContextSizes {
             max_token: PACKAGE_INFO.max_token_len,
-            max_signature: MAX_SIGNATURE as u32,
+            max_signature: MAX_SIGNATURE.into(),
             block: 0,
-            security_trailer: SECURITY_TRAILER as u32 + u32::from(self.encryption_params.ec),
+            security_trailer: u32::from(SECURITY_TRAILER) + u32::from(self.encryption_params.ec),
         })
     }
 

--- a/src/kerberos/server/as_exchange.rs
+++ b/src/kerberos/server/as_exchange.rs
@@ -117,7 +117,7 @@ pub(crate) async fn request_tgt(
 
     let (encryption_type, salt) = extract_encryption_params_from_as_rep(&as_rep)?;
 
-    let encryption_type = CipherSuite::try_from(encryption_type as usize)?;
+    let encryption_type = CipherSuite::try_from(usize::from(encryption_type))?;
     server.encryption_params.encryption_type = Some(encryption_type);
 
     let mut session_key_extractor = AsRepSessionKeyExtractor::AuthIdentity {

--- a/src/kerberos/utils.rs
+++ b/src/kerberos/utils.rs
@@ -15,7 +15,7 @@ pub(super) fn serialize_message<T: ?Sized + Serialize>(v: &T) -> Result<Vec<u8>>
 
     picky_asn1_der::to_writer(v, &mut data)?;
 
-    let len = data.len() as u32 - 4;
+    let len = u32::try_from(data.len())? - 4;
     data[0..4].copy_from_slice(&len.to_be_bytes());
 
     Ok(data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2188,6 +2188,15 @@ pub enum ErrorKind {
     ApplicationProtocolMismatch = 0x8009_0367,
 }
 
+impl From<ErrorKind> for u32 {
+    fn from(value: ErrorKind) -> u32 {
+        #[expect(clippy::as_conversions, reason = "enum repr cast in From impl")]
+        {
+            value as u32
+        }
+    }
+}
+
 /// Holds the `ErrorKind` and the description of the SSPI-related error.
 #[derive(Debug, Clone)]
 pub struct Error {

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -105,7 +105,7 @@ pub mod reqwest_network_client {
                 .read_u32::<BigEndian>()
                 .map_err(|e| Error::new(ErrorKind::NoAuthenticatingAuthority, format!("{e:?}")))?;
 
-            let mut buf = vec![0; len as usize + 4];
+            let mut buf = vec![0; usize::try_from(len + 4)?];
             buf[0..4].copy_from_slice(&(len.to_be_bytes()));
 
             stream
@@ -136,7 +136,7 @@ pub mod reqwest_network_client {
                 .map_err(|e| Error::new(ErrorKind::NoAuthenticatingAuthority, format!("{e:?}")))?;
 
             let mut reply_buf = Vec::with_capacity(n + 4);
-            reply_buf.extend_from_slice(&(n as u32).to_be_bytes());
+            reply_buf.extend_from_slice(&(u32::try_from(n)?).to_be_bytes());
             reply_buf.extend_from_slice(&buf[0..n]);
 
             Ok(reply_buf)

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -105,7 +105,10 @@ pub mod reqwest_network_client {
                 .read_u32::<BigEndian>()
                 .map_err(|e| Error::new(ErrorKind::NoAuthenticatingAuthority, format!("{e:?}")))?;
 
-            let mut buf = vec![0; usize::try_from(len + 4)?];
+            let frame_len = usize::try_from(len)?
+                .checked_add(4)
+                .ok_or_else(|| Error::new(ErrorKind::NoAuthenticatingAuthority, "KDC TCP response length overflow"))?;
+            let mut buf = vec![0; frame_len];
             buf[0..4].copy_from_slice(&(len.to_be_bytes()));
 
             stream

--- a/src/ntlm/messages/av_pair.rs
+++ b/src/ntlm/messages/av_pair.rs
@@ -44,7 +44,7 @@ pub(super) enum AvPair {
 impl AvPair {
     pub(super) fn from_buffer(mut buffer: impl io::Read) -> io::Result<Self> {
         let av_type = buffer.read_u16::<LittleEndian>()?;
-        let len = buffer.read_u16::<LittleEndian>()? as usize;
+        let len = buffer.read_u16::<LittleEndian>()?.into();
 
         match av_type {
             AV_PAIR_EOL => {
@@ -170,7 +170,9 @@ impl AvPair {
             AvPair::ChannelBindings(value) => (HASH_SIZE, value.to_vec()),
         };
         buffer.write_u16::<LittleEndian>(av_type)?;
-        buffer.write_u16::<LittleEndian>(len as u16)?;
+        buffer.write_u16::<LittleEndian>(
+            u16::try_from(len).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
+        )?;
         buffer.write_all(value.as_ref())?;
 
         Ok(())

--- a/src/ntlm/messages/client/authenticate.rs
+++ b/src/ntlm/messages/client/authenticate.rs
@@ -7,18 +7,19 @@ use rand_core::{Rng as _, SeedableRng as _};
 use crate::crypto::Rc4;
 use crate::ntlm::messages::computations::*;
 use crate::ntlm::messages::{
-    CLIENT_SEAL_MAGIC, CLIENT_SIGN_MAGIC, MessageFields, MessageTypes, NTLM_SIGNATURE, NTLM_VERSION_SIZE,
-    SERVER_SEAL_MAGIC, SERVER_SIGN_MAGIC,
+    CLIENT_SEAL_MAGIC, CLIENT_SIGN_MAGIC, MessageFields, MessageTypes, NTLM_SIGNATURE, SERVER_SEAL_MAGIC,
+    SERVER_SIGN_MAGIC,
 };
 use crate::ntlm::{
     AuthIdentityBuffers, AuthenticateMessage, ENCRYPTED_RANDOM_SESSION_KEY_SIZE, MESSAGE_INTEGRITY_CHECK_SIZE, Mic,
     NegotiateFlags, Ntlm, NtlmState, SESSION_KEY_SIZE,
 };
-use crate::{SecurityStatus, Utf16StringExt};
+use crate::{Result, SecurityStatus, Utf16StringExt};
 
-const MIC_SIZE: usize = 16;
-const BASE_OFFSET: usize = 64;
-const AUTH_MESSAGE_OFFSET: usize = BASE_OFFSET + NTLM_VERSION_SIZE + MIC_SIZE; // MIC is always used in NTLMv2
+const MIC_SIZE: u8 = 16;
+const BASE_OFFSET: u8 = 64;
+// NTLM_VERSION_SIZE is 8, which fits in u8
+const AUTH_MESSAGE_OFFSET: u8 = BASE_OFFSET + 8 + MIC_SIZE; // MIC is always used in NTLMv2
 
 struct AuthenticateMessageFields {
     workstation: MessageFields,
@@ -37,7 +38,7 @@ impl AuthenticateMessageFields {
         negotiate_flags: NegotiateFlags,
         encrypted_random_session_key_buffer: &[u8],
         offset: u32,
-    ) -> Self {
+    ) -> Result<Self> {
         let mut workstation = MessageFields::new();
         let mut domain_name = MessageFields::with_buffer(identity.domain.to_bytes_le());
         let mut encrypted_random_session_key = MessageFields::new();
@@ -53,30 +54,34 @@ impl AuthenticateMessageFields {
 
         domain_name.buffer_offset = offset;
 
-        user_name.buffer_offset = domain_name.buffer_offset + domain_name.buffer.len() as u32;
+        let domain_name_len: u32 = domain_name.buffer.len().try_into()?;
+        user_name.buffer_offset = domain_name.buffer_offset + domain_name_len;
 
-        workstation.buffer_offset = user_name.buffer_offset + user_name.buffer.len() as u32;
+        let user_name_len: u32 = user_name.buffer.len().try_into()?;
+        workstation.buffer_offset = user_name.buffer_offset + user_name_len;
 
-        lm_challenge_response.buffer_offset = workstation.buffer_offset + workstation.buffer.len() as u32;
+        let workstation_len: u32 = workstation.buffer.len().try_into()?;
+        lm_challenge_response.buffer_offset = workstation.buffer_offset + workstation_len;
 
-        nt_challenge_response.buffer_offset =
-            lm_challenge_response.buffer_offset + lm_challenge_response.buffer.len() as u32;
+        let lm_challenge_response_len: u32 = lm_challenge_response.buffer.len().try_into()?;
+        nt_challenge_response.buffer_offset = lm_challenge_response.buffer_offset + lm_challenge_response_len;
 
-        encrypted_random_session_key.buffer_offset =
-            nt_challenge_response.buffer_offset + nt_challenge_response.buffer.len() as u32;
+        let nt_challenge_response_len: u32 = nt_challenge_response.buffer.len().try_into()?;
+        encrypted_random_session_key.buffer_offset = nt_challenge_response.buffer_offset + nt_challenge_response_len;
 
-        Self {
+        Ok(Self {
             domain_name,
             user_name,
             workstation,
             lm_challenge_response,
             nt_challenge_response,
             encrypted_random_session_key,
-        }
+        })
     }
 
-    pub(crate) fn data_len(&self) -> usize {
-        self.encrypted_random_session_key.buffer_offset as usize + self.encrypted_random_session_key.buffer.len()
+    pub(crate) fn data_len(&self) -> Result<usize> {
+        let offset: usize = self.encrypted_random_session_key.buffer_offset.try_into()?;
+        Ok(offset + self.encrypted_random_session_key.buffer.len())
     }
 }
 
@@ -84,7 +89,7 @@ pub(crate) fn write_authenticate(
     context: &mut Ntlm,
     credentials: &AuthIdentityBuffers,
     mut transport: impl io::Write,
-) -> crate::Result<SecurityStatus> {
+) -> Result<SecurityStatus> {
     check_state(context.state)?;
 
     let negotiate_message = context
@@ -139,10 +144,10 @@ pub(crate) fn write_authenticate(
         nt_challenge_response.as_ref(),
         context.flags,
         encrypted_session_key.as_ref(),
-        AUTH_MESSAGE_OFFSET as u32,
-    );
+        AUTH_MESSAGE_OFFSET.into(),
+    )?;
 
-    let mut buffer = Vec::with_capacity(message_fields.data_len());
+    let mut buffer = Vec::with_capacity(message_fields.data_len()?);
 
     write_header(context.flags, context.version.as_ref(), &message_fields, &mut buffer)?;
     write_payload(&message_fields, &mut buffer)?;
@@ -155,7 +160,7 @@ pub(crate) fn write_authenticate(
         challenge_message.message.as_ref(),
         message.as_ref(),
         session_key.as_ref(),
-        AUTH_MESSAGE_OFFSET as u8,
+        AUTH_MESSAGE_OFFSET,
         &mut buffer,
     )?;
 
@@ -184,7 +189,7 @@ pub(crate) fn write_authenticate(
     Ok(SecurityStatus::Ok)
 }
 
-fn check_state(state: NtlmState) -> crate::Result<()> {
+fn check_state(state: NtlmState) -> Result<()> {
     if state != NtlmState::Authenticate {
         Err(crate::Error::new(
             crate::ErrorKind::OutOfSequence,
@@ -233,7 +238,7 @@ fn write_header(
     mut buffer: impl io::Write,
 ) -> io::Result<()> {
     buffer.write_all(NTLM_SIGNATURE)?; // signature 8 bytes
-    buffer.write_u32::<LittleEndian>(MessageTypes::Authenticate as u32)?; // message type 4 bytes
+    buffer.write_u32::<LittleEndian>(MessageTypes::Authenticate.as_u32())?; // message type 4 bytes
     message_fields.lm_challenge_response.write_to(&mut buffer)?; // LmChallengeResponseFields (8 bytes)
     message_fields.nt_challenge_response.write_to(&mut buffer)?; // NtChallengeResponseFields (8 bytes)
     message_fields.domain_name.write_to(&mut buffer)?; // DomainNameFields (8 bytes)
@@ -272,9 +277,9 @@ fn write_mic(
     exported_session_key: &[u8],
     offset: u8,
     mut buffer: impl io::Write + io::Seek,
-) -> crate::Result<Mic> {
+) -> Result<Mic> {
     let mic = Mic {
-        offset: offset - MIC_SIZE as u8,
+        offset: offset - MIC_SIZE,
         value: compute_message_integrity_check(
             negotiate_message,
             challenge_message,

--- a/src/ntlm/messages/client/negotiate.rs
+++ b/src/ntlm/messages/client/negotiate.rs
@@ -2,12 +2,13 @@ use std::io;
 
 use byteorder::{LittleEndian, WriteBytesExt};
 
-use crate::SecurityStatus;
-use crate::ntlm::messages::{MessageFields, MessageTypes, NTLM_SIGNATURE, NTLM_VERSION_SIZE};
+use crate::ntlm::messages::{MessageFields, MessageTypes, NTLM_SIGNATURE};
 use crate::ntlm::{NegotiateFlags, NegotiateMessage, Ntlm, NtlmState};
+use crate::{Result, SecurityStatus};
 
-const HEADER_SIZE: usize = 32;
-const NEGO_MESSAGE_OFFSET: usize = HEADER_SIZE + NTLM_VERSION_SIZE;
+const HEADER_SIZE: u8 = 32;
+// NTLM_VERSION_SIZE is 8, which fits in u8
+const NEGO_MESSAGE_OFFSET: u8 = HEADER_SIZE + 8;
 
 struct NegotiateMessageFields {
     domain_name: MessageFields,
@@ -15,25 +16,27 @@ struct NegotiateMessageFields {
 }
 
 impl NegotiateMessageFields {
-    pub(crate) fn new(offset: u32, workstation: Option<Vec<u8>>) -> Self {
+    pub(crate) fn new(offset: u32, workstation: Option<Vec<u8>>) -> Result<Self> {
         let mut domain_name = MessageFields::new();
         let mut workstation = MessageFields::with_buffer(workstation.unwrap_or_default());
 
         domain_name.buffer_offset = offset;
-        workstation.buffer_offset = domain_name.buffer_offset + domain_name.buffer.len() as u32;
+        let domain_name_len: u32 = domain_name.buffer.len().try_into()?;
+        workstation.buffer_offset = domain_name.buffer_offset + domain_name_len;
 
-        NegotiateMessageFields {
+        Ok(NegotiateMessageFields {
             domain_name,
             workstation,
-        }
+        })
     }
 
-    pub(crate) fn data_len(&self) -> usize {
-        self.workstation.buffer_offset as usize + self.workstation.buffer.len()
+    pub(crate) fn data_len(&self) -> Result<usize> {
+        let offset: usize = self.workstation.buffer_offset.try_into()?;
+        Ok(offset + self.workstation.buffer.len())
     }
 }
 
-fn check_state(state: NtlmState) -> crate::Result<()> {
+fn check_state(state: NtlmState) -> Result<()> {
     if state != NtlmState::Negotiate {
         Err(crate::Error::new(
             crate::ErrorKind::OutOfSequence,
@@ -44,20 +47,20 @@ fn check_state(state: NtlmState) -> crate::Result<()> {
     }
 }
 
-pub(crate) fn write_negotiate(context: &mut Ntlm, mut transport: impl io::Write) -> crate::Result<SecurityStatus> {
+pub(crate) fn write_negotiate(context: &mut Ntlm, mut transport: impl io::Write) -> Result<SecurityStatus> {
     check_state(context.state)?;
 
     let negotiate_flags = get_flags(context);
     let message_fields = NegotiateMessageFields::new(
-        NEGO_MESSAGE_OFFSET as u32,
+        NEGO_MESSAGE_OFFSET.into(),
         context
             .config
             .client_computer_name
             .as_ref()
             .map(|workstation| workstation.as_bytes().to_vec()),
-    );
+    )?;
 
-    let mut buffer = Vec::with_capacity(message_fields.data_len());
+    let mut buffer = Vec::with_capacity(message_fields.data_len()?);
 
     write_header(negotiate_flags, context.version.as_ref(), &message_fields, &mut buffer)?;
     write_payload(&message_fields, &mut buffer)?;
@@ -109,7 +112,7 @@ fn write_header(
     mut buffer: impl io::Write,
 ) -> io::Result<()> {
     buffer.write_all(NTLM_SIGNATURE)?; // signature 8 bytes
-    buffer.write_u32::<LittleEndian>(MessageTypes::Negotiate as u32)?; // message type 4 bytes
+    buffer.write_u32::<LittleEndian>(MessageTypes::Negotiate.as_u32())?; // message type 4 bytes
     buffer.write_u32::<LittleEndian>(negotiate_flags.bits())?; // negotiate flags 4 bytes
     message_fields.domain_name.write_to(&mut buffer)?; // domain name 8 bytes
     message_fields.workstation.write_to(&mut buffer)?; // workstation 8 bytes

--- a/src/ntlm/messages/computations.rs
+++ b/src/ntlm/messages/computations.rs
@@ -31,7 +31,13 @@ pub(super) static SINGLE_HOST_DATA: LazyLock<[u8; SINGLE_HOST_DATA_SIZE]> = Lazy
     let mut result = [0x00; SINGLE_HOST_DATA_SIZE];
     let mut buffer = io::Cursor::new(result.as_mut());
 
-    buffer.write_u32::<LittleEndian>(SINGLE_HOST_DATA_SIZE as u32).unwrap(); //size
+    buffer
+        .write_u32::<LittleEndian>(
+            SINGLE_HOST_DATA_SIZE
+                .try_into()
+                .expect("SINGLE_HOST_DATA_SIZE should fit into u32"),
+        )
+        .unwrap(); //size
     buffer.write_u32::<LittleEndian>(0).unwrap(); //z4
     buffer.write_u32::<LittleEndian>(1).unwrap(); //data present
     buffer.write_u32::<LittleEndian>(0x2000).unwrap(); //custom_data
@@ -57,7 +63,7 @@ fn convert_to_file_time(end_date: OffsetDateTime) -> crate::Result<u64> {
     } else {
         let duration = end_date - start_date;
         let whole_microseconds = duration.whole_microseconds();
-        let file_time = u64::try_from(whole_microseconds).expect("whole_microseconds to u64 conversion") * 10;
+        let file_time = u64::try_from(whole_microseconds)? * 10;
         Ok(file_time)
     }
 }
@@ -101,7 +107,7 @@ pub(super) fn get_authenticate_target_info(
     if let Some(channel_bindings) = channel_bindings {
         av_pairs.push(AvPair::ChannelBindings(compute_md5_channel_bindings_hash(
             channel_bindings,
-        )));
+        )?));
     }
 
     let mut authenticate_target_info = AvPair::list_to_buffer(&av_pairs)?;

--- a/src/ntlm/messages/mod.rs
+++ b/src/ntlm/messages/mod.rs
@@ -22,10 +22,20 @@ pub(super) const CLIENT_SEAL_MAGIC: &[u8; MAGIC_SIZE] = b"session key to client-
 pub(super) const SERVER_SEAL_MAGIC: &[u8; MAGIC_SIZE] = b"session key to server-to-client sealing key magic constant\0";
 
 #[derive(Clone, Copy)]
+#[repr(u32)]
 pub(super) enum MessageTypes {
     Negotiate = 1,
     Challenge = 2,
     Authenticate = 3,
+}
+
+impl MessageTypes {
+    fn as_u32(&self) -> u32 {
+        #[expect(clippy::as_conversions, reason = "#[repr(u32)] guarantees this cast is lossless")]
+        {
+            *self as u32
+        }
+    }
 }
 
 pub(super) struct MessageFields {
@@ -47,8 +57,11 @@ impl MessageFields {
         }
     }
     fn write_to(&self, mut buffer: impl io::Write) -> io::Result<()> {
-        buffer.write_u16::<LittleEndian>(self.buffer.len() as u16)?; // Len
-        buffer.write_u16::<LittleEndian>(self.buffer.len() as u16)?; // MaxLen
+        let len = u16::try_from(self.buffer.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+        buffer.write_u16::<LittleEndian>(len)?; // Len
+        buffer.write_u16::<LittleEndian>(len)?; // MaxLen
+
         buffer.write_u32::<LittleEndian>(self.buffer_offset)?; // BufferOffset
 
         Ok(())
@@ -62,7 +75,7 @@ impl MessageFields {
         let len = buffer.read_u16::<LittleEndian>()?; // Len
         let _max_len = buffer.read_u16::<LittleEndian>()?; // MaxLen
         self.buffer_offset = buffer.read_u32::<LittleEndian>()?; // BufferOffset
-        self.buffer.resize(len as usize, 0x00);
+        self.buffer.resize(len.into(), 0x00);
         Ok(())
     }
     fn read_buffer_from(&mut self, mut cursor: impl io::Read + io::Seek) -> io::Result<()> {
@@ -107,12 +120,13 @@ pub(super) fn read_ntlm_header(mut stream: impl io::Read, expected_message_type:
             format!("Read NTLM signature is invalid: {signature:?}"),
         ));
     }
-    if message_type != expected_message_type as u32 {
+    if message_type != expected_message_type.as_u32() {
         return Err(crate::Error::new(
             crate::ErrorKind::InvalidToken,
             format!(
                 "Message type is invalid: {} != expected ({})",
-                message_type, expected_message_type as u32
+                message_type,
+                expected_message_type.as_u32()
             ),
         ));
     }

--- a/src/ntlm/messages/server/authenticate.rs
+++ b/src/ntlm/messages/server/authenticate.rs
@@ -119,7 +119,9 @@ where
     io::Cursor<T>: Read + io::Seek,
 {
     let mic = if negotiate_flags.contains(NegotiateFlags::NTLM_SSP_NEGOTIATE_TARGET_INFO) {
-        let mic_offset = buffer.position() as u8;
+        let mic_offset = u8::try_from(buffer.position())
+            .map_err(|_| crate::Error::new(crate::ErrorKind::InvalidToken, "MIC offset exceeds u8"))?;
+
         let mut mic_value = [0x00; MESSAGE_INTEGRITY_CHECK_SIZE];
         buffer.read_exact(&mut mic_value)?;
         Some(Mic::new(mic_value, mic_offset))
@@ -172,7 +174,7 @@ fn process_message_fields(
         .iter()
         .find(|av_pair| av_pair.as_u16() == AV_PAIR_CHANNEL_BINDINGS)
         && let Some(channel_bindings) = channel_bindings.as_ref()
-        && compute_md5_channel_bindings_hash(channel_bindings) != *hash
+        && compute_md5_channel_bindings_hash(channel_bindings)? != *hash
     {
         return Err(crate::Error::new(
             crate::ErrorKind::BadBindings,

--- a/src/ntlm/messages/server/challenge.rs
+++ b/src/ntlm/messages/server/challenge.rs
@@ -2,13 +2,14 @@ use std::io;
 
 use byteorder::{LittleEndian, WriteBytesExt};
 
-use crate::SecurityStatus;
 use crate::ntlm::messages::computations::*;
-use crate::ntlm::messages::{MessageFields, MessageTypes, NTLM_SIGNATURE, NTLM_VERSION_SIZE};
+use crate::ntlm::messages::{MessageFields, MessageTypes, NTLM_SIGNATURE};
 use crate::ntlm::{ChallengeMessage, NegotiateFlags, Ntlm, NtlmState};
+use crate::{Result, SecurityStatus};
 
-const BASE_OFFSET: usize = 48;
-const CHALLENGE_MESSAGE_OFFSET: usize = BASE_OFFSET + NTLM_VERSION_SIZE;
+const BASE_OFFSET: u8 = 48;
+// NTLM_VERSION_SIZE is 8, which fits in u8
+const CHALLENGE_MESSAGE_OFFSET: u8 = BASE_OFFSET + 8;
 
 struct ChallengeMessageFields {
     target_name: MessageFields,
@@ -16,27 +17,29 @@ struct ChallengeMessageFields {
 }
 
 impl ChallengeMessageFields {
-    fn new(target_info: &[u8], offset: u32) -> Self {
+    fn new(target_info: &[u8], offset: u32) -> Result<Self> {
         let mut target_info = MessageFields::with_buffer(target_info.to_vec());
         let mut target_name = MessageFields::new();
 
         // will not set target name because it is not used anywhere
 
         target_name.buffer_offset = offset;
-        target_info.buffer_offset = target_name.buffer_offset + target_name.buffer.len() as u32;
+        let target_name_len: u32 = target_name.buffer.len().try_into()?;
+        target_info.buffer_offset = target_name.buffer_offset + target_name_len;
 
-        ChallengeMessageFields {
+        Ok(ChallengeMessageFields {
             target_name,
             target_info,
-        }
+        })
     }
 
-    fn data_len(&self) -> usize {
-        self.target_info.buffer_offset as usize + self.target_info.buffer.len()
+    fn data_len(&self) -> Result<usize> {
+        let offset: usize = self.target_info.buffer_offset.try_into()?;
+        Ok(offset + self.target_info.buffer.len())
     }
 }
 
-pub(crate) fn write_challenge(context: &mut Ntlm, mut transport: impl io::Write) -> crate::Result<SecurityStatus> {
+pub(crate) fn write_challenge(context: &mut Ntlm, mut transport: impl io::Write) -> Result<SecurityStatus> {
     check_state(context.state)?;
 
     let server_challenge = generate_challenge()?;
@@ -44,9 +47,9 @@ pub(crate) fn write_challenge(context: &mut Ntlm, mut transport: impl io::Write)
     let target_info = get_challenge_target_info(timestamp)?;
 
     context.flags = get_flags(context.flags);
-    let message_fields = ChallengeMessageFields::new(target_info.as_ref(), CHALLENGE_MESSAGE_OFFSET as u32);
+    let message_fields = ChallengeMessageFields::new(target_info.as_ref(), CHALLENGE_MESSAGE_OFFSET.into())?;
 
-    let mut buffer = io::Cursor::new(Vec::with_capacity(message_fields.data_len()));
+    let mut buffer = io::Cursor::new(Vec::with_capacity(message_fields.data_len()?));
 
     write_header(
         context.flags,
@@ -68,7 +71,7 @@ pub(crate) fn write_challenge(context: &mut Ntlm, mut transport: impl io::Write)
     Ok(SecurityStatus::ContinueNeeded)
 }
 
-fn check_state(state: NtlmState) -> crate::Result<()> {
+fn check_state(state: NtlmState) -> Result<()> {
     if state != NtlmState::Challenge {
         Err(crate::Error::new(
             crate::ErrorKind::OutOfSequence,
@@ -91,7 +94,7 @@ fn write_header(
     mut buffer: impl io::Write,
 ) -> io::Result<()> {
     buffer.write_all(NTLM_SIGNATURE)?; // signature 8 bytes
-    buffer.write_u32::<LittleEndian>(MessageTypes::Challenge as u32)?; // message type 4 bytes
+    buffer.write_u32::<LittleEndian>(MessageTypes::Challenge.as_u32())?; // message type 4 bytes
     message_fields.target_name.write_to(&mut buffer)?; // target name fields 8 bytes
     buffer.write_u32::<LittleEndian>(negotiate_flags.bits())?; // negotiate flags 4 bytes
     buffer.write_all(server_challenge)?; // server challenge 8 bytes

--- a/src/ntlm/messages/server/complete_authenticate.rs
+++ b/src/ntlm/messages/server/complete_authenticate.rs
@@ -137,7 +137,7 @@ fn check_mic_correctness(
         // we need empty the MIC part of auth. message and then will come back the MIC.
         let mic = mic.as_ref().unwrap();
         let mut authenticate_message = authenticate_message.to_vec();
-        authenticate_message[mic.offset as usize..mic.offset as usize + MESSAGE_INTEGRITY_CHECK_SIZE]
+        authenticate_message[usize::from(mic.offset)..usize::from(mic.offset) + MESSAGE_INTEGRITY_CHECK_SIZE]
             .clone_from_slice(&[0x00; MESSAGE_INTEGRITY_CHECK_SIZE]);
         let calculated_mic = compute_message_integrity_check(
             negotiate_message,

--- a/src/ntlm/messages/server/test.rs
+++ b/src/ntlm/messages/server/test.rs
@@ -544,8 +544,11 @@ fn read_authenticate_fails_with_incorrect_encrypted_key_size() {
     context.state = NtlmState::Authenticate;
 
     let mut buffer = DOMAIN_AUTHENTICATE_MESSAGE.to_vec();
+    let session_key_size_u8: u8 = SESSION_KEY_SIZE
+        .try_into()
+        .expect("SESSION_KEY_SIZE should fit into u8");
     buffer[AUTHENTICATE_ENCRYPTED_KEY_START..AUTHENTICATE_ENCRYPTED_KEY_START + 4]
-        .clone_from_slice([SESSION_KEY_SIZE as u8 - 1, 0x00, SESSION_KEY_SIZE as u8 - 1, 0x00].as_ref());
+        .clone_from_slice([session_key_size_u8 - 1, 0x00, session_key_size_u8 - 1, 0x00].as_ref());
     buffer.pop();
 
     assert!(read_authenticate(&mut context, buffer.as_slice()).is_err());

--- a/src/pku2u/cert_utils/win_extraction.rs
+++ b/src/pku2u/cert_utils/win_extraction.rs
@@ -68,28 +68,28 @@ fn decode_private_key(mut buffer: impl Read) -> Result<PrivateKey> {
         ));
     }
 
-    let mut public_exp = vec![0; rsa_key_blob.public_exp as usize];
+    let mut public_exp = vec![0; rsa_key_blob.public_exp.try_into()?];
     buffer.read_exact(&mut public_exp)?;
 
-    let mut modulus = vec![0; rsa_key_blob.modulus as usize];
+    let mut modulus = vec![0; rsa_key_blob.modulus.try_into()?];
     buffer.read_exact(&mut modulus)?;
 
-    let mut prime1 = vec![0; rsa_key_blob.prime1 as usize];
+    let mut prime1 = vec![0; rsa_key_blob.prime1.try_into()?];
     buffer.read_exact(&mut prime1)?;
 
-    let mut prime2 = vec![0; rsa_key_blob.prime2 as usize];
+    let mut prime2 = vec![0; rsa_key_blob.prime2.try_into()?];
     buffer.read_exact(&mut prime2)?;
 
-    let mut exp = vec![0; rsa_key_blob.prime1 as usize];
+    let mut exp = vec![0; rsa_key_blob.prime1.try_into()?];
     buffer.read_exact(&mut exp)?;
 
-    let mut exp = vec![0; rsa_key_blob.prime2 as usize];
+    let mut exp = vec![0; rsa_key_blob.prime2.try_into()?];
     buffer.read_exact(&mut exp)?;
 
-    let mut coef = vec![0; rsa_key_blob.prime1 as usize];
+    let mut coef = vec![0; rsa_key_blob.prime1.try_into()?];
     buffer.read_exact(&mut coef)?;
 
-    let mut private_exp = vec![0; (rsa_key_blob.bit_len / 8) as usize];
+    let mut private_exp = vec![0; (rsa_key_blob.bit_len / 8).try_into()?];
     buffer.read_exact(&mut private_exp)?;
 
     debug!("RSA private key components are decoded successfully");
@@ -237,7 +237,7 @@ unsafe fn export_certificate_private_key(cert: NonNull<CERT_CONTEXT>) -> Result<
         };
     }
 
-    let mut private_key_blob = vec![0; private_key_buffer_len as usize];
+    let mut private_key_blob = vec![0; private_key_buffer_len.try_into()?];
 
     // SAFETY:
     // - `private_key_handle` is a valid `NCRYPT_KEY_HANDLE`.
@@ -285,7 +285,8 @@ unsafe fn export_certificate_private_key(cert: NonNull<CERT_CONTEXT>) -> Result<
 
     debug!("The certificate private key exported");
 
-    let private_key = decode_private_key(&private_key_blob[0..private_key_buffer_len as usize])?;
+    let private_key_len: usize = private_key_buffer_len.try_into()?;
+    let private_key = decode_private_key(&private_key_blob[0..private_key_len])?;
 
     Ok(private_key)
 }
@@ -305,7 +306,7 @@ unsafe fn extract_client_p2p_certificate(cert_store: HCERTSTORE) -> Result<(Cert
         let certificate_data = unsafe { (*certificate).pbCertEncoded };
         // SAFETY:
         // - `certificate` is not null.
-        let certificate_len = unsafe { (*certificate).cbCertEncoded as usize };
+        let certificate_len: usize = unsafe { (*certificate).cbCertEncoded }.try_into()?;
         // SAFETY:
         // - `certificate` is not null.
         // - `(*certificate).pbCertEncoded` and `(*certificate).cbCertEncoded` are valid `data` and `len`.

--- a/src/pku2u/generators.rs
+++ b/src/pku2u/generators.rs
@@ -274,12 +274,12 @@ pub fn generate_authenticator(options: GenerateAuthenticatorOptions<'_>) -> Resu
             }
             // [Authenticator Checksum](https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1)
             // 4..19 - Channel binding information (19 inclusive).
-            checksum_value[4..20].copy_from_slice(&compute_md5_channel_bindings_hash(channel_bindings));
+            checksum_value[4..20].copy_from_slice(&compute_md5_channel_bindings_hash(channel_bindings)?);
         }
 
         for extension in extensions {
             checksum_value.extend_from_slice(&extension.extension_type.to_be_bytes());
-            checksum_value.extend_from_slice(&(extension.extension_value.len() as u32).to_be_bytes());
+            checksum_value.extend_from_slice(&u32::try_from(extension.extension_value.len())?.to_be_bytes());
             checksum_value.extend_from_slice(&extension.extension_value);
         }
 

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -239,11 +239,11 @@ impl Sspi for Pku2u {
 
         match self.state {
             Pku2uState::PubKeyAuth | Pku2uState::Credentials | Pku2uState::Final => {
-                if raw_wrap_token.len() < SECURITY_TRAILER {
+                if raw_wrap_token.len() < usize::from(SECURITY_TRAILER) {
                     return Err(Error::new(ErrorKind::EncryptFailure, "Cannot encrypt the data"));
                 }
 
-                let (token, data) = raw_wrap_token.split_at(SECURITY_TRAILER);
+                let (token, data) = raw_wrap_token.split_at(usize::from(SECURITY_TRAILER));
                 data_buffer.write_data(data)?;
                 let token_buffer = SecurityBufferRef::find_buffer_mut(message, BufferType::Token)?;
                 token_buffer.write_data(token)?;
@@ -302,9 +302,9 @@ impl Sspi for Pku2u {
     fn query_context_sizes(&mut self) -> Result<ContextSizes> {
         Ok(ContextSizes {
             max_token: PACKAGE_INFO.max_token_len,
-            max_signature: MAX_SIGNATURE as u32,
+            max_signature: MAX_SIGNATURE.into(),
             block: 0,
-            security_trailer: SECURITY_TRAILER as u32,
+            security_trailer: u32::from(SECURITY_TRAILER) + u32::from(self.encryption_params.ec),
         })
     }
 
@@ -524,11 +524,23 @@ impl Pku2u {
                     ));
                 }
 
-                if buffer.len() < acceptor_nego.header.header_len as usize {
+                let nego_header_len = acceptor_nego.header.header_len.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorKind::InvalidToken,
+                        "NEGOEX header length is too big to fit into usize",
+                    )
+                })?;
+                if buffer.len() < nego_header_len {
                     return Err(Error::new(ErrorKind::InvalidToken, "NEGOEX buffer is too short"));
                 }
 
-                let acceptor_exchange_data = &buffer[(acceptor_nego.header.message_len as usize)..];
+                let nego_message_len = acceptor_nego.header.message_len.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorKind::InvalidToken,
+                        "NEGOEX message length is too big to fit into usize",
+                    )
+                })?;
+                let acceptor_exchange_data = &buffer[nego_message_len..];
                 let acceptor_exchange = Exchange::decode(acceptor_exchange_data)?;
                 trace!(?acceptor_exchange, "NEGOEX ACCEPTOR EXCHANGE");
 
@@ -775,14 +787,25 @@ impl Pku2u {
                 check_sequence_number!(acceptor_exchange.header.sequence_num, self.next_seq_number());
                 check_auth_scheme!(acceptor_exchange.auth_scheme, self.auth_scheme);
 
-                if buffer.len() < acceptor_exchange.header.header_len as usize {
+                let exchange_header_len = acceptor_exchange.header.header_len.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorKind::InvalidToken,
+                        "NEGOEX header length is too big to fit into usize",
+                    )
+                })?;
+                if buffer.len() < exchange_header_len {
                     return Err(Error::new(ErrorKind::InvalidToken, "NEGOEX buffer is too short"));
                 }
 
-                self.negoex_messages
-                    .extend_from_slice(&buffer[0..(acceptor_exchange.header.message_len as usize)]);
+                let exchange_message_len = acceptor_exchange.header.message_len.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorKind::InvalidToken,
+                        "NEGOEX message length is too big to fit into usize",
+                    )
+                })?;
+                self.negoex_messages.extend_from_slice(&buffer[0..exchange_message_len]);
 
-                let acceptor_verify_data = &buffer[(acceptor_exchange.header.message_len as usize)..];
+                let acceptor_verify_data = &buffer[exchange_message_len..];
                 let acceptor_verify = Verify::decode(acceptor_verify_data)?;
                 trace!(?acceptor_exchange, "NEGOEX ACCEPTOR VERIFY MESSAGE");
 
@@ -800,17 +823,21 @@ impl Pku2u {
 
                 self.encryption_params.sub_session_key = Some(sub_session_key);
 
-                let acceptor_checksum = ChecksumSuite::try_from(acceptor_verify.checksum.checksum_type as usize)?
-                    .hasher()
-                    .checksum(
-                        check_if_empty!(
-                            self.encryption_params.sub_session_key.as_ref(),
-                            "sub-session key is not set"
-                        )
-                        .as_ref(),
-                        ACCEPTOR_SIGN,
-                        &self.negoex_messages,
-                    )?;
+                let checksum_type: usize = acceptor_verify.checksum.checksum_type.try_into().map_err(|_| {
+                    Error::new(
+                        ErrorKind::InvalidToken,
+                        "NEGOEX checksum type is too big to fit into usize",
+                    )
+                })?;
+                let acceptor_checksum = ChecksumSuite::try_from(checksum_type)?.hasher().checksum(
+                    check_if_empty!(
+                        self.encryption_params.sub_session_key.as_ref(),
+                        "sub-session key is not set"
+                    )
+                    .as_ref(),
+                    ACCEPTOR_SIGN,
+                    &self.negoex_messages,
+                )?;
                 if acceptor_verify.checksum.checksum_value != acceptor_checksum {
                     return Err(Error::new(
                         ErrorKind::MessageAltered,

--- a/tests/sspi/client_server/kerberos/kdc.rs
+++ b/tests/sspi/client_server/kerberos/kdc.rs
@@ -38,6 +38,14 @@ pub(crate) const KDC_URL: &str = "tcp://192.168.1.103:88";
 pub(crate) const CLIENT_COMPUTER_NAME: &str = "DESKTOP-8F33RFH.example.com";
 pub(crate) const SERVER_COMPUTER_NAME: &str = "WIN-956CQOSSJTF.example.com";
 
+/// `AES256_CTS_HMAC_SHA1_96` cast to `u8` for use in ASN.1 encoding.
+/// The constant value fits in u8 by definition of the Kerberos etype numbering.
+#[expect(
+    clippy::as_conversions,
+    reason = "AES256_CTS_HMAC_SHA1_96 constant fits in u8 by definition"
+)]
+const AES256_ENC_TYPE: u8 = AES256_CTS_HMAC_SHA1_96 as u8;
+
 /// Represents user credentials in the internal KDC database.
 pub(crate) struct PasswordCreds {
     /// User's password.
@@ -151,9 +159,7 @@ impl KdcMock {
                             padata_type: ExplicitContextTag1::from(IntegerAsn1::from(PA_ETYPE_INFO2_TYPE.to_vec())),
                             padata_data: ExplicitContextTag2::from(OctetStringAsn1::from(
                                 picky_asn1_der::to_vec(&Asn1SequenceOf::from(vec![EtypeInfo2Entry {
-                                    etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![
-                                        AES256_CTS_HMAC_SHA1_96 as u8,
-                                    ])),
+                                    etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                                     salt: Optional::from(Some(ExplicitContextTag1::from(KerberosStringAsn1::from(
                                         IA5String::from_string(salt).unwrap(),
                                     )))),
@@ -275,7 +281,7 @@ impl KdcMock {
             realm: ExplicitContextTag1::from(realm),
             sname: ExplicitContextTag2::from(sname),
             enc_part: ExplicitContextTag3::from(EncryptedData {
-                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                 kvno: Optional::from(None),
                 cipher: ExplicitContextTag2::from(OctetStringAsn1::from(ticket_enc_data)),
             }),
@@ -351,7 +357,7 @@ impl KdcMock {
 
         let as_rep_enc_part = EncAsRepPart::from(EncKdcRepPart {
             key: ExplicitContextTag0::from(EncryptionKey {
-                key_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                key_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                 key_value: ExplicitContextTag1::from(OctetStringAsn1::from(session_key.to_vec())),
             }),
             last_req: ExplicitContextTag1::from(LastReq::from(vec![LastReqInner {
@@ -387,7 +393,7 @@ impl KdcMock {
                 padata_type: ExplicitContextTag1::from(IntegerAsn1::from(PA_ETYPE_INFO2_TYPE.to_vec())),
                 padata_data: ExplicitContextTag2::from(OctetStringAsn1::from(
                     picky_asn1_der::to_vec(&Asn1SequenceOf::from(vec![EtypeInfo2Entry {
-                        etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                        etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                         salt: Optional::from(Some(ExplicitContextTag1::from(KerberosStringAsn1::from(
                             IA5String::from_string(creds.salt.clone()).unwrap(),
                         )))),
@@ -407,7 +413,7 @@ impl KdcMock {
                 username.0,
             )),
             enc_part: ExplicitContextTag6::from(EncryptedData {
-                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                 kvno: Optional::from(None),
                 cipher: ExplicitContextTag2::from(OctetStringAsn1::from(as_rep_enc_data)),
             }),
@@ -578,7 +584,7 @@ impl KdcMock {
 
         let tgs_rep_enc_part = EncTgsRepPart::from(EncKdcRepPart {
             key: ExplicitContextTag0::from(EncryptionKey {
-                key_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                key_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                 key_value: ExplicitContextTag1::from(OctetStringAsn1::from(session_key.to_vec())),
             }),
             last_req: ExplicitContextTag1::from(LastReq::from(vec![LastReqInner {
@@ -622,7 +628,7 @@ impl KdcMock {
                 cname,
             )),
             enc_part: ExplicitContextTag6::from(EncryptedData {
-                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_CTS_HMAC_SHA1_96 as u8])),
+                etype: ExplicitContextTag0::from(IntegerAsn1::from(vec![AES256_ENC_TYPE])),
                 kvno: Optional::from(None),
                 cipher: ExplicitContextTag2::from(OctetStringAsn1::from(tgs_rep_enc_data)),
             }),

--- a/tests/sspi/common.rs
+++ b/tests/sspi/common.rs
@@ -179,7 +179,8 @@ where
 pub(crate) fn check_messages_encryption(client: &mut impl Sspi, server: &mut impl Sspi) -> sspi::Result<()> {
     let server_sizes = server.query_context_sizes()?;
 
-    let mut token = vec![0; server_sizes.security_trailer as usize];
+    let security_trailer_size: usize = server_sizes.security_trailer.try_into()?;
+    let mut token = vec![0; security_trailer_size];
     let mut data = MESSAGE_TO_CLIENT.to_vec();
     let mut messages = [
         SecurityBufferRef::token_buf(token.as_mut_slice()),


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/#as_conversions

> Checks for usage of `as` conversions.
>
> `as` conversions will perform many kinds of conversions, including silently lossy conversions and dangerous coercions.