### PR TITLE
refactor!(auth_identity): make Username format explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fn main() {
     let account_name = "example_user";
     let computer_name = "example_computer";
     let mut ntlm = Ntlm::new();
-    let username = Username::new(&account_name, Some(&computer_name)).unwrap();
+    let username = Username::new_down_level_logon_name(&account_name, Some(&computer_name)).unwrap();
     let identity = sspi::AuthIdentity {
         username,
         password: String::from("example_password").into(),

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -24,7 +24,8 @@ fn main() -> Result<(), io::Error> {
 
     let account_name = whoami::username().unwrap();
     let computer_name = whoami::hostname().unwrap();
-    let username = Username::new(&account_name, Some(&computer_name)).map_err(io::Error::other)?;
+    let username =
+        Username::new_down_level_logon_name(&account_name, Some(&computer_name)).map_err(io::Error::other)?;
 
     let identity = AuthIdentity {
         username,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -25,7 +25,8 @@ fn main() -> Result<(), io::Error> {
 
     let account_name = whoami::username().unwrap();
     let computer_name = whoami::hostname().unwrap();
-    let username = Username::new(&account_name, Some(&computer_name)).map_err(io::Error::other)?;
+    let username =
+        Username::new_down_level_logon_name(&account_name, Some(&computer_name)).map_err(io::Error::other)?;
 
     let identity = AuthIdentity {
         username,

--- a/ffi/src/sspi/sec_handle.rs
+++ b/ffi/src/sspi/sec_handle.rs
@@ -1061,8 +1061,7 @@ unsafe fn query_context_attributes_common(
 
                 if is_wide {
                     let sec_pkg_names = p_buffer.cast::<SecPkgContextNamesW>();
-                    // We use `.inner()` instead of `.account_name()` because we want to return the full username, including the domain part.
-                    let wide_username = Utf16String::from_str(sspi_names.username.inner()).into_vec_with_nul();
+                    let wide_username = Utf16String::from_str(sspi_names.username.as_str()).into_vec_with_nul();
                     let username_len = wide_username.len();
 
                     // SAFETY: Memory allocation is safe.
@@ -1094,8 +1093,7 @@ unsafe fn query_context_attributes_common(
                 } else {
                     let sec_pkg_names = p_buffer.cast::<SecPkgContextNamesA>();
 
-                    // We use `.inner()` instead of `.account_name()` because we want to return the full username, including the domain part.
-                    let username = sspi_names.username.inner();
+                    let username = sspi_names.username.as_str();
 
                     // SAFETY: Memory allocation is safe.
                     let buf = unsafe {

--- a/src/auth_identity.rs
+++ b/src/auth_identity.rs
@@ -1,14 +1,46 @@
 use std::fmt;
-use std::ops::Not;
 
 use picky_krb::crypto::CipherSuite;
 
 use crate::utf16string::ZeroizedUtf16String;
 use crate::{Error, Secret, Utf16String, Utf16StringExt};
 
+/// A component of a [`Username`] used in validation errors.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UsernameComponent {
+    /// The account portion of a user principal name.
+    UserPrincipalNameAccount,
+    /// The suffix portion of a user principal name.
+    UserPrincipalNameSuffix,
+    /// The account portion of a down-level logon name.
+    DownLevelAccountName,
+    /// The NetBIOS domain portion of a down-level logon name.
+    NetbiosDomain,
+}
+
+impl fmt::Display for UsernameComponent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UserPrincipalNameAccount => f.write_str("user principal name account"),
+            Self::UserPrincipalNameSuffix => f.write_str("user principal name suffix"),
+            Self::DownLevelAccountName => f.write_str("down-level account name"),
+            Self::NetbiosDomain => f.write_str("NetBIOS domain"),
+        }
+    }
+}
+
+/// An error in the structure of a [`Username`].
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UsernameError {
-    MixedFormat,
+    /// A component contains a delimiter that is not valid in that position.
+    ForbiddenDelimiter {
+        component: UsernameComponent,
+        delimiter: char,
+    },
+    /// A required component is empty.
+    EmptyComponent { component: UsernameComponent },
 }
 
 impl std::error::Error for UsernameError {}
@@ -16,308 +48,259 @@ impl std::error::Error for UsernameError {}
 impl fmt::Display for UsernameError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UsernameError::MixedFormat => write!(f, "mixed username format"),
+            Self::ForbiddenDelimiter { component, delimiter } => {
+                write!(f, "delimiter {delimiter:?} is forbidden in the {component}")
+            }
+            Self::EmptyComponent { component } => write!(f, "the {component} is empty"),
         }
     }
 }
 
-/// Enumeration of the supported [User Name Formats].
-///
-/// [User Name Formats]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum UserNameFormat {
-    /// [User principal name] (UPN) format is used to specify an Internet-style name, such as UserName@Example.Microsoft.com.
-    ///
-    /// [User principal name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name
-    UserPrincipalName,
-    /// The [down-level logon name] format is used to specify a domain and a user account in that domain, for example, DOMAIN\UserName.
-    ///
-    /// [down-level logon name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name
-    DownLevelLogonName,
+/// An error converting a tagged [`AuthIdentity`] to raw [`AuthIdentityBuffers`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AuthIdentityBuffersError {
+    /// A raw empty-domain buffer cannot distinguish this name from a user principal name.
+    UnrepresentableDomainlessDownLevelLogonName,
 }
 
-/// A username formatted as either UPN or Down-Level Logon Name
+impl std::error::Error for AuthIdentityBuffersError {}
+
+impl fmt::Display for AuthIdentityBuffersError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnrepresentableDomainlessDownLevelLogonName => f.write_str(
+                "a domain-less down-level account containing '@' cannot be represented in raw user/domain buffers",
+            ),
+        }
+    }
+}
+
+/// An opaque, validated user principal name.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Username {
+pub struct UserPrincipalName {
     value: String,
-    format: UserNameFormat,
-    sep_idx: Option<usize>,
+    separator_index: usize,
 }
 
-/// A format-tagged, borrowed view into the components of a [`Username`].
+impl UserPrincipalName {
+    fn new(account_name: &str, suffix: &str) -> Result<Self, UsernameError> {
+        if account_name.is_empty() {
+            return Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::UserPrincipalNameAccount,
+            });
+        }
+        if account_name.contains('\\') {
+            return Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::UserPrincipalNameAccount,
+                delimiter: '\\',
+            });
+        }
+        if suffix.is_empty() {
+            return Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::UserPrincipalNameSuffix,
+            });
+        }
+        for delimiter in ['\\', '@'] {
+            if suffix.contains(delimiter) {
+                return Err(UsernameError::ForbiddenDelimiter {
+                    component: UsernameComponent::UserPrincipalNameSuffix,
+                    delimiter,
+                });
+            }
+        }
+
+        Ok(Self {
+            value: format!("{account_name}@{suffix}"),
+            separator_index: account_name.len(),
+        })
+    }
+
+    /// Returns the account name before the format-defining `@`.
+    pub fn account_name(&self) -> &str {
+        &self.value[..self.separator_index]
+    }
+
+    /// Returns the UPN suffix after the format-defining `@`.
+    pub fn suffix(&self) -> &str {
+        &self.value[self.separator_index + 1..]
+    }
+
+    /// Returns the complete user principal name.
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+/// An opaque, validated down-level logon name.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DownLevelLogonName {
+    value: String,
+    separator_index: Option<usize>,
+}
+
+impl DownLevelLogonName {
+    fn new(account_name: &str, netbios_domain: Option<&str>) -> Result<Self, UsernameError> {
+        if let Some(netbios_domain) = netbios_domain {
+            if netbios_domain.is_empty() {
+                return Err(UsernameError::EmptyComponent {
+                    component: UsernameComponent::NetbiosDomain,
+                });
+            }
+            for delimiter in ['\\', '@'] {
+                if netbios_domain.contains(delimiter) {
+                    return Err(UsernameError::ForbiddenDelimiter {
+                        component: UsernameComponent::NetbiosDomain,
+                        delimiter,
+                    });
+                }
+            }
+        }
+
+        if account_name.is_empty() && netbios_domain.is_some() {
+            return Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::DownLevelAccountName,
+            });
+        }
+        if account_name.contains('\\') {
+            return Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::DownLevelAccountName,
+                delimiter: '\\',
+            });
+        }
+
+        if let Some(netbios_domain) = netbios_domain {
+            Ok(Self {
+                value: format!("{netbios_domain}\\{account_name}"),
+                separator_index: Some(netbios_domain.len()),
+            })
+        } else {
+            Ok(Self {
+                value: account_name.to_owned(),
+                separator_index: None,
+            })
+        }
+    }
+
+    /// Returns the account name after `\`, or the complete value when unqualified.
+    pub fn account_name(&self) -> &str {
+        match self.separator_index {
+            Some(index) => &self.value[index + 1..],
+            None => &self.value,
+        }
+    }
+
+    /// Returns the NetBIOS domain before `\`, or `None` when unqualified.
+    pub fn netbios_domain(&self) -> Option<&str> {
+        self.separator_index.map(|index| &self.value[..index])
+    }
+
+    /// Returns the complete down-level logon name.
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+/// A validated, explicitly tagged Windows username.
 ///
-/// Unlike the (deprecated) [`Username::domain_name`] accessor, each variant only exposes the
-/// components that are actually meaningful for its [`UserNameFormat`]. This makes it impossible to
-/// mistake a UPN suffix for a NetBIOS domain name (or vice versa): the [`UserPrincipalNameParts`]
-/// arm has no "domain" component at all, only a suffix.
-///
-/// Matching is exhaustive over the two [User Name Formats], so callers are forced to handle both.
-///
-/// A `UsernameParts` can only be obtained from [`Username::parts`]; the variant payloads are opaque
-/// (accessor-only, not constructible outside this crate), so a view can never be forged into an
-/// inconsistent state.
-///
-/// [User Name Formats]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum UsernameParts<'a> {
-    /// [User principal name] components, e.g. `account_name@suffix`.
+/// Equality compares the tagged representation. It does not determine whether two names resolve to
+/// the same directory account.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Username {
+    /// A user principal name such as `account@example.com`.
+    UserPrincipalName(UserPrincipalName),
+    /// A down-level logon name such as `DOMAIN\account`, or an unqualified account.
+    DownLevelLogonName(DownLevelLogonName),
+}
+
+impl Username {
+    /// Builds a user principal name from an account name and UPN suffix.
     ///
-    /// [User principal name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name
-    UserPrincipalName(UserPrincipalNameParts<'a>),
-    /// [Down-level logon name] components, e.g. `netbios_domain\account_name`.
+    /// # Errors
     ///
-    /// [Down-level logon name]: https://learn.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name
-    DownLevelLogonName(DownLevelLogonNameParts<'a>),
-}
-
-/// The components of a [user principal name](UsernameParts::UserPrincipalName).
-///
-/// Obtained via [`Username::parts`]; the components are opaque and exposed through accessors only,
-/// so this type can never be constructed with inconsistent fields.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct UserPrincipalNameParts<'a> {
-    account_name: &'a str,
-    suffix: &'a str,
-    upn: &'a str,
-}
-
-impl<'a> UserPrincipalNameParts<'a> {
-    /// The account name, i.e. the part before the `@`.
-    pub fn account_name(&self) -> &'a str {
-        self.account_name
+    /// Returns [`UsernameError::EmptyComponent`] when either component is empty. Returns
+    /// [`UsernameError::ForbiddenDelimiter`] when the account contains `\`, or the suffix contains
+    /// `\` or `@`. This validates representation consistency, not complete Windows account-name validity.
+    pub fn new_upn(account_name: &str, upn_suffix: &str) -> Result<Self, UsernameError> {
+        UserPrincipalName::new(account_name, upn_suffix).map(Self::UserPrincipalName)
     }
 
-    /// The UPN suffix, i.e. the part after the `@`. This is *not* a NetBIOS domain name.
-    pub fn suffix(&self) -> &'a str {
-        self.suffix
-    }
-
-    /// The complete user principal name (`account_name@suffix`), borrowed as-is.
+    /// Builds a down-level logon name from an account name and optional NetBIOS domain.
     ///
-    /// For a UPN, this whole string is what identifies the user (e.g. it is used verbatim as the
-    /// NT-ENTERPRISE client name in Kerberos), unlike a down-level logon name where only
-    /// `account_name` does. Prefer this over reconstructing the string from `account_name`/`suffix`
-    /// or reaching for [`Username::inner`].
-    pub fn upn(&self) -> &'a str {
-        self.upn
-    }
-}
-
-/// The components of a [down-level logon name](UsernameParts::DownLevelLogonName).
-///
-/// Obtained via [`Username::parts`]; the components are opaque and exposed through accessors only,
-/// so this type can never be constructed with inconsistent fields.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct DownLevelLogonNameParts<'a> {
-    account_name: &'a str,
-    netbios_domain: Option<&'a str>,
-}
-
-impl<'a> DownLevelLogonNameParts<'a> {
-    /// The account name, i.e. the part after the `\` (or the whole value when there is no separator).
-    pub fn account_name(&self) -> &'a str {
-        self.account_name
-    }
-
-    /// The NetBIOS domain name, i.e. the part before the `\`, or `None` when the value has no separator.
-    pub fn netbios_domain(&self) -> Option<&'a str> {
-        self.netbios_domain
-    }
-}
-
-impl UsernameParts<'_> {
-    /// Compares two username views for equality, ignoring ASCII case.
+    /// The account name may contain `@`, including when `netbios_domain` is `None`. Such a domain-less
+    /// name is explicitly tagged but cannot be converted to [`AuthIdentityBuffers`] without losing
+    /// that tag.
     ///
-    /// Equality is *format-aware*: a [`UsernameParts::UserPrincipalName`] and a
-    /// [`UsernameParts::DownLevelLogonName`] are never equal, even if their account names and their
-    /// UPN suffix / NetBIOS domain happen to match case-insensitively. Because the format is part of
-    /// the comparison, a UPN suffix is only ever compared against another UPN suffix, and a NetBIOS
-    /// domain only ever against another NetBIOS domain: the two can never be conflated.
-    pub fn eq_ignore_ascii_case(&self, other: &UsernameParts<'_>) -> bool {
+    /// An empty account is allowed only with `None`, as the credential-less SSPI sentinel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsernameError::EmptyComponent`] for an empty supplied domain or a qualified empty
+    /// account. Returns [`UsernameError::ForbiddenDelimiter`] when the account contains `\`, or the
+    /// domain contains `\` or `@`. This validates representation consistency, not complete Windows
+    /// account-name validity.
+    pub fn new_down_level_logon_name(account_name: &str, netbios_domain: Option<&str>) -> Result<Self, UsernameError> {
+        DownLevelLogonName::new(account_name, netbios_domain).map(Self::DownLevelLogonName)
+    }
+
+    /// Parses a combined username spelling using deterministic separator precedence.
+    ///
+    /// A `\` establishes down-level syntax and takes precedence over `@`. Otherwise the last `@`
+    /// establishes UPN syntax. A value with neither delimiter is an unqualified down-level name.
+    /// The empty string is accepted as the credential-less SSPI sentinel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsernameError::EmptyComponent`] for delimiter-bearing forms with an empty component,
+    /// and [`UsernameError::ForbiddenDelimiter`] for additional delimiters forbidden by the selected
+    /// format. This validates representation consistency, not complete Windows account-name validity.
+    pub fn parse(value: &str) -> Result<Self, UsernameError> {
+        if let Some((netbios_domain, account_name)) = value.split_once('\\') {
+            Self::new_down_level_logon_name(account_name, Some(netbios_domain))
+        } else if let Some((account_name, upn_suffix)) = value.rsplit_once('@') {
+            Self::new_upn(account_name, upn_suffix)
+        } else {
+            Self::new_down_level_logon_name(value, None)
+        }
+    }
+
+    /// Returns the complete stored spelling.
+    ///
+    /// This rendering is not injective: an explicitly domain-less down-level account containing `@`
+    /// has the same spelling as a UPN and will parse as a UPN.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::UserPrincipalName(upn) => upn.as_str(),
+            Self::DownLevelLogonName(down_level) => down_level.as_str(),
+        }
+    }
+
+    /// Compares two tagged username representations, ignoring ASCII case within each component.
+    ///
+    /// Different variants compare unequal. This does not determine whether two names resolve to the
+    /// same directory account.
+    pub fn eq_ignore_ascii_case(&self, other: &Username) -> bool {
         match (self, other) {
-            (UsernameParts::UserPrincipalName(lhs), UsernameParts::UserPrincipalName(rhs)) => {
-                // `upn` is fully determined by `account_name` and `suffix`, so it needs no comparison.
-                lhs.account_name.eq_ignore_ascii_case(rhs.account_name) && lhs.suffix.eq_ignore_ascii_case(rhs.suffix)
+            (Self::UserPrincipalName(lhs), Self::UserPrincipalName(rhs)) => {
+                lhs.account_name().eq_ignore_ascii_case(rhs.account_name())
+                    && lhs.suffix().eq_ignore_ascii_case(rhs.suffix())
             }
-            (UsernameParts::DownLevelLogonName(lhs), UsernameParts::DownLevelLogonName(rhs)) => {
-                let domains_equal = match (lhs.netbios_domain, rhs.netbios_domain) {
-                    (Some(lhs_domain), Some(rhs_domain)) => lhs_domain.eq_ignore_ascii_case(rhs_domain),
-                    (None, None) => true,
-                    _ => false,
-                };
-
-                lhs.account_name.eq_ignore_ascii_case(rhs.account_name) && domains_equal
+            (Self::DownLevelLogonName(lhs), Self::DownLevelLogonName(rhs)) => {
+                lhs.account_name().eq_ignore_ascii_case(rhs.account_name())
+                    && match (lhs.netbios_domain(), rhs.netbios_domain()) {
+                        (Some(lhs_domain), Some(rhs_domain)) => lhs_domain.eq_ignore_ascii_case(rhs_domain),
+                        (None, None) => true,
+                        _ => false,
+                    }
             }
-            // Different formats are distinct identities.
             _ => false,
         }
     }
 }
 
-impl Username {
-    /// Builds a user principal name from an account name and an UPN suffix
-    pub fn new_upn(account_name: &str, upn_suffix: &str) -> Result<Self, UsernameError> {
-        // NOTE: AD usernames may contain `@`
-        if account_name.contains(['\\']) {
-            return Err(UsernameError::MixedFormat);
-        }
-
-        if upn_suffix.contains(['\\', '@']) {
-            return Err(UsernameError::MixedFormat);
-        }
-
-        Ok(Self {
-            value: format!("{account_name}@{upn_suffix}"),
-            format: UserNameFormat::UserPrincipalName,
-            sep_idx: Some(account_name.len()),
-        })
-    }
-
-    /// Builds a down-level logon name from an account name and a NetBIOS domain name
-    ///
-    /// The account name may contain `@`: once the down-level format is established, the account
-    /// name is opaque. Windows itself accepts `MicrosoftAccount\user@example.com`, where the
-    /// entire e-mail address *is* the account name (a Microsoft account, not an AD UPN), and
-    /// rejecting the `@` here left such accounts with no representable form at all (#718).
-    pub fn new_down_level_logon_name(account_name: &str, netbios_domain_name: &str) -> Result<Self, UsernameError> {
-        // NOTE: account names may contain `@` (Microsoft accounts, AD names with an embedded `@`)
-        if account_name.contains('\\') || (netbios_domain_name.is_empty() && account_name.contains('@')) {
-            return Err(UsernameError::MixedFormat);
-        }
-
-        if netbios_domain_name.contains(['\\', '@']) {
-            return Err(UsernameError::MixedFormat);
-        }
-
-        // An empty NetBIOS domain means "no domain": represent it accurately as a separator-less
-        // down-level logon name (`netbios_domain == None`) rather than a distinct `Some("")`.
-        if netbios_domain_name.is_empty() {
-            return Ok(Self {
-                value: account_name.to_owned(),
-                format: UserNameFormat::DownLevelLogonName,
-                sep_idx: None,
-            });
-        }
-
-        Ok(Self {
-            value: format!("{netbios_domain_name}\\{account_name}"),
-            format: UserNameFormat::DownLevelLogonName,
-            sep_idx: Some(netbios_domain_name.len()),
-        })
-    }
-
-    /// Attempts to guess the right name format for the account name/domain combo
-    ///
-    /// If no netbios domain name is provided, or if it is an empty string, the username will
-    /// be parsed as either a user principal name or a down-level logon name.
-    ///
-    /// It falls back to a down-level logon name when the format can’t be guessed.
-    pub fn new(account_name: &str, netbios_domain_name: Option<&str>) -> Result<Self, UsernameError> {
-        match netbios_domain_name {
-            Some(netbios_domain_name) if !netbios_domain_name.is_empty() => {
-                Self::new_down_level_logon_name(account_name, netbios_domain_name)
-            }
-            _ => Self::parse(account_name),
-        }
-    }
-
-    /// Parses the value in order to find if the value is a user principal name or a down-level logon name
-    ///
-    /// If there is no `\` or `@` separator, the value is considered to be a down-level logon name with
-    /// an empty NetBIOS domain.
-    ///
-    /// A value containing both separators is a down-level logon name: the `\` takes precedence and
-    /// everything after it is the account name, so `MicrosoftAccount\user@example.com` parses as
-    /// NetBIOS domain `MicrosoftAccount` with account name `user@example.com` — matching how
-    /// Windows itself reads that qualification.
-    pub fn parse(value: &str) -> Result<Self, UsernameError> {
-        match (value.split_once('\\'), value.rsplit_once('@')) {
-            (None, None) => Ok(Self {
-                value: value.to_owned(),
-                format: UserNameFormat::DownLevelLogonName,
-                sep_idx: None,
-            }),
-            (Some((netbios_domain_name, account_name)), _) => {
-                Self::new_down_level_logon_name(account_name, netbios_domain_name)
-            }
-            (_, Some((account_name, upn_suffix))) => Self::new_upn(account_name, upn_suffix),
-        }
-    }
-
-    /// Returns the internal representation, as-is
-    pub fn inner(&self) -> &str {
-        &self.value
-    }
-
-    /// Returns the [`UserNameFormat`] for this username
-    pub fn format(&self) -> UserNameFormat {
-        self.format
-    }
-
-    /// Returns a format-tagged, borrowed view into the components of the username.
-    ///
-    /// Prefer this over [`Username::domain_name`]: matching on the returned [`UsernameParts`]
-    /// forces both user name formats to be handled explicitly and prevents confusing a UPN
-    /// suffix with a NetBIOS domain name.
-    pub fn parts(&self) -> UsernameParts<'_> {
-        match self.format {
-            UserNameFormat::UserPrincipalName => {
-                // A user principal name is always built with a separator (the `@`).
-                let idx = self.sep_idx.expect("a UPN always has an `@` separator");
-                UsernameParts::UserPrincipalName(UserPrincipalNameParts {
-                    account_name: &self.value[..idx],
-                    suffix: &self.value[idx + 1..],
-                    upn: &self.value,
-                })
-            }
-            UserNameFormat::DownLevelLogonName => match self.sep_idx {
-                Some(idx) => UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
-                    account_name: &self.value[idx + 1..],
-                    netbios_domain: Some(&self.value[..idx]),
-                }),
-                None => UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
-                    account_name: &self.value,
-                    netbios_domain: None,
-                }),
-            },
-        }
-    }
-
-    /// May return an UPN suffix or NetBIOS domain name depending on the internal format
-    #[allow(
-        clippy::deprecated_semver,
-        reason = "`<next-version>` placeholder filled in at release time"
-    )]
-    #[deprecated(
-        since = "<next-version>",
-        note = "conflates UPN suffix with NetBIOS domain; match on `Username::parts()` instead — see https://github.com/Devolutions/sspi-rs/issues/708"
-    )]
-    pub fn domain_name(&self) -> Option<&str> {
-        self.sep_idx.map(|idx| match self.format {
-            UserNameFormat::UserPrincipalName => &self.value[idx + 1..],
-            UserNameFormat::DownLevelLogonName => &self.value[..idx],
-        })
-    }
-
-    /// Returns the account name
-    pub fn account_name(&self) -> &str {
-        if let Some(idx) = self.sep_idx {
-            match self.format {
-                UserNameFormat::UserPrincipalName => &self.value[..idx],
-                UserNameFormat::DownLevelLogonName => &self.value[idx + 1..],
-            }
-        } else {
-            &self.value
-        }
-    }
-
-    /// Compares two usernames for equality, ignoring ASCII case.
-    ///
-    /// This is a case-insensitive counterpart to the (case-sensitive) [`PartialEq`] implementation,
-    /// matching Windows' case-insensitive treatment of account and domain names. Usernames of
-    /// different [formats](UserNameFormat) are never equal (see [`UsernameParts::eq_ignore_ascii_case`]).
-    pub fn eq_ignore_ascii_case(&self, other: &Username) -> bool {
-        self.parts().eq_ignore_ascii_case(&other.parts())
+impl fmt::Display for Username {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -426,26 +409,35 @@ impl fmt::Debug for AuthIdentityBuffers {
     }
 }
 
-impl From<AuthIdentity> for AuthIdentityBuffers {
-    fn from(credentials: AuthIdentity) -> Self {
-        let password: &str = credentials.password.as_ref().as_ref();
+impl TryFrom<&AuthIdentity> for AuthIdentityBuffers {
+    type Error = AuthIdentityBuffersError;
 
-        // Encode the username so that it round-trips back to the same format through
-        // `TryFrom<&AuthIdentityBuffers>` (which parses `user` and treats `domain` as a NetBIOS
-        // domain). A UPN is stored whole in `user` with an empty `domain` (parsing recovers the UPN
-        // via its `@`), while a down-level logon name keeps the `(account_name, netbios_domain)` split.
-        let (user, domain) = match credentials.username.parts() {
-            UsernameParts::UserPrincipalName(parts) => (parts.upn(), ""),
-            UsernameParts::DownLevelLogonName(parts) => {
-                (parts.account_name(), parts.netbios_domain().unwrap_or_default())
+    fn try_from(credentials: &AuthIdentity) -> Result<Self, Self::Error> {
+        let password: &str = credentials.password.as_ref().as_ref();
+        let (user, domain) = match &credentials.username {
+            Username::UserPrincipalName(upn) => (upn.as_str(), ""),
+            Username::DownLevelLogonName(down_level) => {
+                let domain = down_level.netbios_domain().unwrap_or_default();
+                if domain.is_empty() && down_level.account_name().contains('@') {
+                    return Err(AuthIdentityBuffersError::UnrepresentableDomainlessDownLevelLogonName);
+                }
+                (down_level.account_name(), domain)
             }
         };
 
-        Self {
+        Ok(Self {
             user: user.into(),
             domain: domain.into(),
             password: ZeroizedUtf16String(password.into()).into(),
-        }
+        })
+    }
+}
+
+impl TryFrom<AuthIdentity> for AuthIdentityBuffers {
+    type Error = AuthIdentityBuffersError;
+
+    fn try_from(credentials: AuthIdentity) -> Result<Self, Self::Error> {
+        Self::try_from(&credentials)
     }
 }
 
@@ -455,13 +447,12 @@ impl TryFrom<&AuthIdentityBuffers> for AuthIdentity {
     fn try_from(credentials_buffers: &AuthIdentityBuffers) -> Result<Self, Self::Error> {
         let account_name = credentials_buffers.user.to_string();
 
-        let domain_name = credentials_buffers
-            .domain
-            .is_empty()
-            .not()
-            .then(|| credentials_buffers.domain.to_string());
-
-        let username = Username::new(&account_name, domain_name.as_deref())?;
+        let username = if credentials_buffers.domain.is_empty() {
+            Username::parse(&account_name)?
+        } else {
+            let domain_name = credentials_buffers.domain.to_string();
+            Username::new_down_level_logon_name(&account_name, Some(&domain_name))?
+        };
         let password = credentials_buffers.password.as_ref().as_ref().to_string().into();
 
         Ok(Self { username, password })
@@ -779,7 +770,7 @@ impl TryFrom<Credentials> for CredentialsBuffers {
 
     fn try_from(value: Credentials) -> Result<Self, Self::Error> {
         Ok(match value {
-            Credentials::AuthIdentity(identity) => Self::AuthIdentity(identity.into()),
+            Credentials::AuthIdentity(identity) => Self::AuthIdentity(identity.try_into()?),
             #[cfg(feature = "scard")]
             Credentials::SmartCard(identity) => Self::SmartCard((*identity).try_into()?),
             Credentials::Keytab(identity) => Self::Keytab(identity),
@@ -792,238 +783,243 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+    use crate::ErrorKind;
 
     #[test]
-    fn username_format_conversion() {
-        proptest!(|(value in "[a-zA-Z0-9.]{1,3}@?\\\\?[a-zA-Z0-9.]{1,3}@?\\\\?[a-zA-Z0-9.]{1,3}")| {
-            let res = Username::parse(&value);
-            prop_assume!(res.is_ok());
-            let initial_username = res.unwrap();
-            assert_eq!(initial_username.inner(), value);
-
-            // The "domain-ish" component, whatever its format-specific meaning is.
-            let domain = match initial_username.parts() {
-                UsernameParts::UserPrincipalName(upn) => Some(upn.suffix()),
-                UsernameParts::DownLevelLogonName(dlln) => dlln.netbios_domain(),
-            };
-
-            if let Some(domain) = domain {
-                let reconstructed_upn = Username::new_upn(initial_username.account_name(), domain).expect("UPN");
-                assert_eq!(reconstructed_upn.account_name(), initial_username.account_name());
-                assert_eq!(
-                    reconstructed_upn.parts(),
-                    UsernameParts::UserPrincipalName(UserPrincipalNameParts {
-                        account_name: initial_username.account_name(),
-                        suffix: domain,
-                        upn: reconstructed_upn.inner(),
-                    })
-                );
-            }
-
-            // With no NetBIOS domain, `Username::new` falls back to `parse`, which reads an `@` as
-            // a UPN separator — only that combination can't reconstruct as a down-level logon name.
-            if domain.is_some() || !initial_username.account_name().contains('@') {
-                let netbios_name = Username::new(initial_username.account_name(), domain).expect("NetBIOS");
-                assert_eq!(netbios_name.format(), UserNameFormat::DownLevelLogonName);
-                assert_eq!(netbios_name.account_name(), initial_username.account_name());
-                let netbios_domain = match netbios_name.parts() {
-                    UsernameParts::DownLevelLogonName(dlln) => dlln.netbios_domain(),
-                    UsernameParts::UserPrincipalName(_) => unreachable!("constructed as a down-level logon name"),
-                };
-                assert_eq!(netbios_domain, domain);
-            }
-        })
-    }
-
-    fn check_round_trip_property(username: &Username) {
-        let round_trip = Username::parse(username.inner()).expect("round-trip parse");
-        assert_eq!(*username, round_trip);
-    }
-
-    #[test]
-    fn upn_round_trip() {
+    fn explicit_upn_has_owned_tagged_components() {
         proptest!(|(account_name in "[a-zA-Z0-9@.]{1,3}", domain_name in "[a-z0-9.]{1,3}")| {
             let username = Username::new_upn(&account_name, &domain_name).expect("UPN");
-
-            assert_eq!(username.account_name(), account_name);
-            assert_eq!(username.format(), UserNameFormat::UserPrincipalName);
-            assert_eq!(
-                username.parts(),
-                UsernameParts::UserPrincipalName(UserPrincipalNameParts {
-                    account_name: &account_name,
-                    suffix: &domain_name,
-                    upn: username.inner(),
-                })
-            );
-
-            check_round_trip_property(&username);
+            let Username::UserPrincipalName(upn) = &username else {
+                panic!("explicit UPN constructor returned a down-level name");
+            };
+            assert_eq!(upn.account_name(), account_name);
+            assert_eq!(upn.suffix(), domain_name);
+            assert_eq!(upn.as_str(), format!("{account_name}@{domain_name}"));
+            assert_eq!(Username::parse(username.as_str()).unwrap(), username);
         })
     }
 
     #[test]
-    fn down_level_logon_name_round_trip() {
-        // The account-name alphabet includes `@`: `DOMAIN\user@example.com` is a valid down-level
-        // logon name (the whole e-mail address is the account name — a Microsoft account, #718).
+    fn explicit_qualified_down_level_name_has_owned_tagged_components() {
         proptest!(|(account_name in "[a-zA-Z0-9@.]{1,3}", domain_name in "[A-Z0-9.]{1,3}")| {
-            let username = Username::new_down_level_logon_name(&account_name, &domain_name).expect("down-level logon name");
-
-            assert_eq!(username.account_name(), account_name);
-            assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
-            assert_eq!(
-                username.parts(),
-                UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
-                    account_name: &account_name,
-                    netbios_domain: Some(&domain_name),
-                })
-            );
-
-            check_round_trip_property(&username);
+            let username =
+                Username::new_down_level_logon_name(&account_name, Some(&domain_name)).expect("down-level name");
+            let Username::DownLevelLogonName(down_level) = &username else {
+                panic!("explicit down-level constructor returned a UPN");
+            };
+            assert_eq!(down_level.account_name(), account_name);
+            assert_eq!(down_level.netbios_domain(), Some(domain_name.as_str()));
+            assert_eq!(down_level.as_str(), format!("{domain_name}\\{account_name}"));
+            assert_eq!(Username::parse(username.as_str()).unwrap(), username);
         })
     }
 
     #[test]
-    fn down_level_logon_name_without_domain_parts() {
-        // When a bare name (no `\` and no `@`) is parsed, it is a down-level logon name with no
-        // NetBIOS domain: the `netbios_domain` field must be `None`.
+    fn bare_name_parses_as_unqualified_down_level_name() {
         proptest!(|(account_name in "[a-zA-Z0-9.]{1,3}")| {
             let username = Username::parse(&account_name).expect("parse");
-
-            assert_eq!(username.account_name(), account_name);
-            assert_eq!(username.format(), UserNameFormat::DownLevelLogonName);
-            assert_eq!(
-                username.parts(),
-                UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
-                    account_name: &account_name,
-                    netbios_domain: None,
-                })
-            );
-
-            check_round_trip_property(&username);
+            let Username::DownLevelLogonName(down_level) = &username else {
+                panic!("bare name parsed as a UPN");
+            };
+            assert_eq!(down_level.account_name(), account_name);
+            assert_eq!(down_level.netbios_domain(), None);
+            assert_eq!(Username::parse(username.as_str()).unwrap(), username);
         })
     }
 
     #[test]
-    fn down_level_logon_name_with_at_requires_a_domain() {
-        // Pins the fix in 2e05ed1 (Copilot's review finding, confirmed by @TheBestTvarynka):
-        // with no NetBIOS domain there is no `\` in the serialized string, so an `@`-bearing
-        // account name came back from an `AuthIdentityBuffers` round trip as a UPN, breaking the
-        // format-preservation invariant. The qualifier is what makes such a name representable.
-        assert_eq!(
-            Username::new_down_level_logon_name("frank@example.com", ""),
-            Err(UsernameError::MixedFormat),
-        );
+    fn parser_uses_backslash_precedence_and_last_at() {
+        let qualified = Username::parse("MicrosoftAccount\\me@example.com").unwrap();
+        let Username::DownLevelLogonName(down_level) = qualified else {
+            panic!("qualified Microsoft account parsed as UPN");
+        };
+        assert_eq!(down_level.account_name(), "me@example.com");
+        assert_eq!(down_level.netbios_domain(), Some("MicrosoftAccount"));
 
-        // Qualified, the same account name is representable and survives the round trip.
-        let qualified =
-            Username::new_down_level_logon_name("frank@example.com", "MicrosoftAccount").expect("qualified");
-        assert_eq!(qualified.account_name(), "frank@example.com");
-        check_round_trip_property(&qualified);
+        let upn = Username::parse("account@department@example.com").unwrap();
+        let Username::UserPrincipalName(upn) = upn else {
+            panic!("UPN parsed as down-level name");
+        };
+        assert_eq!(upn.account_name(), "account@department");
+        assert_eq!(upn.suffix(), "example.com");
     }
 
-    /// #718: a Microsoft account's account name is the entire e-mail address. Every qualified way
-    /// of writing one must parse with the address intact, and the unqualified form keeps its
-    /// (AD-correct) UPN reading.
     #[test]
-    fn microsoft_account_forms_are_representable() {
-        // `MicrosoftAccount\me@example.com` — the qualification Microsoft documents for users.
-        let qualified = Username::parse("MicrosoftAccount\\me@example.com").expect("qualified form");
-        assert_eq!(qualified.format(), UserNameFormat::DownLevelLogonName);
-        assert_eq!(qualified.account_name(), "me@example.com");
+    fn empty_component_semantics_are_explicit() {
+        let empty = Username::parse("").unwrap();
+        assert!(matches!(
+            &empty,
+            Username::DownLevelLogonName(down_level)
+                if down_level.account_name().is_empty() && down_level.netbios_domain().is_none()
+        ));
+        assert_eq!(Username::new_down_level_logon_name("", None).unwrap(), empty);
+
+        for (value, component) in [
+            ("@suffix", UsernameComponent::UserPrincipalNameAccount),
+            ("user@", UsernameComponent::UserPrincipalNameSuffix),
+            ("@", UsernameComponent::UserPrincipalNameAccount),
+            ("\\user", UsernameComponent::NetbiosDomain),
+            ("\\", UsernameComponent::NetbiosDomain),
+            ("DOMAIN\\", UsernameComponent::DownLevelAccountName),
+        ] {
+            assert_eq!(
+                Username::parse(value),
+                Err(UsernameError::EmptyComponent { component }),
+                "{value:?}"
+            );
+        }
+
         assert_eq!(
-            qualified.parts(),
-            UsernameParts::DownLevelLogonName(DownLevelLogonNameParts {
-                account_name: "me@example.com",
-                netbios_domain: Some("MicrosoftAccount"),
+            Username::new_down_level_logon_name("user", Some("")),
+            Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::NetbiosDomain,
             })
         );
-        check_round_trip_property(&qualified);
-
-        // The same identity supplied as separate username + domain fields.
-        let split = Username::new("me@example.com", Some("MicrosoftAccount")).expect("split form");
-        assert_eq!(split, qualified);
-
-        // The unqualified e-mail alone still parses as a UPN: it is indistinguishable from an
-        // AD user principal name, and guessing "Microsoft account" would break AD logons.
-        let bare = Username::parse("me@example.com").expect("bare form");
-        assert_eq!(bare.format(), UserNameFormat::UserPrincipalName);
-        assert_eq!(bare.account_name(), "me");
+        assert_eq!(
+            Username::new_down_level_logon_name("", Some("DOMAIN")),
+            Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::DownLevelAccountName,
+            })
+        );
     }
 
     #[test]
-    fn eq_ignore_ascii_case_matches_within_format() {
-        // UPNs that differ only by ASCII case are equal.
+    fn forbidden_delimiters_identify_the_component() {
+        assert_eq!(
+            Username::new_upn("DOMAIN\\user", "example.com"),
+            Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::UserPrincipalNameAccount,
+                delimiter: '\\',
+            })
+        );
+        assert_eq!(
+            Username::new_upn("user", "example@com"),
+            Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::UserPrincipalNameSuffix,
+                delimiter: '@',
+            })
+        );
+        assert_eq!(
+            Username::new_down_level_logon_name("DOMAIN\\user", None),
+            Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::DownLevelAccountName,
+                delimiter: '\\',
+            })
+        );
+        assert_eq!(
+            Username::new_down_level_logon_name("user", Some("DOMAIN@UPN")),
+            Err(UsernameError::ForbiddenDelimiter {
+                component: UsernameComponent::NetbiosDomain,
+                delimiter: '@',
+            })
+        );
+    }
+
+    #[test]
+    fn ascii_case_comparison_is_structural() {
         let upn = Username::new_upn("Alice", "Example.COM").expect("upn");
         let upn_other_case = Username::new_upn("alice", "example.com").expect("upn");
         assert!(upn.eq_ignore_ascii_case(&upn_other_case));
 
-        // Down-level logon names that differ only by ASCII case are equal.
-        let dlln = Username::new_down_level_logon_name("Bob", "EXAMPLE").expect("dlln");
-        let dlln_other_case = Username::new_down_level_logon_name("bob", "example").expect("dlln");
+        let dlln = Username::new_down_level_logon_name("Bob", Some("EXAMPLE")).expect("dlln");
+        let dlln_other_case = Username::new_down_level_logon_name("bob", Some("example")).expect("dlln");
         assert!(dlln.eq_ignore_ascii_case(&dlln_other_case));
 
-        // Bare down-level logon names (no NetBIOS domain) compare on the account name only.
-        let bare = Username::parse("Carol").expect("parse");
-        let bare_other_case = Username::parse("carol").expect("parse");
-        assert!(bare.eq_ignore_ascii_case(&bare_other_case));
+        let same_rendering_dlln = Username::new_down_level_logon_name("Alice@Example.COM", None).unwrap();
+        assert_eq!(same_rendering_dlln.as_str(), upn.as_str());
+        assert_ne!(same_rendering_dlln, upn);
+        assert!(!same_rendering_dlln.eq_ignore_ascii_case(&upn));
     }
 
     #[test]
-    fn eq_ignore_ascii_case_distinguishes_components_and_formats() {
-        // Different account names are not equal.
-        let alice = Username::new_upn("alice", "example.com").expect("upn");
-        let bob = Username::new_upn("bob", "example.com").expect("upn");
-        assert!(!alice.eq_ignore_ascii_case(&bob));
-
-        // A present NetBIOS domain never equals an absent one.
-        let with_domain = Username::new_down_level_logon_name("alice", "EXAMPLE").expect("dlln");
-        let without_domain = Username::parse("alice").expect("parse");
-        assert!(!with_domain.eq_ignore_ascii_case(&without_domain));
-
-        // A UPN and a down-level logon name are distinct identities even with matching components:
-        // the UPN suffix must never be conflated with the NetBIOS domain across formats.
-        let upn = Username::new_upn("alice", "example").expect("upn");
-        let dlln = Username::new_down_level_logon_name("alice", "example").expect("dlln");
-        assert!(!upn.eq_ignore_ascii_case(&dlln));
-    }
-
-    #[test]
-    fn auth_identity_buffers_round_trip_preserves_format() {
-        // Converting to `AuthIdentityBuffers` and back must preserve the user name format: a UPN
-        // must not silently degrade into a down-level logon name.
+    fn representable_auth_identity_buffers_round_trip_structurally() {
         for username in [
             Username::new_upn("alice", "example.com").expect("upn"),
             Username::new_upn("bob@dept", "example.com").expect("upn with @ in account name"),
-            Username::new_down_level_logon_name("carol", "EXAMPLE").expect("dlln"),
-            // An empty NetBIOS domain is normalized to a separator-less down-level logon name.
-            Username::new_down_level_logon_name("erin", "").expect("dlln without domain"),
+            Username::new_down_level_logon_name("carol@example.com", Some("MicrosoftAccount")).expect("dlln"),
+            Username::new_down_level_logon_name("erin", None).expect("dlln without domain"),
             Username::parse("dave").expect("bare name"),
+            Username::parse("").expect("empty sentinel"),
         ] {
             let identity = AuthIdentity {
                 username: username.clone(),
                 password: String::new().into(),
             };
-
-            let buffers = AuthIdentityBuffers::from(identity);
+            let buffers = AuthIdentityBuffers::try_from(&identity).expect("forward conversion");
             let round_trip = AuthIdentity::try_from(&buffers).expect("round-trip");
-
             assert_eq!(round_trip.username, username);
-            assert_eq!(round_trip.username.format(), username.format());
         }
     }
 
     #[test]
-    fn empty_netbios_domain_is_normalized_to_no_domain() {
-        // An empty NetBIOS domain means "no domain": it must not produce a distinct `Some("")` view
-        // that would compare unequal to a separator-less down-level logon name.
-        let empty_domain = Username::new_down_level_logon_name("alice", "").expect("dlln without domain");
-        let bare = Username::parse("alice").expect("parse");
-
-        assert_eq!(empty_domain, bare);
-        assert_eq!(empty_domain.inner(), "alice");
+    fn domainless_down_level_at_is_explicit_but_not_buffer_representable() {
+        let username = Username::new_down_level_logon_name("me@example.com", None).unwrap();
+        assert_eq!(username.as_str(), "me@example.com");
         assert!(matches!(
-            empty_domain.parts(),
-            UsernameParts::DownLevelLogonName(dlln) if dlln.netbios_domain().is_none()
+            username,
+            Username::DownLevelLogonName(ref down_level)
+                if down_level.account_name() == "me@example.com" && down_level.netbios_domain().is_none()
         ));
-        assert!(empty_domain.eq_ignore_ascii_case(&bare));
+        assert!(matches!(
+            Username::parse(username.as_str()).unwrap(),
+            Username::UserPrincipalName(_)
+        ));
+
+        let identity = AuthIdentity {
+            username,
+            password: String::new().into(),
+        };
+        assert_eq!(
+            AuthIdentityBuffers::try_from(&identity),
+            Err(AuthIdentityBuffersError::UnrepresentableDomainlessDownLevelLogonName)
+        );
+        assert_eq!(
+            AuthIdentityBuffers::try_from(identity),
+            Err(AuthIdentityBuffersError::UnrepresentableDomainlessDownLevelLogonName)
+        );
+    }
+
+    #[test]
+    fn raw_buffers_use_deterministic_username_interpretation() {
+        let raw_upn = AuthIdentityBuffers::from_utf8("me@example.com", "", "");
+        assert!(matches!(
+            AuthIdentity::try_from(&raw_upn).unwrap().username,
+            Username::UserPrincipalName(_)
+        ));
+
+        let raw_dlln = AuthIdentityBuffers::from_utf8("me@example.com", "MicrosoftAccount", "");
+        assert!(matches!(
+            AuthIdentity::try_from(&raw_dlln).unwrap().username,
+            Username::DownLevelLogonName(ref down_level)
+                if down_level.account_name() == "me@example.com"
+                    && down_level.netbios_domain() == Some("MicrosoftAccount")
+        ));
+
+        let empty = AuthIdentity::try_from(&AuthIdentityBuffers::default()).unwrap();
+        assert!(matches!(
+            empty.username,
+            Username::DownLevelLogonName(ref down_level)
+                if down_level.account_name().is_empty() && down_level.netbios_domain().is_none()
+        ));
+
+        let malformed = AuthIdentityBuffers::from_utf8("", "DOMAIN", "");
+        assert_eq!(
+            AuthIdentity::try_from(&malformed),
+            Err(UsernameError::EmptyComponent {
+                component: UsernameComponent::DownLevelAccountName,
+            })
+        );
+    }
+
+    #[test]
+    fn username_boundary_errors_map_to_invalid_parameter() {
+        let syntax_error: Error = UsernameError::EmptyComponent {
+            component: UsernameComponent::UserPrincipalNameSuffix,
+        }
+        .into();
+        assert_eq!(syntax_error.error_type, ErrorKind::InvalidParameter);
+
+        let buffer_error: Error = AuthIdentityBuffersError::UnrepresentableDomainlessDownLevelLogonName.into();
+        assert_eq!(buffer_error.error_type, ErrorKind::InvalidParameter);
     }
 }

--- a/src/credssp/ts_request/test.rs
+++ b/src/credssp/ts_request/test.rs
@@ -202,40 +202,44 @@ static AUTH_IDENTITY_ONE_SYMBOL_USER_AND_PASSWORD: LazyLock<CredentialsBuffers> 
             username: Username::parse("a").unwrap(),
             password: String::from("1").into(),
         }
-        .into(),
+        .try_into()
+        .unwrap(),
     )
 });
 
 static AUTH_IDENTITY_STRONG_USERNAME_AND_PASSWORD: LazyLock<CredentialsBuffers> = LazyLock::new(|| {
     CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: Username::new("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890", None).unwrap(),
+            username: Username::parse("QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890").unwrap(),
             password: String::from(
                 "@#$%^&*()_+1234567890-=QWERTYUIOP{}qwertyuiop[]asdfghjkl;ASDFGHJKL:\\\"|zxcvbnm,.ZXCVBNM<>?",
             )
             .into(),
         }
-        .into(),
+        .try_into()
+        .unwrap(),
     )
 });
 
 static AUTH_IDENTITY_SIMPLE_WITH_USERNAME_AND_DOMAIN_AND_PASSWORD: LazyLock<CredentialsBuffers> = LazyLock::new(|| {
     CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: Username::new("Username", Some("Domain")).unwrap(),
+            username: Username::new_down_level_logon_name("Username", Some("Domain")).unwrap(),
             password: String::from("Password").into(),
         }
-        .into(),
+        .try_into()
+        .unwrap(),
     )
 });
 
 static AUTH_IDENTITY_WITH_RESTRICTED_ADMIN_MODE_REQUIRED: LazyLock<CredentialsBuffers> = LazyLock::new(|| {
     CredentialsBuffers::AuthIdentity(
         AuthIdentity {
-            username: Username::new("", Some("")).unwrap(),
+            username: Username::new_down_level_logon_name("", None).unwrap(),
             password: String::from("").into(),
         }
-        .into(),
+        .try_into()
+        .unwrap(),
     )
 });
 

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -25,8 +25,11 @@ use self::generators::{
     GenerateAuthenticatorOptions, GenerateKeytabPaDataOptions, GenerateTgsReqOptions, GssFlags, generate_ap_rep,
     generate_ap_req, generate_as_req_kdc_body, generate_authenticator, generate_tgs_req,
 };
+#[cfg(feature = "scard")]
+use self::principal::get_client_principal_name_type;
 use self::principal::{
-    ClientPrincipalName, get_client_principal_name, get_client_principal_name_type, get_client_principal_realm,
+    ClientPrincipalName, get_client_principal_name, get_client_principal_name_from_auth_identity,
+    get_client_principal_realm,
 };
 use crate::channel_bindings::ChannelBindings;
 use crate::generator::YieldPointLocal;
@@ -145,14 +148,11 @@ pub async fn initialize_security_context<'a>(
 
             let (username, password, realm, cname_type) = match credentials {
                 CredentialsBuffers::AuthIdentity(auth_identity) => {
-                    let username = auth_identity.user.to_string();
-                    let domain = auth_identity.domain.to_string();
+                    let principal = get_client_principal_name_from_auth_identity(auth_identity)?;
+                    let realm = get_client_principal_realm(&principal.name, &principal.realm_domain);
                     let password = auth_identity.password.as_ref().as_ref().to_string();
 
-                    let realm = get_client_principal_realm(&username, &domain);
-                    let cname_type = get_client_principal_name_type(&username, &domain);
-
-                    (username, password, realm, cname_type)
+                    (principal.name, password, realm, principal.name_type)
                 }
                 #[cfg(feature = "scard")]
                 CredentialsBuffers::SmartCard(smart_card) => {

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use picky_krb::constants::types::{NT_ENTERPRISE, NT_PRINCIPAL};
 
-use crate::Username;
 use crate::krb::Krb5Conf;
+use crate::{AuthIdentity, AuthIdentityBuffers, Result, Username};
 
 /// [MS-KILE] 3.3.5.6.1 Client Principal Lookup
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c
@@ -41,6 +41,13 @@ pub struct ClientPrincipalName<'a> {
     pub name_type: u8,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct OwnedClientPrincipalName {
+    pub name: String,
+    pub realm_domain: String,
+    pub name_type: u8,
+}
+
 /// Derives the [`ClientPrincipalName`] for a principal from its user name format.
 pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_> {
     match username {
@@ -55,6 +62,19 @@ pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_>
             name_type: NT_PRINCIPAL,
         },
     }
+}
+
+pub(crate) fn get_client_principal_name_from_auth_identity(
+    auth_identity: &AuthIdentityBuffers,
+) -> Result<OwnedClientPrincipalName> {
+    let auth_identity = AuthIdentity::try_from(auth_identity)?;
+    let principal = get_client_principal_name(&auth_identity.username);
+
+    Ok(OwnedClientPrincipalName {
+        name: principal.name.to_owned(),
+        realm_domain: principal.realm_domain.to_owned(),
+        name_type: principal.name_type,
+    })
 }
 
 // FIXME: like `get_client_principal_name_type`, this should take a `&Username`
@@ -133,6 +153,7 @@ fn matches_domain(domain: &str, mapping_domain: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{AuthIdentity, AuthIdentityBuffers};
 
     const KRB5_CONFIG_FILE_PATH: &str = "test_assets/krb5.conf";
 
@@ -152,6 +173,34 @@ mod tests {
         assert_eq!(cname.name, "user");
         assert_eq!(cname.realm_domain, "EXAMPLE");
         assert_eq!(cname.name_type, NT_PRINCIPAL);
+    }
+
+    #[test]
+    fn auth_identity_down_level_account_with_at_is_principal() {
+        let identity = AuthIdentity {
+            username: Username::new_down_level_logon_name("alice@dept", Some("EXAMPLE")).unwrap(),
+            password: String::new().into(),
+        };
+        let buffers = AuthIdentityBuffers::try_from(&identity).unwrap();
+        let cname = get_client_principal_name_from_auth_identity(&buffers).unwrap();
+
+        assert_eq!(cname.name, "alice@dept");
+        assert_eq!(cname.realm_domain, "EXAMPLE");
+        assert_eq!(cname.name_type, NT_PRINCIPAL);
+    }
+
+    #[test]
+    fn auth_identity_upn_is_enterprise() {
+        let identity = AuthIdentity {
+            username: Username::new_upn("alice", "dept.example.com").unwrap(),
+            password: String::new().into(),
+        };
+        let buffers = AuthIdentityBuffers::try_from(&identity).unwrap();
+        let cname = get_client_principal_name_from_auth_identity(&buffers).unwrap();
+
+        assert_eq!(cname.name, "alice@dept.example.com");
+        assert_eq!(cname.realm_domain, "dept.example.com");
+        assert_eq!(cname.name_type, NT_ENTERPRISE);
     }
 
     #[test]

--- a/src/kerberos/client/principal.rs
+++ b/src/kerberos/client/principal.rs
@@ -5,16 +5,16 @@ use std::path::Path;
 
 use picky_krb::constants::types::{NT_ENTERPRISE, NT_PRINCIPAL};
 
+use crate::Username;
 use crate::krb::Krb5Conf;
-use crate::{Username, UsernameParts};
 
 /// [MS-KILE] 3.3.5.6.1 Client Principal Lookup
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/6435d3fb-8cf6-4df5-a156-1277690ed59c
 //
 // FIXME: this should take a `&Username` instead of two `&str` parameters. It currently sniffs for an
 // `@` to guess the name type (and ignores `_domain` entirely), which is exactly the lossy heuristic
-// `Username`/`UsernameParts` exist to replace: the name type can be read off the user name format
-// directly (see `get_client_principal_name`). Once the deprecated string-based callers are gone (#708),
+// `Username` exists to replace: the name type can be read off the user name format directly (see
+// `get_client_principal_name`). Once the deprecated string-based callers are gone (#708),
 // fold this into `get_client_principal_name`.
 pub fn get_client_principal_name_type(username: &str, _domain: &str) -> u8 {
     if username.contains('@') {
@@ -27,8 +27,8 @@ pub fn get_client_principal_name_type(username: &str, _domain: &str) -> u8 {
 /// The Kerberos client name (cname) derived from a [`Username`], along with the pieces needed to
 /// build the AS-REQ.
 ///
-/// This centralizes the mapping from a [`UserNameFormat`](crate::UserNameFormat) to a Kerberos
-/// principal name type: it reads the name type off the username format explicitly instead of
+/// This centralizes the mapping from a [`Username`] variant to a Kerberos principal name type:
+/// it reads the name type off the username format explicitly instead of
 /// sniffing for an `@`, so a UPN principal is an NT-ENTERPRISE name (whose full value is the client
 /// name) and a down-level logon name is an NT-PRINCIPAL name identified by its account name alone.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -43,25 +43,25 @@ pub struct ClientPrincipalName<'a> {
 
 /// Derives the [`ClientPrincipalName`] for a principal from its user name format.
 pub fn get_client_principal_name(username: &Username) -> ClientPrincipalName<'_> {
-    match username.parts() {
-        UsernameParts::UserPrincipalName(parts) => ClientPrincipalName {
-            name: parts.upn(),
-            realm_domain: parts.suffix(),
+    match username {
+        Username::UserPrincipalName(upn) => ClientPrincipalName {
+            name: upn.as_str(),
+            realm_domain: upn.suffix(),
             name_type: NT_ENTERPRISE,
         },
-        UsernameParts::DownLevelLogonName(parts) => ClientPrincipalName {
-            name: parts.account_name(),
-            realm_domain: parts.netbios_domain().unwrap_or_default(),
+        Username::DownLevelLogonName(down_level) => ClientPrincipalName {
+            name: down_level.account_name(),
+            realm_domain: down_level.netbios_domain().unwrap_or_default(),
             name_type: NT_PRINCIPAL,
         },
     }
 }
 
-// FIXME: like `get_client_principal_name_type`, this should take a `&Username` (or a `UsernameParts`)
+// FIXME: like `get_client_principal_name_type`, this should take a `&Username`
 // instead of two `&str` parameters. `get_client_principal_realm_impl` re-derives the suffix by
-// splitting on `@` to reconcile the `username`/`domain` pair, which duplicates the parsing
-// `Username::parts()` already does. Migrating callers off the raw-string form (#708) would
-// let this take the parsed username directly and drop the ad-hoc split.
+// splitting on `@` to reconcile the `username`/`domain` pair, which duplicates `Username::parse`.
+// Migrating callers off the raw-string form (#708) would let this take the parsed username directly
+// and drop the ad-hoc split.
 pub fn get_client_principal_realm(username: &str, domain: &str) -> String {
     // https://web.mit.edu/kerberos/krb5-current/doc/user/user_config/kerberos.html#environment-variables
 

--- a/src/kerberos/server/as_exchange.rs
+++ b/src/kerberos/server/as_exchange.rs
@@ -7,7 +7,7 @@ use rand_core::{Rng as _, SeedableRng as _};
 use crate::generator::YieldPointLocal;
 use crate::kerberos::client::extractors::extract_encryption_params_from_as_rep;
 use crate::kerberos::client::generators::{GenerateAsPaDataOptions, GenerateAsReqOptions, generate_as_req_kdc_body};
-use crate::kerberos::client::principal::{get_client_principal_name_type, get_client_principal_realm};
+use crate::kerberos::client::principal::{get_client_principal_name_from_auth_identity, get_client_principal_realm};
 use crate::kerberos::pa_datas::{AsRepSessionKeyExtractor, AsReqPaDataOptions};
 use crate::kerberos::{TGT_SERVICE_NAME, client};
 use crate::{ClientRequestFlags, CredentialsBuffers, Error, ErrorKind, Kerberos, Result};
@@ -43,14 +43,11 @@ pub(crate) async fn request_tgt(
 
     let (username, password, realm, cname_type) = match credentials {
         CredentialsBuffers::AuthIdentity(auth_identity) => {
-            let username = auth_identity.user.to_string();
-            let domain = auth_identity.domain.to_string();
+            let principal = get_client_principal_name_from_auth_identity(auth_identity)?;
+            let realm = get_client_principal_realm(&principal.name, &principal.realm_domain);
             let password = auth_identity.password.as_ref().as_ref().to_string();
 
-            let realm = get_client_principal_realm(&username, &domain);
-            let cname_type = get_client_principal_name_type(&username, &domain);
-
-            (username, password, realm, cname_type)
+            (principal.name, password, realm, principal.name_type)
         }
         #[cfg(feature = "scard")]
         CredentialsBuffers::SmartCard(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ use utils::map_keb_error_code_to_sspi_error;
 pub use utils::modpow;
 
 pub use self::auth_identity::{
-    AuthIdentity, AuthIdentityBuffers, Credentials, CredentialsBuffers, DownLevelLogonNameParts, KeytabIdentity,
-    UserNameFormat, UserPrincipalNameParts, Username, UsernameParts,
+    AuthIdentity, AuthIdentityBuffers, AuthIdentityBuffersError, Credentials, CredentialsBuffers, DownLevelLogonName,
+    KeytabIdentity, UserPrincipalName, Username, UsernameComponent, UsernameError,
 };
 #[cfg(feature = "scard")]
 pub use self::auth_identity::{CertificateRaw, SmartCardIdentity, SmartCardIdentityBuffers, SmartCardType};
@@ -289,7 +289,10 @@ where
     /// let mut ntlm = sspi::Ntlm::new();
     ///
     /// let identity = sspi::AuthIdentity {
-    ///     username: Username::new(&whoami::username().unwrap(), Some(&whoami::hostname().unwrap())).unwrap(),
+    ///     username: Username::new_down_level_logon_name(
+    ///         &whoami::username().unwrap(),
+    ///         Some(&whoami::hostname().unwrap()),
+    ///     ).unwrap(),
     ///     password: String::from("password").into(),
     /// };
     ///
@@ -1010,8 +1013,13 @@ where
     ///     .execute(&mut ntlm).unwrap();
     ///
     /// let names = ntlm.query_context_names().unwrap();
-    /// println!("Username: {:?}", names.username.account_name());
-    /// println!("Parts: {:?}", names.username.parts());
+    /// println!("Username: {}", names.username.as_str());
+    /// match names.username {
+    ///     Username::UserPrincipalName(upn) => println!("UPN suffix: {}", upn.suffix()),
+    ///     Username::DownLevelLogonName(down_level) => {
+    ///         println!("NetBIOS domain: {:?}", down_level.netbios_domain())
+    ///     }
+    /// }
     /// ```
     ///
     /// # MSDN
@@ -2247,9 +2255,15 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<auth_identity::UsernameError> for Error {
-    fn from(value: auth_identity::UsernameError) -> Self {
-        Error::new(ErrorKind::UnknownCredentials, value)
+impl From<UsernameError> for Error {
+    fn from(value: UsernameError) -> Self {
+        Error::new(ErrorKind::InvalidParameter, value)
+    }
+}
+
+impl From<AuthIdentityBuffersError> for Error {
+    fn from(value: AuthIdentityBuffersError) -> Self {
+        Error::new(ErrorKind::InvalidParameter, value)
     }
 }
 

--- a/src/negotiate/client.rs
+++ b/src/negotiate/client.rs
@@ -52,12 +52,9 @@ pub(crate) async fn initialize_security_context<'a>(
     if let Some(Some(CredentialsBuffers::AuthIdentity(identity))) = builder.credentials_handle {
         let auth_identity =
             AuthIdentity::try_from(&*identity).map_err(|e| Error::new(ErrorKind::InvalidParameter, e))?;
-        let account_name = auth_identity.username.account_name();
-        // `realm_domain` is the per-format "authority" (UPN suffix or NetBIOS domain) used purely
-        // as a best-effort realm/Azure-AD hint for protocol negotiation, not as an identity.
-        let domain_name = get_client_principal_name(&auth_identity.username).realm_domain;
-        negotiate.negotiate_protocol(account_name, domain_name)?;
-        negotiate.auth_identity = Some(CredentialsBuffers::AuthIdentity(auth_identity.into()));
+        let principal = get_client_principal_name(&auth_identity.username);
+        negotiate.negotiate_protocol(principal.name, principal.realm_domain)?;
+        negotiate.auth_identity = Some(CredentialsBuffers::AuthIdentity(identity.clone()));
     }
 
     #[cfg(feature = "scard")]

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -322,12 +322,8 @@ impl Negotiate {
             .filter(|auth_data| {
                 trace!("Comparing usernames: {:?} with {:?}", auth_data.username, username);
 
-                // Usernames match only when they share the same format and the same components.
-                // `eq_ignore_ascii_case` is format-aware, so it is safe to fold the UPN suffix and the
-                // NetBIOS domain into a single "domain" comparison here: a UPN and a down-level logon
-                // name are distinct identities and never compare equal, which means the qualifier being
-                // compared always has one unambiguous meaning (a UPN suffix is only ever matched against
-                // a UPN suffix, a NetBIOS domain only ever against a NetBIOS domain).
+                // This compares tagged representations, not canonical directory identities. A UPN and
+                // a down-level name compare unequal, so suffixes and NetBIOS domains are never conflated.
                 auth_data.username.eq_ignore_ascii_case(&username)
             })
             .cloned()
@@ -794,11 +790,8 @@ impl SspiImpl for Negotiate {
         }
 
         if let Some(Credentials::AuthIdentity(identity)) = builder.auth_data {
-            let account_name = identity.username.account_name();
-            // `realm_domain` is the per-format "authority" (UPN suffix or NetBIOS domain) used purely
-            // as a best-effort realm/Azure-AD hint for protocol negotiation, not as an identity.
-            let domain_name = get_client_principal_name(&identity.username).realm_domain;
-            self.negotiate_protocol(account_name, domain_name)?;
+            let principal = get_client_principal_name(&identity.username);
+            self.negotiate_protocol(principal.name, principal.realm_domain)?;
         }
 
         self.auth_identity = builder

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -612,7 +612,7 @@ impl<'a> Negotiate {
 impl SspiEx for Negotiate {
     #[instrument(ret, level = "debug", fields(protocol = self.protocol.protocol_name()), skip_all)]
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) -> Result<()> {
-        self.auth_identity = Some(identity.clone().try_into().unwrap());
+        let auth_identity = identity.clone().try_into()?;
 
         match &mut self.protocol {
             NegotiatedProtocol::Pku2u(pku2u) => {
@@ -632,25 +632,28 @@ impl SspiEx for Negotiate {
                     )
                 })?)
             }
-        }
+        }?;
+
+        self.auth_identity = Some(auth_identity);
+
+        Ok(())
     }
 
     fn custom_set_auth_identities(&mut self, identities: Vec<Self::AuthenticationData>) -> Result<()> {
-        if let Some(first) = identities.first() {
-            self.auth_identity = Some(first.clone().try_into().map_err(|_| {
-                Error::new(
-                    ErrorKind::IncompleteCredentials,
-                    "provided credentials are not password-based",
-                )
-            })?);
-        }
-
         match &mut self.protocol {
             NegotiatedProtocol::Ntlm(ntlm) => {
+                let auth_identity = identities
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| Error::new(ErrorKind::NoCredentials, "no credentials provided"))?
+                    .try_into()?;
                 // NOTE: non-AuthIdentity credentials (e.g. SmartCard) are silently
                 // dropped here. Multi-credential only applies to password-based auth.
                 let auth_identities: Vec<_> = identities.into_iter().filter_map(|c| c.auth_identity()).collect();
-                ntlm.custom_set_auth_identities(auth_identities)
+                ntlm.custom_set_auth_identities(auth_identities)?;
+                self.auth_identity = Some(auth_identity);
+
+                Ok(())
             }
             _ => match identities.into_iter().next() {
                 Some(identity) => self.custom_set_auth_identity(identity),
@@ -880,5 +883,28 @@ impl<'a> Negotiate {
                 "cannot change password for this protocol",
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_set_auth_identity_rejects_unrepresentable_username_without_panicking() {
+        let config = NegotiateConfig::from_protocol_config(Box::<NtlmConfig>::default(), "client".to_owned());
+        let mut negotiate = Negotiate::new_client(config).expect("negotiate client");
+        let identity = AuthIdentity {
+            username: crate::Username::new_down_level_logon_name("alice@example.com", None)
+                .expect("domain-less down-level name"),
+            password: "password".to_owned().into(),
+        };
+
+        let error = negotiate
+            .custom_set_auth_identity(Credentials::AuthIdentity(identity))
+            .expect_err("raw buffers cannot preserve this username format");
+
+        assert_eq!(error.error_type, ErrorKind::InvalidParameter);
+        assert!(negotiate.auth_identity.is_none());
     }
 }

--- a/src/negotiate/server.rs
+++ b/src/negotiate/server.rs
@@ -163,7 +163,7 @@ pub(crate) async fn accept_security_context(
                     // We should skip `mechListMIC` exchange when the client tries guest logon.
                     let ContextNames { username } = negotiate.protocol.query_context_names()?;
 
-                    if !username.inner().eq_ignore_ascii_case(GUEST_USERNAME) {
+                    if !username.as_str().eq_ignore_ascii_case(GUEST_USERNAME) {
                         return Err(Error::new(
                             ErrorKind::InvalidToken,
                             "the client skipped `mechListMIC` exchange, but it is required for non-guest logon",

--- a/src/ntlm/messages/computations/test.rs
+++ b/src/ntlm/messages/computations/test.rs
@@ -221,10 +221,11 @@ fn compute_ntlmv2_hash_password_is_less_than_hash_len_offset() {
 #[test]
 fn compute_ntlmv2_hash_password_local_logon() {
     let identity = AuthIdentity {
-        username: Username::new("username", Some("win7")).unwrap(),
+        username: Username::new_down_level_logon_name("username", Some("win7")).unwrap(),
         password: String::from("password").into(),
     }
-    .into();
+    .try_into()
+    .unwrap();
 
     let expected = [
         0xef, 0xc2, 0xc0, 0x9f, 0x06, 0x11, 0x3d, 0x71, 0x08, 0xd0, 0xd2, 0x29, 0xfa, 0x4d, 0xe6, 0x98,
@@ -236,10 +237,11 @@ fn compute_ntlmv2_hash_password_local_logon() {
 #[test]
 fn compute_ntlmv2_hash_password_domain_logon() {
     let identity = AuthIdentity {
-        username: Username::new("Administrator", Some("AWAKECODING")).unwrap(),
+        username: Username::new_down_level_logon_name("Administrator", Some("AWAKECODING")).unwrap(),
         password: String::from("Password123!").into(),
     }
-    .into();
+    .try_into()
+    .unwrap();
 
     let expected = [
         0xf7, 0x46, 0x48, 0xaa, 0x78, 0x78, 0x2e, 0x92, 0x0f, 0x92, 0x9a, 0xed, 0x7f, 0x1d, 0xd5, 0x23,
@@ -251,10 +253,11 @@ fn compute_ntlmv2_hash_password_domain_logon() {
 #[test]
 fn compute_ntlmv2_hash_works_on_empty_password() {
     let identity = AuthIdentity {
-        username: Username::new("Administrator", Some("AWAKECODING")).unwrap(),
+        username: Username::new_down_level_logon_name("Administrator", Some("AWAKECODING")).unwrap(),
         password: String::new().into(),
     }
-    .into();
+    .try_into()
+    .unwrap();
 
     let expected = [
         0xa0, 0x84, 0x29, 0x48, 0xa6, 0xb9, 0xac, 0xa7, 0x6c, 0xf5, 0x54, 0xdb, 0x5e, 0xc3, 0x17, 0x76,

--- a/src/ntlm/messages/test.rs
+++ b/src/ntlm/messages/test.rs
@@ -122,8 +122,9 @@ pub(crate) static LOCAL_CHALLENGE_MESSAGE: LazyLock<[u8; LOCAL_CHALLENGE_MESSAGE
 
 pub(crate) static TEST_CREDENTIALS: LazyLock<AuthIdentityBuffers> = LazyLock::new(|| {
     AuthIdentity {
-        username: Username::new("User", Some("Domain")).unwrap(),
+        username: Username::new_down_level_logon_name("User", Some("Domain")).unwrap(),
         password: String::from("Password").into(),
     }
-    .into()
+    .try_into()
+    .unwrap()
 });

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -785,24 +785,24 @@ impl SspiEx for Ntlm {
             return Err(Error::new(ErrorKind::NoCredentials, "no credentials provided"));
         }
 
+        let allowed_identities = identities
+            .iter()
+            .map(AuthIdentityBuffers::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let first_identity = &allowed_identities[0];
+
         // Set identity from the first candidate (for wire user/domain
         // during complete_authenticate), without going through
         // custom_set_auth_identity which would also set allowed_identities.
         if let Some(credentials) = &mut self.identity {
             if credentials.password.as_ref().as_ref().is_empty() {
-                let identity = AuthIdentityBuffers::try_from(&identities[0])?;
-                credentials.password = identity.password;
+                credentials.password = first_identity.password.clone();
             }
         } else {
-            self.identity = Some(AuthIdentityBuffers::try_from(&identities[0])?);
+            self.identity = Some(first_identity.clone());
         }
 
-        self.allowed_identities = Some(
-            identities
-                .iter()
-                .map(AuthIdentityBuffers::try_from)
-                .collect::<Result<_, _>>()?,
-        );
+        self.allowed_identities = Some(allowed_identities);
 
         Ok(())
     }

--- a/src/ntlm/mod.rs
+++ b/src/ntlm/mod.rs
@@ -334,7 +334,7 @@ impl SspiImpl for Ntlm {
             ));
         }
 
-        self.identity = builder.auth_data.cloned().map(AuthIdentityBuffers::from);
+        self.identity = builder.auth_data.map(AuthIdentityBuffers::try_from).transpose()?;
 
         Ok(AcquireCredentialsHandleResult {
             credentials_handle: self.identity.clone(),
@@ -767,11 +767,11 @@ impl SspiEx for Ntlm {
         // and read username/domain from it. In this case, we only update the password.
         if let Some(credentials) = &mut self.identity {
             if credentials.password.as_ref().as_ref().is_empty() {
-                let identity: AuthIdentityBuffers = identity.into();
+                let identity = AuthIdentityBuffers::try_from(&identity)?;
                 credentials.password = identity.password;
             }
         } else {
-            self.identity = Some(identity.into());
+            self.identity = Some(identity.try_into()?);
         }
 
         self.allowed_identities = self.identity.as_ref().map(|id| vec![id.clone()]);
@@ -790,14 +790,19 @@ impl SspiEx for Ntlm {
         // custom_set_auth_identity which would also set allowed_identities.
         if let Some(credentials) = &mut self.identity {
             if credentials.password.as_ref().as_ref().is_empty() {
-                let identity: AuthIdentityBuffers = identities[0].clone().into();
+                let identity = AuthIdentityBuffers::try_from(&identities[0])?;
                 credentials.password = identity.password;
             }
         } else {
-            self.identity = Some(identities[0].clone().into());
+            self.identity = Some(AuthIdentityBuffers::try_from(&identities[0])?);
         }
 
-        self.allowed_identities = Some(identities.into_iter().map(AuthIdentityBuffers::from).collect());
+        self.allowed_identities = Some(
+            identities
+                .iter()
+                .map(AuthIdentityBuffers::try_from)
+                .collect::<Result<_, _>>()?,
+        );
 
         Ok(())
     }

--- a/src/ntlm/test.rs
+++ b/src/ntlm/test.rs
@@ -27,6 +27,27 @@ pub(super) const SIGNATURE_FOR_TEST_DATA: [u8; 16] = [
 ];
 
 #[test]
+fn custom_set_auth_identities_is_atomic_when_conversion_fails() {
+    let mut context = Ntlm::new();
+    let valid = AuthIdentity {
+        username: Username::parse("alice").expect("valid username"),
+        password: "password".to_owned().into(),
+    };
+    let unrepresentable = AuthIdentity {
+        username: Username::new_down_level_logon_name("alice@example.com", None).expect("domain-less down-level name"),
+        password: "password".to_owned().into(),
+    };
+
+    let error = context
+        .custom_set_auth_identities(vec![valid, unrepresentable])
+        .expect_err("all identities must convert before state changes");
+
+    assert_eq!(error.error_type, ErrorKind::InvalidParameter);
+    assert!(context.identity.is_none());
+    assert!(context.allowed_identities.is_none());
+}
+
+#[test]
 fn encrypt_message_crypts_data() {
     let mut context = Ntlm::new();
     context.send_sealing_key = Some(Rc4::new(&SEALING_KEY));

--- a/src/pku2u/mod.rs
+++ b/src/pku2u/mod.rs
@@ -391,7 +391,7 @@ impl SspiImpl for Pku2u {
             ));
         }
 
-        self.auth_identity = builder.auth_data.cloned().map(AuthIdentityBuffers::from);
+        self.auth_identity = builder.auth_data.map(AuthIdentityBuffers::try_from).transpose()?;
 
         Ok(AcquireCredentialsHandleResult {
             credentials_handle: self.auth_identity.clone(),
@@ -844,7 +844,7 @@ impl Pku2u {
 impl SspiEx for Pku2u {
     #[instrument(level = "trace", ret, fields(state = ?self.state), skip(self))]
     fn custom_set_auth_identity(&mut self, identity: Self::AuthenticationData) -> Result<()> {
-        self.auth_identity = Some(identity.into());
+        self.auth_identity = Some(identity.try_into()?);
 
         Ok(())
     }

--- a/tests/sspi/client_server/credssp.rs
+++ b/tests/sspi/client_server/credssp.rs
@@ -21,6 +21,13 @@ use crate::client_server::TARGET_NAME;
 use crate::client_server::kerberos::kdc::SERVER_COMPUTER_NAME;
 use crate::common::CredentialsProxyImpl;
 
+fn account_name(username: &Username) -> &str {
+    match username {
+        Username::UserPrincipalName(upn) => upn.account_name(),
+        Username::DownLevelLogonName(down_level) => down_level.account_name(),
+    }
+}
+
 const PUBLIC_KEY: &[u8] = &[
     48, 130, 2, 34, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 1, 5, 0, 3, 130, 2, 15, 0, 48, 130, 2, 10, 2, 130,
     2, 1, 0, 153, 85, 210, 206, 231, 176, 16, 84, 146, 20, 255, 201, 74, 62, 122, 183, 157, 210, 202, 111, 17, 50, 30,
@@ -124,7 +131,7 @@ fn credssp_kerberos() {
 
     let identity_1 = credentials.to_auth_identity().unwrap();
     let mut identity_2 = identity_1.clone();
-    identity_2.username = Username::new_upn(identity_1.username.account_name(), &realm.to_ascii_lowercase()).unwrap();
+    identity_2.username = Username::new_upn(account_name(&identity_1.username), &realm.to_ascii_lowercase()).unwrap();
 
     let kdc = KdcMock::new(realm, keys, users, Validators::default());
     let mut network_client = NetworkClientMock { kdc };

--- a/tests/sspi/client_server/kerberos/mod.rs
+++ b/tests/sspi/client_server/kerberos/mod.rs
@@ -32,6 +32,13 @@ use crate::client_server::kerberos::kdc::{
 use crate::client_server::kerberos::network_client::{FailedNetworkClientMock, NetworkClientMock};
 use crate::client_server::{test_encryption, test_rpc_request_encryption, test_stream_buffer_encryption};
 
+fn account_name(username: &Username) -> &str {
+    match username {
+        Username::UserPrincipalName(upn) => upn.account_name(),
+        Username::DownLevelLogonName(down_level) => down_level.account_name(),
+    }
+}
+
 /// Represents a Kerberos environment:
 /// * user and services keys;
 /// * user logon credentials;
@@ -123,7 +130,7 @@ pub(super) fn init_krb_environment() -> KrbEnvironment {
     .collect();
 
     let credentials = Credentials::AuthIdentity(AuthIdentity {
-        username: Username::new_down_level_logon_name(username, domain).unwrap(),
+        username: Username::new_down_level_logon_name(username, Some(domain)).unwrap(),
         password: user_password.to_owned().into(),
     });
 
@@ -360,7 +367,7 @@ fn spnego_kerberos_u2u() {
 
     let identity_1 = credentials.to_auth_identity().unwrap();
     let mut identity_2 = identity_1.clone();
-    identity_2.username = Username::new_upn(identity_1.username.account_name(), &realm.to_ascii_lowercase()).unwrap();
+    identity_2.username = Username::new_upn(account_name(&identity_1.username), &realm.to_ascii_lowercase()).unwrap();
 
     let kdc = KdcMock::new(
         realm,
@@ -474,7 +481,7 @@ fn run_spnego(
 
     let identity_1 = credentials.to_auth_identity().unwrap();
     let mut identity_2 = identity_1.clone();
-    identity_2.username = Username::new_upn(identity_1.username.account_name(), &realm.to_ascii_lowercase()).unwrap();
+    identity_2.username = Username::new_upn(account_name(&identity_1.username), &realm.to_ascii_lowercase()).unwrap();
 
     let kdc = KdcMock::new(
         realm,
@@ -706,7 +713,7 @@ fn spnego_kerberos_ntlm_fallback_spn_ip_address() {
 
     let identity_1 = credentials.to_auth_identity().unwrap();
     let mut identity_2 = identity_1.clone();
-    identity_2.username = Username::new_upn(identity_1.username.account_name(), &realm.to_ascii_lowercase()).unwrap();
+    identity_2.username = Username::new_upn(account_name(&identity_1.username), &realm.to_ascii_lowercase()).unwrap();
 
     let kdc = KdcMock::new(
         realm,

--- a/tests/sspi/common.rs
+++ b/tests/sspi/common.rs
@@ -9,7 +9,7 @@ use sspi::{
 use time::OffsetDateTime;
 
 pub(crate) static CREDENTIALS: LazyLock<AuthIdentity> = LazyLock::new(|| AuthIdentity {
-    username: Username::new("Username", Some("Domain")).unwrap(),
+    username: Username::new_down_level_logon_name("Username", Some("Domain")).unwrap(),
     password: String::from("Password").into(),
 });
 
@@ -29,7 +29,15 @@ impl credssp::CredentialsProxy for CredentialsProxyImpl<'_> {
     type AuthenticationData = AuthIdentity;
 
     fn auth_data_by_user(&mut self, username: &Username) -> io::Result<Self::AuthenticationData> {
-        assert_eq!(username.account_name(), self.credentials.username.account_name());
+        let requested_account = match username {
+            Username::UserPrincipalName(upn) => upn.account_name(),
+            Username::DownLevelLogonName(down_level) => down_level.account_name(),
+        };
+        let expected_account = match &self.credentials.username {
+            Username::UserPrincipalName(upn) => upn.account_name(),
+            Username::DownLevelLogonName(down_level) => down_level.account_name(),
+        };
+        assert_eq!(requested_account, expected_account);
 
         Ok(self.credentials.clone())
     }


### PR DESCRIPTION
## Summary

Replace the heuristic string-backed `Username` API with an exhaustive owned representation:

- `Username::UserPrincipalName(UserPrincipalName)`
- `Username::DownLevelLogonName(DownLevelLogonName)`

Each payload is opaque and validated, while direct enum matching makes the selected format explicit. Parsing remains deterministic (`\\` precedence, otherwise the last `@`, otherwise an unqualified down-level name).

## Breaking API changes

- Remove `Username::new`; use `parse`, `new_upn`, or `new_down_level_logon_name` according to intent.
- Remove `UsernameParts`, `*Parts`, `UserNameFormat`, `parts`, `format`, `inner`, and top-level format-erasing component accessors.
- Change `new_down_level_logon_name` to accept `Option<&str>` for an explicit optional NetBIOS domain.
- Replace `UsernameError::MixedFormat` with non-exhaustive, component-specific errors.
- Replace `From<AuthIdentity> for AuthIdentityBuffers` with borrowed and owned `TryFrom` implementations.

## Buffer boundary

An explicit domain-less down-level account containing `@` is now valid in the domain model. Converting it to raw `AuthIdentityBuffers` fails explicitly because empty-domain user/domain fields cannot preserve its tag; raw empty-domain `me@example.com` still deterministically decodes as UPN.

The all-empty down-level name remains valid as the credential-less CredSSP/restricted-admin sentinel. Representable NTLM and CredSSP user/domain fields are unchanged.

## Migration examples

```rust
// Combined spelling
let username = Username::parse("user@example.com")?;

// Explicit UPN
let username = Username::new_upn("user", "example.com")?;

// Explicit qualified down-level name
let username = Username::new_down_level_logon_name("user@example.com", Some("MicrosoftAccount"))?;

// Explicit unqualified down-level name
let username = Username::new_down_level_logon_name("user", None)?;

match &username {
    Username::UserPrincipalName(upn) => { /* upn.account_name(), upn.suffix() */ }
    Username::DownLevelLogonName(down_level) => {
        /* down_level.account_name(), down_level.netbios_domain() */
    }
}

let buffers = AuthIdentityBuffers::try_from(&identity)?;
```

Closes #708.