### PR TITLE
fix(sspi): RD Gateway auth

### DIFF
--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -463,7 +463,7 @@ pub async fn initialize_security_context<'a>(
 
             // "HTTP/" prefix of the target name means RD Gateway authorization.
             // The RD Gateway server does not send an AP_REP message, so we skip the AP_REP processing and go directly to the final state.
-            let security_status = if let Some(target_name) = &builder.target_name
+            if let Some(target_name) = &builder.target_name
                 && target_name.starts_with("HTTP/")
             {
                 client.state = KerberosState::Final;
@@ -473,9 +473,7 @@ pub async fn initialize_security_context<'a>(
                 client.state = KerberosState::ApExchange;
 
                 SecurityStatus::ContinueNeeded
-            };
-
-            security_status
+            }
         }
         KerberosState::ApExchange => {
             let input = builder

--- a/src/kerberos/client/mod.rs
+++ b/src/kerberos/client/mod.rs
@@ -461,9 +461,21 @@ pub async fn initialize_security_context<'a>(
             let output_token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
             output_token.buffer = encoded_neg_ap_req;
 
-            client.state = KerberosState::ApExchange;
+            // "HTTP/" prefix of the target name means RD Gateway authorization.
+            // The RD Gateway server does not send an AP_REP message, so we skip the AP_REP processing and go directly to the final state.
+            let security_status = if let Some(target_name) = &builder.target_name
+                && target_name.starts_with("HTTP/")
+            {
+                client.state = KerberosState::Final;
 
-            SecurityStatus::ContinueNeeded
+                SecurityStatus::Ok
+            } else {
+                client.state = KerberosState::ApExchange;
+
+                SecurityStatus::ContinueNeeded
+            };
+
+            security_status
         }
         KerberosState::ApExchange => {
             let input = builder

--- a/src/negotiate/client.rs
+++ b/src/negotiate/client.rs
@@ -103,7 +103,7 @@ pub(crate) async fn initialize_security_context<'a>(
                 .initialize_security_context(negotiate.auth_identity.as_ref(), yield_point, builder)
                 .await;
 
-            let first_token = match result {
+            let (first_token, security_status) = match result {
                 Ok(result) => {
                     if result.status != SecurityStatus::ContinueNeeded && result.status != SecurityStatus::Ok {
                         return Err(Error::new(
@@ -113,7 +113,7 @@ pub(crate) async fn initialize_security_context<'a>(
                     }
 
                     let token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
-                    Some(mem::take(&mut token.buffer))
+                    (Some(mem::take(&mut token.buffer)), result.status)
                 }
                 Err(err)
                     if matches!(negotiate.protocol, NegotiatedProtocol::Kerberos(_))
@@ -143,7 +143,7 @@ pub(crate) async fn initialize_security_context<'a>(
 
                     let token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
 
-                    Some(mem::take(&mut token.buffer))
+                    (Some(mem::take(&mut token.buffer)), result.status)
                 }
                 Err(err) => {
                     return Err(err);
@@ -162,10 +162,18 @@ pub(crate) async fn initialize_security_context<'a>(
             let output_token = SecurityBuffer::find_buffer_mut(builder.output, BufferType::Token)?;
             output_token.buffer = encoded_neg_token_init;
 
-            negotiate.state = NegotiateState::InProgress;
+            let status = if security_status == SecurityStatus::Ok {
+                negotiate.state = NegotiateState::Ok;
+
+                SecurityStatus::Ok
+            } else {
+                negotiate.state = NegotiateState::InProgress;
+
+                SecurityStatus::ContinueNeeded
+            };
 
             Ok(InitializeSecurityContextResult {
-                status: SecurityStatus::ContinueNeeded,
+                status,
                 flags: ClientResponseFlags::empty(),
                 expiry: None,
             })
@@ -225,8 +233,18 @@ pub(crate) async fn initialize_security_context<'a>(
 
                     ACCEPT_COMPLETE.to_vec()
                 } else {
-                    result.status = SecurityStatus::ContinueNeeded;
-                    negotiate.state = NegotiateState::VerifyMic;
+                    // "HTTP/" prefix of the target name means RD Gateway authorization.
+                    // The RD Gateway server does not send an ACCEPT_COMPLETE response back but upgrades the connection to WebSocket.
+                    // So we do not wait for ACCEPT_COMPLETE and go directly to the final state.
+                    if let Some(target_name) = &builder.target_name
+                        && target_name.starts_with("HTTP/")
+                    {
+                        result.status = SecurityStatus::Ok;
+                        negotiate.state = NegotiateState::Ok;
+                    } else {
+                        result.status = SecurityStatus::ContinueNeeded;
+                        negotiate.state = NegotiateState::VerifyMic;
+                    }
 
                     ACCEPT_INCOMPLETE.to_vec()
                 };

--- a/src/negotiate/mod.rs
+++ b/src/negotiate/mod.rs
@@ -583,6 +583,7 @@ impl Negotiate {
         true
     }
 
+    #[instrument(level = "debug", fields(protocol = self.protocol_name(), is_token_present = mic.is_some()), skip_all, ret)]
     fn verify_mic_token(&mut self, mic: Option<&[u8]>) -> Result<()> {
         if let Some(mic) = mic {
             self.protocol

--- a/tests/sspi/client_server/credssp.rs
+++ b/tests/sspi/client_server/credssp.rs
@@ -120,7 +120,7 @@ fn credssp_kerberos() {
         users,
         target_name,
         target_service_name,
-    } = init_krb_environment();
+    } = init_krb_environment(None);
 
     let identity_1 = credentials.to_auth_identity().unwrap();
     let mut identity_2 = identity_1.clone();

--- a/tests/sspi/client_server/kerberos/mod.rs
+++ b/tests/sspi/client_server/kerberos/mod.rs
@@ -52,11 +52,7 @@ pub(super) struct KrbEnvironment {
 /// * Kerberos services keys.
 /// * Target machine name.
 pub(super) fn init_krb_environment(target_name: Option<[&str; 2]>) -> KrbEnvironment {
-    let [service_name, target_machine_name] = if let Some(target_name) = target_name {
-        target_name
-    } else {
-        ["TERMSRV", "DESKTOP-8F33RFH.example.com"]
-    };
+    let [service_name, target_machine_name] = target_name.unwrap_or(["TERMSRV", "DESKTOP-8F33RFH.example.com"]);
 
     let username = "pw13";
     let user_password = "qweQWE123!@#";

--- a/tests/sspi/client_server/kerberos/mod.rs
+++ b/tests/sspi/client_server/kerberos/mod.rs
@@ -51,7 +51,13 @@ pub(super) struct KrbEnvironment {
 /// * User logon credentials (password-based).
 /// * Kerberos services keys.
 /// * Target machine name.
-pub(super) fn init_krb_environment() -> KrbEnvironment {
+pub(super) fn init_krb_environment(target_name: Option<[&str; 2]>) -> KrbEnvironment {
+    let [service_name, target_machine_name] = if let Some(target_name) = target_name {
+        target_name
+    } else {
+        ["TERMSRV", "DESKTOP-8F33RFH.example.com"]
+    };
+
     let username = "pw13";
     let user_password = "qweQWE123!@#";
     let domain = "EXAMPLE";
@@ -59,9 +65,7 @@ pub(super) fn init_krb_environment() -> KrbEnvironment {
     let mut salt = realm.to_string();
     salt.push_str(username);
     let krbtgt = "krbtgt";
-    let termsrv = "TERMSRV";
-    let target_machine_name = "DESKTOP-8F33RFH.example.com";
-    let mut target_name = termsrv.to_string();
+    let mut target_name = service_name.to_string();
     target_name.push('/');
     target_name.push_str(target_machine_name);
 
@@ -98,7 +102,7 @@ pub(super) fn init_krb_environment() -> KrbEnvironment {
             UserName(PrincipalName {
                 name_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NT_SRV_INST])),
                 name_string: ExplicitContextTag1::from(Asn1SequenceOf::from(vec![
-                    KerberosStringAsn1::from(IA5String::from_string(termsrv.into()).unwrap()),
+                    KerberosStringAsn1::from(IA5String::from_string(service_name.into()).unwrap()),
                     KerberosStringAsn1::from(IA5String::from_string(target_machine_name.into()).unwrap()),
                 ])),
             }),
@@ -136,8 +140,8 @@ pub(super) fn init_krb_environment() -> KrbEnvironment {
         target_service_name: PrincipalName {
             name_type: ExplicitContextTag0::from(IntegerAsn1::from(vec![NT_SRV_INST])),
             name_string: ExplicitContextTag1::from(Asn1SequenceOf::from(vec![
-                KerberosStringAsn1::from(IA5String::from_string("TERMSRV".into()).unwrap()),
-                KerberosStringAsn1::from(IA5String::from_string("DESKTOP-8F33RFH.example.com".into()).unwrap()),
+                KerberosStringAsn1::from(IA5String::from_string(service_name.into()).unwrap()),
+                KerberosStringAsn1::from(IA5String::from_string(target_machine_name.into()).unwrap()),
             ])),
         },
     }
@@ -258,7 +262,7 @@ fn kerberos_auth() {
         users,
         target_name,
         target_service_name,
-    } = init_krb_environment();
+    } = init_krb_environment(None);
 
     let ticket_decryption_key = keys[&UserName(target_service_name.clone())].clone();
 
@@ -354,7 +358,7 @@ fn spnego_kerberos_u2u() {
         users,
         target_name,
         target_service_name,
-    } = init_krb_environment();
+    } = init_krb_environment(None);
 
     let ticket_decryption_key = keys[&UserName(target_service_name.clone())].clone();
 
@@ -452,6 +456,66 @@ fn spnego_kerberos_u2u() {
     );
 }
 
+#[test]
+fn spnego_kerberos_rd_gateway_client() {
+    let KrbEnvironment {
+        realm,
+        credentials,
+        mut keys,
+        users,
+        target_name,
+        target_service_name,
+        ..
+    } = init_krb_environment(Some(["HTTP", "rdgateway.example.com"]));
+
+    let http_service_name = target_service_name.clone();
+    let service_key = keys[&UserName(target_service_name)].clone();
+    keys.insert(UserName(http_service_name), service_key);
+
+    let kdc = KdcMock::new(
+        realm,
+        keys,
+        users,
+        Validators {
+            as_req: Box::new(|_as_req| {}),
+            tgs_req: Box::new(|_tgs_req| {}),
+        },
+    );
+    let mut network_client = NetworkClientMock { kdc };
+
+    let client_config = KerberosConfig {
+        kdc_url: Some(Url::parse(KDC_URL).unwrap()),
+        client_computer_name: CLIENT_COMPUTER_NAME.into(),
+    };
+    let client = Negotiate::new_client(NegotiateConfig::new(
+        Box::new(client_config),
+        Some(String::from("kerberos,!ntlm")),
+        CLIENT_COMPUTER_NAME.into(),
+    ))
+    .unwrap();
+
+    let credentials = CredentialsBuffers::try_from(credentials).unwrap();
+    let mut client_credentials_handle = Some(credentials);
+    let client_flags = ClientRequestFlags::MUTUAL_AUTH
+        | ClientRequestFlags::INTEGRITY
+        | ClientRequestFlags::SEQUENCE_DETECT
+        | ClientRequestFlags::REPLAY_DETECT
+        | ClientRequestFlags::CONFIDENTIALITY;
+
+    let (status, token) = initialize_security_context(
+        &mut SspiContext::Negotiate(client),
+        &mut client_credentials_handle,
+        client_flags,
+        &target_name,
+        Vec::new(),
+        &mut network_client,
+    );
+
+    // For RD Gateway auth, Kerberos authorization should be completed in one step.
+    assert_eq!(status, SecurityStatus::Ok);
+    assert!(!token.is_empty());
+}
+
 fn run_spnego(
     client_flags: ClientRequestFlags,
     server_flags: ServerRequestFlags,
@@ -468,7 +532,7 @@ fn run_spnego(
         users,
         target_name,
         target_service_name,
-    } = init_krb_environment();
+    } = init_krb_environment(None);
 
     let ticket_decryption_key = keys[&UserName(target_service_name.clone())].clone();
 
@@ -700,7 +764,7 @@ fn spnego_kerberos_ntlm_fallback_spn_ip_address() {
         users,
         target_name: _,
         target_service_name,
-    } = init_krb_environment();
+    } = init_krb_environment(None);
 
     let ticket_decryption_key = keys[&UserName(target_service_name.clone())].clone();
 

--- a/tests/sspi/client_server/negotiate.rs
+++ b/tests/sspi/client_server/negotiate.rs
@@ -11,7 +11,7 @@ use crate::client_server::{TARGET_NAME, test_encryption, test_rpc_request_encryp
 
 const CLIENT_COMPUTER_NAME: &str = "DESKTOP-IHPPQ95.example.com";
 
-fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mic_expected: bool) {
+fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mic_expected: bool) -> usize {
     let ntlm_config = NtlmConfig {
         client_computer_name: Some(CLIENT_COMPUTER_NAME.to_owned()),
     };
@@ -63,7 +63,7 @@ fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mi
     let mut input_token = [SecurityBuffer::new(Vec::new(), BufferType::Token)];
     let mut output_token = [SecurityBuffer::new(Vec::new(), BufferType::Token)];
 
-    for _ in 0..4 {
+    for client_message in 1..=4 {
         let mut builder = client
             .initialize_security_context()
             .with_credentials_handle(&mut client_credentials_handle)
@@ -112,7 +112,7 @@ fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mi
             test_stream_buffer_encryption(&mut client, &mut server);
             test_rpc_request_encryption(&mut client, &mut server);
 
-            return;
+            return client_message;
         }
     }
 
@@ -121,15 +121,31 @@ fn run_spnego_ntlm(target_name: Option<&str>, username: &str, password: &str, mi
 
 #[test]
 fn spnego_ntlm_client_server() {
-    run_spnego_ntlm(Some(TARGET_NAME), "test_user@example.com", "test_password", true);
+    assert_eq!(
+        run_spnego_ntlm(Some(TARGET_NAME), "test_user@example.com", "test_password", true),
+        3
+    );
 }
 
 #[test]
 fn spnego_ntlm_guest_logon() {
-    run_spnego_ntlm(Some(TARGET_NAME), "/GUEST", "", false);
+    assert_eq!(run_spnego_ntlm(Some(TARGET_NAME), "/GUEST", "", false), 2);
 }
 
 #[test]
 fn spnego_ntlm_without_target_name() {
-    run_spnego_ntlm(None, "test_user@example.com", "test_password", true);
+    assert_eq!(run_spnego_ntlm(None, "test_user@example.com", "test_password", true), 3);
+}
+
+#[test]
+fn spnego_ntlm_rd_gateway() {
+    let client_message = run_spnego_ntlm(
+        Some("HTTP/DESKTOP-8F33RFH.example.com"),
+        "test_user@example.com",
+        "test_password",
+        true,
+    );
+
+    // During RD Gateway auth, we do not wait for the confirmation. So, the resulting amount of messages is 2 instead of 3.
+    assert_eq!(client_message, 2);
 }


### PR DESCRIPTION
closes #729 

Hi,
I fixed the RD Gateway auth in this PR.

# What's wrong with RD Gateway?

It does not send a confirmation (finalization) message back. When we send a Kerberos AP_REQ message wrapped in an SPNEGO token, the RD Gateway server doesn't send an AP_REP back. Moreover, when the last message from the client contains SPNEGO ACCEPT_INCOMPLETE, the server does not respond with SPNEGO ACCEPT_COMPLETE. Instead, it processes further with a WebSocket upgrade:

<img width="1675" height="446" alt="image" src="https://github.com/user-attachments/assets/97130a03-2554-42dd-a2fc-9734b2d1fbbb" />

Even when the SPNEGO MIC token exchange is needed, the RD Gateway server still doesn't send the MIC token back and continues with the WebSocket upgrade.

# Why does FreeRDP fail to connect?

Because `sspi-rs` waits for confirmation and returns `SecurityStatus::ContinueNeeded`. FreeRDP doesn't expect this status code and interrupts auth. FreeRDP expects the last NLA status code to be `SecurityStatus::Ok` before processing the WebSocket upgrade.

To fix this, we need to recognize RD Gateway auth and return `SecurityStatus::Ok` immediately.

# The fix

The fix is simple: `sspi-rs` detects RD Gateway auth by checking the target name. If it starts with "HTTP/", then we return `SecurityStatus::Ok` without waiting for the confirmation/response.

The fix may not feel right, but there is no other good way to do it (at least for now). Ideally, I would like to use the `ClientRequestFlags::MUTUAL_AUTH` flag here. If it is not present, we return `SecurityStatus::Ok` without waiting for the response. But FreeRDP provides this flag in all cases, so it is not an option.

# Native SSPI behavior

I was curious about how it works in native SSPI. Turned out that native SSPI returns `SecurityStatus::ContinueNeeded` (as we did). `mstsc` ignores it and continues with the WebSocket upgrade. The `ClientRequestFlags::MUTUAL_AUTH` flag is also present.

In other words, this fix is caused by the behavior difference between FreeRDP and `mstsc` in the RD Gateway implementation.

# Testing

I added a few tests to cover this case. I also dev-tested auth using FreeRDP (both NTLM and Kerberos protocols). Users should be able to connect via RD Gateway using NTLM or Kerberos when this PR is merged.