### PR TITLE
fix(kerberos): use negotiated AES size for MIC

### DIFF
--- a/src/kerberos/encryption_params.rs
+++ b/src/kerberos/encryption_params.rs
@@ -52,4 +52,16 @@ impl EncryptionParams {
             CipherSuite::Des3CbcSha1Kd => None,
         })
     }
+
+    pub fn active_key_aes_size(&self) -> Option<AesSize> {
+        let key = self.sub_session_key.as_ref().or(self.session_key.as_ref())?;
+
+        // The supported AES enctypes have distinct key lengths, so the active key
+        // remains authoritative when an AP subkey differs from the ticket enctype.
+        match key.as_ref().len() {
+            16 => Some(AesSize::Aes128),
+            32 => Some(AesSize::Aes256),
+            _ => None,
+        }
+    }
 }

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -778,7 +778,11 @@ impl SspiEx for Kerberos {
             .sub_session_key
             .as_ref()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "kerberos sub-session key is not set"))?;
-        let aes_size = self.encryption_params.aes_size().unwrap_or(AesSize::Aes256);
+        let aes_size = self
+            .encryption_params
+            .active_key_aes_size()
+            .or_else(|| self.encryption_params.aes_size())
+            .unwrap_or(AesSize::Aes256);
         utils::generate_mic_token(
             self.is_client(),
             u64::from(seq_number),

--- a/src/kerberos/mod.rs
+++ b/src/kerberos/mod.rs
@@ -778,7 +778,14 @@ impl SspiEx for Kerberos {
             .sub_session_key
             .as_ref()
             .ok_or_else(|| Error::new(ErrorKind::InternalError, "kerberos sub-session key is not set"))?;
-        utils::generate_mic_token(self.is_client(), u64::from(seq_number), data.to_vec(), session_key)
+        let aes_size = self.encryption_params.aes_size().unwrap_or(AesSize::Aes256);
+        utils::generate_mic_token(
+            self.is_client(),
+            u64::from(seq_number),
+            data.to_vec(),
+            session_key,
+            &aes_size,
+        )
     }
 }
 

--- a/src/kerberos/tests.rs
+++ b/src/kerberos/tests.rs
@@ -315,3 +315,12 @@ fn aes256_mic_preserves_aes256_checksum() {
 
     assert_mic_uses_aes_size(CipherSuite::Aes256CtsHmacSha196, AesSize::Aes256, &key);
 }
+
+#[test]
+fn aes128_subkey_mic_uses_subkey_size_with_aes256_ticket_enctype() {
+    let key = [
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    ];
+
+    assert_mic_uses_aes_size(CipherSuite::Aes256CtsHmacSha196, AesSize::Aes128, &key);
+}

--- a/src/kerberos/tests.rs
+++ b/src/kerberos/tests.rs
@@ -1,8 +1,10 @@
-use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL};
+use picky_krb::constants::key_usages::{ACCEPTOR_SEAL, INITIATOR_SEAL, INITIATOR_SIGN};
 use picky_krb::crypto::CipherSuite;
+use picky_krb::crypto::aes::{AesSize, checksum_sha_aes};
+use picky_krb::gss_api::MicToken;
 
 use crate::kerberos::{EncryptionParams, KerberosConfig, KerberosState, test_data};
-use crate::{EncryptionFlags, Kerberos, SecurityBufferFlags, SecurityBufferRef, Sspi};
+use crate::{EncryptionFlags, Kerberos, SecurityBufferFlags, SecurityBufferRef, Sspi, SspiEx};
 
 #[test]
 fn stream_buffer_decryption() {
@@ -268,4 +270,48 @@ fn integrity_only_wrap_decryption() {
     kerberos_client.decrypt_message(&mut message).unwrap();
 
     assert_eq!(message[1].data(), plaintext);
+}
+
+fn assert_mic_uses_aes_size(encryption_type: CipherSuite, aes_size: AesSize, key: &[u8]) {
+    let data = b"SPNEGO mechTypes";
+    let mut client = test_data::fake_client();
+    client.encryption_params.encryption_type = Some(encryption_type.clone());
+    client.encryption_params.sub_session_key = Some(key.to_vec().into());
+
+    let token = client
+        .generate_mic_token(data, crate::private::Sealed)
+        .expect("MIC generation should use the negotiated AES key size");
+    let mic_token = MicToken::decode(token.as_slice()).unwrap();
+
+    let mut checksum_input = data.to_vec();
+    checksum_input.extend_from_slice(&mic_token.header());
+    let expected_checksum = checksum_sha_aes(key, INITIATOR_SIGN, &checksum_input, &aes_size).unwrap();
+    assert_eq!(mic_token.checksum, expected_checksum);
+
+    let mut server = test_data::fake_server();
+    server.encryption_params.encryption_type = Some(encryption_type);
+    server.encryption_params.sub_session_key = Some(key.to_vec().into());
+    server.remote_seq_number = client.seq_number;
+    server
+        .verify_mic_token(&token, data, crate::private::Sealed)
+        .expect("MIC verification should use the negotiated AES key size");
+}
+
+#[test]
+fn aes128_mic_uses_aes128_checksum() {
+    let key = [
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    ];
+
+    assert_mic_uses_aes_size(CipherSuite::Aes128CtsHmacSha196, AesSize::Aes128, &key);
+}
+
+#[test]
+fn aes256_mic_preserves_aes256_checksum() {
+    let key = [
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x10, 0x21,
+        0x32, 0x43, 0x54, 0x65, 0x76, 0x87, 0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe, 0x0f,
+    ];
+
+    assert_mic_uses_aes_size(CipherSuite::Aes256CtsHmacSha196, AesSize::Aes256, &key);
 }

--- a/src/kerberos/utils.rs
+++ b/src/kerberos/utils.rs
@@ -99,6 +99,7 @@ pub(super) fn generate_mic_token(
     seq_number: u64,
     mut payload: Vec<u8>,
     session_key: &Secret<Vec<u8>>,
+    aes_size: &AesSize,
 ) -> Result<Vec<u8>> {
     let (mic_token, key_usage) = if is_client {
         (MicToken::with_initiator_flags(), INITIATOR_SIGN)
@@ -110,12 +111,7 @@ pub(super) fn generate_mic_token(
 
     payload.extend_from_slice(&mic_token.header());
 
-    mic_token.set_checksum(checksum_sha_aes(
-        session_key.as_ref(),
-        key_usage,
-        &payload,
-        &AesSize::Aes256,
-    )?);
+    mic_token.set_checksum(checksum_sha_aes(session_key.as_ref(), key_usage, &payload, aes_size)?);
 
     let mut mic_token_raw = Vec::new();
     mic_token.encode(&mut mic_token_raw)?;

--- a/src/kerberos/utils.rs
+++ b/src/kerberos/utils.rs
@@ -84,7 +84,10 @@ pub(super) fn validate_mic_token(
         key.as_ref(),
         key_usage,
         &payload,
-        &params.aes_size().unwrap_or(AesSize::Aes256),
+        &params
+            .active_key_aes_size()
+            .or_else(|| params.aes_size())
+            .unwrap_or(AesSize::Aes256),
     )?;
 
     if checksum != token.checksum {


### PR DESCRIPTION
## Summary

- derive the Kerberos MIC AES size from the negotiated encryption parameters
- generate AES-128 MICs with AES-128 instead of the previous hard-coded AES-256 mode
- preserve AES-256 MIC generation and verify both enctypes with focused round-trip tests

This extracts the standalone Kerberos correctness fix from #733 without the unrelated PKU2U or GSS changes.